### PR TITLE
Reflect outgoing pending NIM txs in address and account balance

### DIFF
--- a/src/components/AccountMenuItem.vue
+++ b/src/components/AccountMenuItem.vue
@@ -58,10 +58,16 @@ export default defineComponent({
         const backgroundClass = computed(() => getBackgroundClass(firstAddressInfo.value.address));
         const outgoingPendingAmount = computed(() => {
             const pendingTxs: Transaction[] = [];
+            const addresses: string[] = [];
             for (const ai of addressInfos.value) {
                 pendingTxs.push(...(pendingTransactionsBySender.value[ai.address] || []));
+                addresses.push(ai.address);
             }
-            return pendingTxs.reduce((sum, tx) => sum + tx.value + tx.fee, 0);
+            return pendingTxs
+                // Do not consider pending transactions to our own addresses, to prevent the account
+                // balance from getting reduced when sending between own accounts.
+                .filter((tx) => !addresses.includes(tx.recipient))
+                .reduce((sum, tx) => sum + tx.value + tx.fee, 0);
         });
         const nimAccountBalance = computed(() => addressInfos.value.reduce((sum, ai) =>
             sum + Math.max(0, (ai.balance || 0) - outgoingPendingAmount.value), 0));

--- a/src/components/AccountMenuItem.vue
+++ b/src/components/AccountMenuItem.vue
@@ -34,6 +34,7 @@ import { useAddressStore } from '../stores/Address';
 import { useBtcAddressStore, BtcAddressSet } from '../stores/BtcAddress';
 import { useFiatStore } from '../stores/Fiat';
 import { CryptoCurrency } from '../lib/Constants';
+import { Transaction, useTransactionsStore } from '../stores/Transactions';
 
 export default defineComponent({
     props: {
@@ -49,12 +50,21 @@ export default defineComponent({
     setup(props) {
         const { accountInfos } = useAccountStore();
         const { state: addressState } = useAddressStore();
+        const { pendingTransactionsBySender } = useTransactionsStore();
 
         const accountInfo = computed(() => accountInfos.value[props.id]);
         const addressInfos = computed(() => accountInfo.value.addresses.map((addr) => addressState.addressInfos[addr]));
         const firstAddressInfo = computed(() => addressInfos.value[0]);
         const backgroundClass = computed(() => getBackgroundClass(firstAddressInfo.value.address));
-        const nimAccountBalance = computed(() => addressInfos.value.reduce((sum, acc) => sum + (acc.balance || 0), 0));
+        const outgoingPendingAmount = computed(() => {
+            const pendingTxs: Transaction[] = [];
+            for (const ai of addressInfos.value) {
+                pendingTxs.push(...(pendingTransactionsBySender.value[ai.address] || []));
+            }
+            return pendingTxs.reduce((sum, tx) => sum + tx.value + tx.fee, 0);
+        });
+        const nimAccountBalance = computed(() => addressInfos.value.reduce((sum, ai) =>
+            sum + Math.max(0, (ai.balance || 0) - outgoingPendingAmount.value), 0));
 
         const addressSet = computed(() => {
             if (accountInfo.value.type === AccountType.LEGACY) return [];

--- a/src/stores/Transactions.ts
+++ b/src/stores/Transactions.ts
@@ -31,6 +31,16 @@ export const useTransactionsStore = createStore({
     }),
     getters: {
         // activeAccount: state => state.accounts[state.activeAccountId],
+        pendingTransactionsBySender: (state) => {
+            const pendingTxs = Object.values(state.transactions).filter((tx) => !tx.confirmations);
+            const txsBySender: {[address: string]: Transaction[] | undefined} = {};
+            for (const tx of pendingTxs) {
+                const array = txsBySender[tx.sender] || [];
+                array.push(tx);
+                txsBySender[tx.sender] = array;
+            }
+            return txsBySender;
+        },
     },
     actions: {
         // Note: this method should not be async to avoid race conditions between parallel calls. Otherwise an older


### PR DESCRIPTION
With this PR, _outgoing_ pending transactions are subtracted from the displayed address and account balance. This gives better feedback about available balance and increases feedback that a transaction has successfully been broadcast and will be mined.

~~There is one disadvantage: When sending between addresses in the same wallet, or even within the same account, the displayed "Total Balance" will be reduced by the sent amount while the transaction is pending, which might be weird (or frightening) to users.~~