### PR TITLE
fix: overflowing tooltips on network map

### DIFF
--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -7,6 +7,7 @@
                 class="node"
                 theme="inverse"
                 :container="$container ? { $el: $container } : null"
+                :preferredPosition="getPreferredTooltipPosition(node)"
                 :margin="{ left: 12, top: 12, right: 12, bottom: 12 }"
                 :style="`transform: translate(${Math.floor(node.x * scale)}px, ${Math.floor(node.y * scale)}px);`"
                 :styles="{
@@ -47,7 +48,7 @@ import { NetworkClient } from '@nimiq/network-client';
 import I18nDisplayNames from '@/lib/I18nDisplayNames';
 import { useSettingsStore } from '@/stores/Settings';
 import { getNetworkClient } from '../network';
-import NetworkMap, { NodeHexagon, WIDTH, HEIGHT, SCALING_FACTOR, Node, NodeType } from '../lib/NetworkMap';
+import NetworkMap, { NodeHexagon, NETWORK_MAP_WIDTH, WIDTH, NETWORK_MAP_HEIGHT, HEIGHT, SCALING_FACTOR, Node, NodeType } from '../lib/NetworkMap';
 
 export default defineComponent({
     setup(props, context) {
@@ -137,6 +138,20 @@ export default defineComponent({
                 : peer.locationData.country;
         }
 
+        function getPreferredTooltipPosition(hexagon: NodeHexagon): string {
+            let verticalPosition = 'top';
+            let horizontalPosition = 'right';
+            // display tooltip below for hexagons near the bottom edge
+            if (hexagon.position.y < Math.ceil(NETWORK_MAP_HEIGHT / 2)) {
+                verticalPosition = 'bottom';
+            }
+            // display tooltip to the left for hexagons near the right edge
+            if (hexagon.position.x > Math.ceil(NETWORK_MAP_WIDTH / 2)) {
+                horizontalPosition = 'left';
+            }
+            return `${verticalPosition} ${horizontalPosition}`;
+        }
+
         return {
             $container,
             $network,
@@ -147,6 +162,7 @@ export default defineComponent({
             height,
             getPeerCity,
             getPeerCountry,
+            getPreferredTooltipPosition,
         };
     },
     components: {

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -150,7 +150,7 @@ export default defineComponent({
         function getPreferredTooltipPosition(hexagon: NodeHexagon): string {
             let verticalPosition = 'top';
             let horizontalPosition = 'right';
-            // display tooltip below for hexagons near the bottom edge
+            // display tooltip below for hexagons near the top edge
             if (hexagon.position.y < Math.ceil(NETWORK_MAP_HEIGHT / 2)) {
                 verticalPosition = 'bottom';
             }

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -48,7 +48,16 @@ import { NetworkClient } from '@nimiq/network-client';
 import I18nDisplayNames from '@/lib/I18nDisplayNames';
 import { useSettingsStore } from '@/stores/Settings';
 import { getNetworkClient } from '../network';
-import NetworkMap, { NodeHexagon, NETWORK_MAP_WIDTH, WIDTH, NETWORK_MAP_HEIGHT, HEIGHT, SCALING_FACTOR, Node, NodeType } from '../lib/NetworkMap';
+import NetworkMap, {
+    NodeHexagon,
+    NETWORK_MAP_WIDTH,
+    WIDTH,
+    NETWORK_MAP_HEIGHT,
+    HEIGHT,
+    SCALING_FACTOR,
+    Node,
+    NodeType,
+} from '../lib/NetworkMap';
 
 export default defineComponent({
     setup(props, context) {

--- a/src/lib/NetworkMap.ts
+++ b/src/lib/NetworkMap.ts
@@ -12,9 +12,9 @@ const CURVINESS_FACTOR = .2;
 const CURVINESS_ANGLE = Math.PI / 6;
 
 /** Map width in hexagons */
-const NETWORK_MAP_WIDTH = 129;
+export const NETWORK_MAP_WIDTH = 129;
 /** Map height in hexagons */
-const NETWORK_MAP_HEIGHT = 52;
+export const NETWORK_MAP_HEIGHT = 52;
 
 /**
  * These WIDTH and HEIGHT values are used in Network.vue CSS to calculate the width of the map on mobile!


### PR DESCRIPTION
This PR fixes #15 

## Description
Break down the map in 4 squares and depending on the position of the hexagon on the map, set the tooltip position instead of relying on auto-positioning.

![image](https://user-images.githubusercontent.com/1634484/108595384-e0884580-737f-11eb-8dcc-fcf20ab0656d.png)

## Changes
- calculate `preferredPosition` for each `NodeHexagon` on the map
