### PR TITLE
QR scanner is using full width in small screens

### DIFF
--- a/src/components/modals/ScanQrModal.vue
+++ b/src/components/modals/ScanQrModal.vue
@@ -136,6 +136,7 @@ export default defineComponent({
             height: 100%;
             max-height: 100%;
             border-radius: 0;
+            min-width: 100vw;
         }
 
         .swipe-bar {

--- a/src/components/modals/ScanQrModal.vue
+++ b/src/components/modals/ScanQrModal.vue
@@ -155,6 +155,10 @@ export default defineComponent({
         ::v-deep .cancel-button {
             bottom: 6rem;
         }
+
+        ::v-deep .access-denied-instructions {
+            bottom: 13rem;
+        }
     }
 }
 </style>


### PR DESCRIPTION
Before:
![before change](https://user-images.githubusercontent.com/22072217/148532917-aefd762d-5013-4516-b146-4c663cd3fcf7.jpeg)

After:
![after change](https://user-images.githubusercontent.com/22072217/148532950-b7260863-0c9c-44b6-a9b1-06dfd180d819.jpeg)

