### PR TITLE
fix: fetch account history on re-login

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -104,6 +104,12 @@ export async function launchNetwork() {
         client.getTransactionsByAddress(address, /* lastConfirmedHeight - 10 */ 0, knownTxDetails)
             .then((txDetails) => {
                 transactionsStore.addTransactions(txDetails);
+                // update address balance because balanceListeners are not triggered
+                const { state: { transactions } } = transactionsStore;
+                const balance = Object.values(transactions)
+                    .filter((tx) => tx.sender === address || tx.recipient === address)
+                    .reduce((sum, tx) => tx.recipient === address ? sum + tx.value : sum - tx.value, 0);
+                addressStore.patchAddress(address, { balance });
             })
             .catch(() => fetchedAddresses.delete(address))
             .then(() => network$.fetchingTxHistory--);

--- a/src/network.ts
+++ b/src/network.ts
@@ -60,7 +60,7 @@ export async function launchNetwork() {
     // Also remove logged out addresses from fetched (so that they get fetched on next login)
     watch(addressStore.addressInfos, () => {
         const newAddresses: string[] = [];
-        const removedAddresses: Set<string> = new Set<string>(subscribedAddresses);
+        const removedAddresses = new Set(subscribedAddresses);
 
         for (const address of Object.keys(addressStore.state.addressInfos)) {
             if (subscribedAddresses.has(address)) {
@@ -72,14 +72,14 @@ export async function launchNetwork() {
             newAddresses.push(address);
         }
 
-        if (newAddresses.length > 0) {
-            console.debug('Subscribing addresses', newAddresses);
-            client.subscribe(newAddresses);
-        }
-
         removedAddresses.forEach((removedAddress) => {
             fetchedAddresses.delete(removedAddress);
         });
+
+        if (!newAddresses.length) return;
+
+        console.debug('Subscribing addresses', newAddresses);
+        client.subscribe(newAddresses);
     });
 
     // Fetch transactions for active address


### PR DESCRIPTION
This PR fixes #27 

## Description

The account history is only fetched once per address. This causes a problem when login out and login in again because history is removed during logout but not fetched again during login. 

**Steps to reproduce**
- Log into 2 accounts that both have account history
- Log out of one account
- Log in again with that account
- Account history is not fetched for that account (only transactions that are in both accounts are displayed)

## Changes
- in `addressStore.addressInfos` watcher, track addresses that have been removed (logout)
- delete the `removedAddresses` from the `fetchedAddresses` so they are fetched again once added (login)
- fixed typo "heigth" -> "height"

