### PR TITLE
Mitigate iOS 14.6 IndexedDB issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pinia": "^0.0.5",
     "promise.allsettled": "^1.0.2",
     "register-service-worker": "^1.7.0",
+    "safari-14-idb-fix": "^1.0.3",
     "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
     "vue-i18n": "^8.15.5",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,6 @@ import VueVirtualScroller from 'vue-virtual-scroller';
 import { setAssetPublicPath as setVueComponentsAssetPath } from '@nimiq/vue-components';
 import { init as initFastspotApi } from '@nimiq/fastspot-api';
 
-// TODO: remove this as soon as the Safari IndexedDB bug is fixed
-import idbReady from 'safari-14-idb-fix';
-
 import Config from 'config';
 import App from './App.vue';
 import { serviceWorkerHasUpdate } from './registerServiceWorker';
@@ -38,8 +35,6 @@ Vue.use(VueCompositionApi);
 Vue.use(VueVirtualScroller);
 
 async function start() {
-    await idbReady(); // TODO: remove this as soon as the Safari IndexedDB bug is fixed
-
     await initStorage(); // Must be awaited before starting Vue
     await initHubApi(); // Must be called after VueCompositionApi has been enabled
     syncFromHub(); // Can run parallel to Vue initialization

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,9 @@ import VueVirtualScroller from 'vue-virtual-scroller';
 import { setAssetPublicPath as setVueComponentsAssetPath } from '@nimiq/vue-components';
 import { init as initFastspotApi } from '@nimiq/fastspot-api';
 
+// TODO: remove this as soon as the Safari IndexedDB bug is fixed
+import idbReady from 'safari-14-idb-fix';
+
 import Config from 'config';
 import App from './App.vue';
 import { serviceWorkerHasUpdate } from './registerServiceWorker';
@@ -35,6 +38,8 @@ Vue.use(VueCompositionApi);
 Vue.use(VueVirtualScroller);
 
 async function start() {
+    await idbReady(); // TODO: remove this as soon as the Safari IndexedDB bug is fixed
+
     await initStorage(); // Must be awaited before starting Vue
     await initHubApi(); // Must be called after VueCompositionApi has been enabled
     syncFromHub(); // Can run parallel to Vue initialization

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,6 +2,7 @@
 
 import { get as idbGet, set as idbSet, del as idbDel } from 'idb-keyval';
 import { captureException } from '@sentry/vue';
+import idbReady from 'safari-14-idb-fix';
 import Config from 'config';
 import { useTransactionsStore, Transaction } from './stores/Transactions';
 import { useAddressStore, AddressState } from './stores/Address';
@@ -103,6 +104,7 @@ let Storage: StorageBackend;
 
 export async function initStorage() {
     try {
+        await idbReady();
         await migrateToIdb();
         Storage = IndexedDBStorage;
     } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9128,6 +9128,11 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+safari-14-idb-fix@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/safari-14-idb-fix/-/safari-14-idb-fix-1.0.3.tgz#3efabd6ee57bcd1522ebecbedaa61d14ca6061cc"
+  integrity sha512-g+mlH1SOHKYmZ46O5gV7A5LSpxyzpJhjhhwEl8EOp8BX2iy6XgfnrlY0fo3+Xjiid82ilEBTwIKiJHe38i8N2w==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
Using IndexedDB facilities in Safari always fails in iOS 14.6 on their first
use in a new browser context due to an underlying module lazy loading issue.

Hence, the mitigation waits for the IndexedDB initialisation to complete within
a timeout. If the initialisation isn't completed by then, it is retried until it succeeds.