### PR TITLE
Option to skip "name this contact" screen when send a TX to an unknown address.

### DIFF
--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -48,7 +48,11 @@
                         </p>
                     </div>
 
-                    <select id="askForLabeling" name="askForLabeling" @input="setAskForRecipientLabeling(!!$event.target.value)">
+                    <select
+                        id="askForLabeling"
+                        name="askForLabeling"
+                        @input="setAskForRecipientLabeling(!!$event.target.value)"
+                    >
                         <option value="1" :selected="!askForRecipientLabeling">{{ $t('Yes') }}</option>
                         <option value="0" :selected="askForRecipientLabeling">{{ $t('No') }}</option>
                     </select>

--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -51,10 +51,10 @@
                     <select
                         id="askForLabeling"
                         name="askForLabeling"
-                        @input="setAskForRecipientLabeling(!!$event.target.value)"
+                        @input="setAskForRecipientLabeling(!!parseInt($event.target.value))"
                     >
-                        <option value="1" :selected="!askForRecipientLabeling">{{ $t('Yes') }}</option>
-                        <option value="0" :selected="askForRecipientLabeling">{{ $t('No') }}</option>
+                        <option value="1" :selected="askForRecipientLabeling">{{ $t('Yes') }}</option>
+                        <option value="0" :selected="!askForRecipientLabeling">{{ $t('No') }}</option>
                     </select>
                 </div>
 

--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -42,6 +42,20 @@
 
                 <div class="setting">
                     <div class="description">
+                        <label class="nq-h2" for="skipLabeling">{{ $t('Ask for labels') }}</label>
+                        <p class="nq-text">
+                            {{ $t('Ask for a label when sending to an unknown address?') }}
+                        </p>
+                    </div>
+
+                    <select id="skipLabeling" name="skipLabeling" @input="setSkipRecipientLabeling($event.target.value)">
+                        <option :value="true" :selected="skipRecipientLabeling">{{ $t('No') }}</option>
+                        <option :value="false" :selected="!skipRecipientLabeling">{{ $t('Yes') }}</option>
+                    </select>
+                </div>
+
+                <div class="setting">
+                    <div class="description">
                         <label class="nq-h2" for="contact-import">{{ $t('Import Contacts') }}</label>
                         <p class="nq-text">
                             {{ $t('Import contacts that you exported from the Safe.') }}

--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -42,15 +42,15 @@
 
                 <div class="setting">
                     <div class="description">
-                        <label class="nq-h2" for="skipLabeling">{{ $t('Ask for labels') }}</label>
+                        <label class="nq-h2" for="askForLabeling">{{ $t('Ask for labels') }}</label>
                         <p class="nq-text">
                             {{ $t('Ask for a label when sending to an unknown address?') }}
                         </p>
                     </div>
 
-                    <select id="skipLabeling" name="skipLabeling" @input="setSkipRecipientLabeling($event.target.value)">
-                        <option :value="true" :selected="skipRecipientLabeling">{{ $t('No') }}</option>
-                        <option :value="false" :selected="!skipRecipientLabeling">{{ $t('Yes') }}</option>
+                    <select id="askForLabeling" name="askForLabeling" @input="setAskForRecipientLabeling(!!$event.target.value)">
+                        <option value="1" :selected="!askForRecipientLabeling">{{ $t('Yes') }}</option>
+                        <option value="0" :selected="askForRecipientLabeling">{{ $t('No') }}</option>
                     </select>
                 </div>
 

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -248,7 +248,7 @@ export default defineComponent({
         const { state: addresses$, activeAddressInfo, addressInfos } = useAddressStore();
         const { contactsArray: contacts, setContact, getLabel } = useContactsStore();
         const { state: network$ } = useNetworkStore();
-        const { amountsHidden, skipRecipientLabeling } = useSettingsStore();
+        const { amountsHidden, askForRecipientLabeling } = useSettingsStore();
 
         const recipientDetailsOpened = ref(false);
         const recipientWithLabel = ref<{address: string, label: string, type: RecipientType} | null>(null);
@@ -296,7 +296,7 @@ export default defineComponent({
             }
 
             recipientWithLabel.value = { address, label, type };
-            if (!skipRecipientLabeling.value && !label) {
+            if (!askForRecipientLabeling.value && !label) {
                 recipientDetailsOpened.value = true;
             } else {
                 page.value = Pages.AMOUNT_INPUT;

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -248,6 +248,7 @@ export default defineComponent({
         const { state: addresses$, activeAddressInfo, addressInfos } = useAddressStore();
         const { contactsArray: contacts, setContact, getLabel } = useContactsStore();
         const { state: network$ } = useNetworkStore();
+        const { amountsHidden, skipRecipientLabeling } = useSettingsStore();
 
         const recipientDetailsOpened = ref(false);
         const recipientWithLabel = ref<{address: string, label: string, type: RecipientType} | null>(null);
@@ -295,7 +296,7 @@ export default defineComponent({
             }
 
             recipientWithLabel.value = { address, label, type };
-            if (!label) {
+            if (!skipRecipientLabeling.value && !label) {
                 recipientDetailsOpened.value = true;
             } else {
                 page.value = Pages.AMOUNT_INPUT;
@@ -541,8 +542,6 @@ export default defineComponent({
             addressListOpened.value = false;
             feeSelectionOpened.value = false;
         }
-
-        const { amountsHidden } = useSettingsStore();
 
         return {
             // General

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -296,7 +296,7 @@ export default defineComponent({
             }
 
             recipientWithLabel.value = { address, label, type };
-            if (!askForRecipientLabeling.value && !label) {
+            if (askForRecipientLabeling.value && !label) {
                 recipientDetailsOpened.value = true;
             } else {
                 page.value = Pages.AMOUNT_INPUT;

--- a/src/stores/Settings.ts
+++ b/src/stores/Settings.ts
@@ -12,7 +12,7 @@ export type SettingsState = {
     language: string, // locale
     colorMode: ColorMode,
     amountsHidden: boolean,
-    skipRecipientLabeling: boolean,
+    askForRecipientLabeling: boolean,
 };
 
 export const useSettingsStore = createStore({
@@ -22,14 +22,14 @@ export const useSettingsStore = createStore({
         language: detectLanguage(),
         colorMode: ColorMode.AUTOMATIC,
         amountsHidden: false,
-        skipRecipientLabeling: false,
+        askForRecipientLabeling: true,
     }),
     getters: {
         decimals: (state): Readonly<number> => state.decimals,
         language: (state): Readonly<string> => state.language,
         colorMode: (state): Readonly<ColorMode> => state.colorMode,
         amountsHidden: (state): Readonly<boolean> => state.amountsHidden,
-        skipRecipientLabeling: (state): Readonly<boolean> => state.skipRecipientLabeling,
+        askForRecipientLabeling: (state): Readonly<boolean> => state.askForRecipientLabeling,
     },
     actions: {
         setDecimals(num: 0 | 2 | 5 = 0) {
@@ -44,8 +44,8 @@ export const useSettingsStore = createStore({
                 this.state.colorMode = colorMode;
             }
         },
-        setSkipRecipientLabeling(skip: boolean) {
-            this.state.skipRecipientLabeling = skip;
+        setAskForRecipientLabeling(ask: boolean) {
+            this.state.askForRecipientLabeling = ask;
         },
         toggleAmountsHidden() {
             this.state.amountsHidden = !this.state.amountsHidden;

--- a/src/stores/Settings.ts
+++ b/src/stores/Settings.ts
@@ -12,6 +12,7 @@ export type SettingsState = {
     language: string, // locale
     colorMode: ColorMode,
     amountsHidden: boolean,
+    skipRecipientLabeling: boolean,
 };
 
 export const useSettingsStore = createStore({
@@ -21,12 +22,14 @@ export const useSettingsStore = createStore({
         language: detectLanguage(),
         colorMode: ColorMode.AUTOMATIC,
         amountsHidden: false,
+        skipRecipientLabeling: false,
     }),
     getters: {
         decimals: (state): Readonly<number> => state.decimals,
         language: (state): Readonly<string> => state.language,
         colorMode: (state): Readonly<ColorMode> => state.colorMode,
         amountsHidden: (state): Readonly<boolean> => state.amountsHidden,
+        skipRecipientLabeling: (state): Readonly<boolean> => state.skipRecipientLabeling,
     },
     actions: {
         setDecimals(num: 0 | 2 | 5 = 0) {
@@ -40,6 +43,9 @@ export const useSettingsStore = createStore({
             if (Object.values(ColorMode).includes(colorMode)) {
                 this.state.colorMode = colorMode;
             }
+        },
+        setSkipRecipientLabeling(skip: boolean) {
+            this.state.skipRecipientLabeling = skip;
         },
         toggleAmountsHidden() {
             this.state.amountsHidden = !this.state.amountsHidden;


### PR DESCRIPTION
Added switch to setting panel that enables to skipping the labeling screen "name this contact" when sending a TX to a previously unknown address. Why? It's a hassle if one is mostly sending to one-time addresses, e.g. to companies, collaborators, etc. in a professional setup - so such a custom setting comes handy.

