### PR TITLE
Update SASS compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-vue": "^6.2.2",
     "node-fetch": "^2.6.1",
-    "node-sass": "^4.13.1",
+    "sass": "^1.46.0",
     "sass-loader": "^8.0.2",
     "typescript": "^4.0.0",
     "vue-template-compiler": "^2.6.11",

--- a/src/App.vue
+++ b/src/App.vue
@@ -243,19 +243,19 @@ export default defineComponent({
             position: relative;
         }
 
-        /deep/ .account-overview {
+        ::v-deep .account-overview {
             width: var(--account-column-width);
             flex-shrink: 0;
             z-index: 2;
         }
 
-        /deep/ .address-overview {
+        ::v-deep .address-overview {
             width: var(--address-column-width);
             min-width: 0;
             z-index: 3;
         }
 
-        /deep/ .mobile-tap-area {
+        ::v-deep .mobile-tap-area {
             z-index: 100;
         }
 
@@ -292,7 +292,7 @@ export default defineComponent({
             }
 
             &.column-sidebar {
-                /deep/ .mobile-tap-area {
+                ::v-deep .mobile-tap-area {
                     opacity: 1;
                     pointer-events: all;
                 }
@@ -314,7 +314,7 @@ export default defineComponent({
                 width: 100%;
             }
 
-            /deep/ .address-overview {
+            ::v-deep .address-overview {
                 min-width: unset;
             }
 

--- a/src/components/AccountMenu.vue
+++ b/src/components/AccountMenu.vue
@@ -266,7 +266,7 @@ export default defineComponent({
     .menu {
         display: block;
 
-        /deep/ .wrapper {
+        ::v-deep .wrapper {
             position: absolute;
             left: calc(var(--sidebar-width) - 1rem);
             bottom: 2rem;
@@ -278,7 +278,7 @@ export default defineComponent({
             }
         }
 
-        /deep/ .close-button {
+        ::v-deep .close-button {
             display: none;
         }
     }
@@ -288,7 +288,7 @@ export default defineComponent({
     position: fixed;
     cursor: auto;
 
-    /deep/ .wrapper {
+    ::v-deep .wrapper {
         .small-page {
             padding: 1rem;
             min-height: unset;
@@ -305,7 +305,7 @@ export default defineComponent({
     margin-bottom: 1rem;
 }
 
-.current-account .account-menu-item /deep/ .nq-icon {
+.current-account .account-menu-item ::v-deep .nq-icon {
     display: none;
 }
 
@@ -378,7 +378,7 @@ export default defineComponent({
         color var(--attr-duration) var(--nimiq-ease),
         background var(--attr-duration) var(--nimiq-ease);
 
-    /deep/ .icon {
+    ::v-deep .icon {
         opacity: 0.8;
 
         transition: opacity var(--attr-duration) var(--nimiq-ease),
@@ -390,7 +390,7 @@ export default defineComponent({
     background: var(--nimiq-highlight-bg);
     color: var(--text-100);
 
-    /deep/ .icon {
+    ::v-deep .icon {
         opacity: 1;
     }
 }
@@ -404,11 +404,11 @@ export default defineComponent({
     .backdrop {
         background-color: rgba(31, 35, 72, 0.3);
 
-        /deep/ .wrapper {
+        ::v-deep .wrapper {
             transform-origin: left center;
         }
 
-        /deep/ .nq-card {
+        ::v-deep .nq-card {
             box-shadow:
                 0px 2px 2.5px rgba(31, 35, 72, 0.02),
                 0px 7px 8.5px rgba(31, 35, 72, 0.04),
@@ -418,7 +418,7 @@ export default defineComponent({
 
     // Special transition for Account Menu modal
     .modal-enter, .modal-leave-to {
-        /deep/ .wrapper {
+        ::v-deep .wrapper {
             transform: translate3D(1rem, 0, 0) scale(0.99);
         }
     }
@@ -426,7 +426,7 @@ export default defineComponent({
 
 @media (max-width: 700px) { // Full mobile breakpoint
     .menu {
-        /deep/ .wrapper {
+        ::v-deep .wrapper {
             .small-page {
                 padding: 2rem;
                 font-size: 2.25rem;

--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -357,7 +357,7 @@ export default defineComponent({
         }
     }
 
-    .embedded /deep/ .mobile-arrow {
+    .embedded ::v-deep .mobile-arrow {
         display: none;
     }
 

--- a/src/components/AddressListItem.vue
+++ b/src/components/AddressListItem.vue
@@ -114,7 +114,7 @@ export default defineComponent({
     text-align: right;
     flex-shrink: 0;
 
-    /deep/ .circle-spinner {
+    ::v-deep .circle-spinner {
         display: block;
     }
 }

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -260,7 +260,7 @@ export default defineComponent({
             }
         }
 
-        .tooltip /deep/ .tooltip-box {
+        .tooltip ::v-deep .tooltip-box {
             padding: 1rem;
             transform: translate(calc(26px - 50%), -2rem);
             white-space: nowrap;
@@ -295,15 +295,15 @@ export default defineComponent({
             .tooltip {
                 width: 100%;
 
-                /deep/ .trigger {
+                ::v-deep .trigger {
                     display: block;
                 }
 
-                /deep/ .trigger::after {
+                ::v-deep .trigger::after {
                     background: white;
                 }
 
-                /deep/ .tooltip-box {
+                ::v-deep .tooltip-box {
                     background: white;
                     color: var(--nimiq-blue);
                 }

--- a/src/components/BankCheckInput.vue
+++ b/src/components/BankCheckInput.vue
@@ -448,7 +448,7 @@ export default defineComponent({
     .label-input {
         font-size: 3rem !important;
 
-        /deep/ input {
+        ::v-deep input {
             width: 100% !important;
             padding: 1.75rem 2rem;
             padding-right: 6.5rem;
@@ -475,11 +475,11 @@ export default defineComponent({
     top: 50%;
     transform: translateY(-50%);
 
-    /deep/ .trigger {
+    ::v-deep .trigger {
         padding: 1.5rem 1rem;
     }
 
-    /deep/ .dropdown {
+    ::v-deep .dropdown {
         left: unset;
         right: 0.25rem;
         top: 0;
@@ -613,7 +613,7 @@ export default defineComponent({
             flex-shrink: 0;
             flex-grow: 0;
 
-            &.tooltip /deep/ .tooltip-box {
+            &.tooltip ::v-deep .tooltip-box {
                 width: 32rem;
                 box-shadow:
                     0px 18px 38px rgba(31, 35, 72, 0.14),

--- a/src/components/BtcAddressInput.vue
+++ b/src/components/BtcAddressInput.vue
@@ -218,7 +218,7 @@ export default defineComponent({
     .label-input {
         font-family: 'Fira Mono', monospace;
 
-        /deep/ input {
+        ::v-deep input {
             width: 100% !important;
             padding: 1.75rem 2rem;
             line-height: 2.5rem;
@@ -236,7 +236,7 @@ export default defineComponent({
             }
         }
 
-        /deep/ .width-finder {
+        ::v-deep .width-finder {
             padding: 0 2rem;
         }
     }

--- a/src/components/BtcCopiedAddress.vue
+++ b/src/components/BtcCopiedAddress.vue
@@ -126,7 +126,7 @@ export default defineComponent({
 .label-input {
     margin-left: 0.375rem;
 
-    /deep/ {
+    ::v-deep {
         .nq-input,
         .width-finder {
             padding: 0.25rem .75rem;
@@ -181,7 +181,7 @@ export default defineComponent({
 }
 
 .copyable-short-address {
-    &.tooltip /deep/ {
+    &.tooltip ::v-deep {
         .trigger {
             transition: transform var(--short-transition-duration) var(--nimiq-ease);
             transform: translateX(4rem);
@@ -230,7 +230,7 @@ export default defineComponent({
             color: var(--nimiq-light-blue);
         }
 
-        /deep/ .tooltip {
+        ::v-deep .tooltip {
             z-index: 4;
         }
     }
@@ -251,7 +251,7 @@ export default defineComponent({
     transition: background var(--short-transition-duration) var(--nimiq-ease),
                 opacity var(--short-transition-duration) var(--nimiq-ease);
 
-    /deep/ svg {
+    ::v-deep svg {
         width: auto;
         height: 2rem;
 
@@ -265,7 +265,7 @@ export default defineComponent({
     &:hover {
         background: rgba(#D94432/*Nimiq red*/, .12);
 
-        /deep/ svg g {
+        ::v-deep svg g {
             stroke: var(--nimiq-red)
         }
     }

--- a/src/components/BtcLabelInput.vue
+++ b/src/components/BtcLabelInput.vue
@@ -133,16 +133,16 @@ export default defineComponent({
             letter-spacing: -0.05em;
         }
 
-        & >.avatar /deep/ svg path {
+        & >.avatar ::v-deep svg path {
             transition: fill 200ms var(--nimiq-ease);
         }
 
-        &:hover > .avatar /deep/ svg path,
-        &:focus-within > .avatar /deep/ svg path {
+        &:hover > .avatar ::v-deep svg path,
+        &:focus-within > .avatar ::v-deep svg path {
             fill: var(--nimiq-light-blue);
         }
 
-        /deep/ input {
+        ::v-deep input {
             width: 100% !important;
             padding: 1.75rem 2rem 1.75rem 5.75rem;
 
@@ -157,7 +157,7 @@ export default defineComponent({
                 opacity: 0.5;
             }
 
-            /deep/ input {
+            ::v-deep input {
                 color: var(--text-50);
             }
         }

--- a/src/components/BtcTransactionListItem.vue
+++ b/src/components/BtcTransactionListItem.vue
@@ -409,12 +409,12 @@ svg {
     .pending,
     .new,
     .invalid {
-        /deep/ svg {
+        ::v-deep svg {
             margin: 0 auto;
         }
     }
 
-    /deep/ .circle-spinner {
+    ::v-deep .circle-spinner {
         display: block;
     }
 

--- a/src/components/ContactBook.vue
+++ b/src/components/ContactBook.vue
@@ -188,11 +188,11 @@ export default defineComponent({
     .label-input {
         margin-left: 1.25rem;
 
-        /deep/ .width-finder {
+        ::v-deep .width-finder {
             padding: 0 0.75rem;
         }
 
-        /deep/ input {
+        ::v-deep input {
             padding: 0.625rem 0.75rem;
             padding-right: 0;
         }

--- a/src/components/DoubleInput.vue
+++ b/src/components/DoubleInput.vue
@@ -179,7 +179,7 @@ $inputHeight: 6rem;
     width: calc(100% - #{$inputBoxShadowSize});
 
     position: absolute;
-    left: #{$inputBoxShadowSize / 2};
+    left: #{calc($inputBoxShadowSize / 2)};
     z-index: 3;
 
     border-radius: 0;
@@ -198,8 +198,8 @@ $inputHeight: 6rem;
         border-top-left-radius: #{$inputBoxShadowSize};
         border-top-right-radius: #{$inputBoxShadowSize};
         box-shadow:
-            0 #{($borderSize / 2 + $inputBoxShadowSize) * -1}
-            0 #{$borderSize / 2}
+            0 #{calc(($borderSize / 2 + $inputBoxShadowSize) * -1)}
+            0 #{calc($borderSize / 2)}
             $borderColor;
     }
 
@@ -207,8 +207,8 @@ $inputHeight: 6rem;
         border-bottom-left-radius: $inputBoxShadowSize;
         border-bottom-right-radius: $inputBoxShadowSize;
         box-shadow:
-            0 #{$borderSize / 2 + $inputBoxShadowSize}
-            0 #{$borderSize / 2}
+            0 #{calc($borderSize / 2 + $inputBoxShadowSize)}
+            0 #{calc($borderSize / 2)}
             $borderColor;
     }
 

--- a/src/components/DoubleInput.vue
+++ b/src/components/DoubleInput.vue
@@ -74,7 +74,7 @@ $inputHeight: 6rem;
     .second-input-wrapper {
         margin-bottom: -0.25rem;
 
-        & /deep/ form {
+        & ::v-deep form {
             background-color: white;
         }
 
@@ -109,11 +109,11 @@ $inputHeight: 6rem;
         font-size: 15px;
         position: relative; // For correct z-index positioning
 
-        & /deep/ input {
+        & ::v-deep input {
             transition: all 200ms, width 50ms;
         }
 
-        & /deep/ form {
+        & ::v-deep form {
             background-color: white;
         }
     }
@@ -125,31 +125,31 @@ $inputHeight: 6rem;
 
     &.extended {
         .second-input-wrapper {
-            /deep/ input {
+            ::v-deep input {
                 border-bottom-left-radius: 0;
                 border-bottom-right-radius: 0;
             }
 
             &:hover,
             &:focus-within {
-                /deep/ .label-input,
-                /deep/ .avatar {
+                ::v-deep .label-input,
+                ::v-deep .avatar {
                     z-index: 2;
                 }
 
-                /deep/ .label-autocomplete {
+                ::v-deep .label-autocomplete {
                     z-index: 4;
                 }
             }
 
-            &:focus-within /deep/ input {
+            &:focus-within ::v-deep input {
                 border-bottom-left-radius: .5rem;
                 border-bottom-right-radius: .5rem;
             }
         }
 
         .main-input-wrapper {
-            /deep/ input {
+            ::v-deep input {
                 border-top-left-radius: 0;
                 border-top-right-radius: 0;
             }
@@ -157,7 +157,7 @@ $inputHeight: 6rem;
             &:focus-within {
                 z-index: 2;
 
-                /deep/ input {
+                ::v-deep input {
                     border-top-left-radius: .5rem;
                     border-top-right-radius: .5rem;
                 }

--- a/src/components/InteractiveShortAddress.vue
+++ b/src/components/InteractiveShortAddress.vue
@@ -33,7 +33,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.interactive-short-address.tooltip /deep/ {
+.interactive-short-address.tooltip ::v-deep {
     .tooltip-box {
         padding: 1rem;
         font-size: var(--small-size);
@@ -63,11 +63,11 @@ export default defineComponent({
     }
 }
 
-.tooltip.right /deep/ .tooltip-box {
+.tooltip.right ::v-deep .tooltip-box {
     transform: translate(-20%, 2rem);
 }
 
-.tooltip.left /deep/ .tooltip-box {
+.tooltip.left ::v-deep .tooltip-box {
     transform: translate(20%, 2rem);
 }
 

--- a/src/components/ResizingCopyable.vue
+++ b/src/components/ResizingCopyable.vue
@@ -85,7 +85,7 @@ export default defineComponent({
         background-color: transparent;
     }
 
-    &:hover /deep/ .background {
+    &:hover ::v-deep .background {
         opacity: 0.1;
     }
 

--- a/src/components/TransactionDetailOasisPayoutStatus.vue
+++ b/src/components/TransactionDetailOasisPayoutStatus.vue
@@ -79,7 +79,7 @@ export default defineComponent({
         text-align: left;
         font-size: 1.75rem;
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             width: 28rem;
 
             box-shadow:

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -476,7 +476,7 @@ export default defineComponent({
         top: 1.5rem;
         right: 1.5rem;
 
-        /deep/ svg {
+        ::v-deep svg {
             opacity: 0.5;
         }
     }

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -371,12 +371,12 @@ svg {
     .pending,
     .new,
     .invalid {
-        /deep/ svg {
+        ::v-deep svg {
             margin: 0 auto;
         }
     }
 
-    /deep/ .circle-spinner {
+    ::v-deep .circle-spinner {
         display: block;
     }
 

--- a/src/components/UpdateNotification.vue
+++ b/src/components/UpdateNotification.vue
@@ -63,13 +63,13 @@ export default defineComponent({
         border-radius: 1rem 1rem 0 0;
     }
 
-    /deep/ .close-button {
+    ::v-deep .close-button {
         position: relative;
         top: 0;
         right: 0;
     }
 
-    &.hide-close-button /deep/ .close-button {
+    &.hide-close-button ::v-deep .close-button {
         display: none;
     }
 }
@@ -81,12 +81,12 @@ export default defineComponent({
 }
 
 .nq-button-s,
-/deep/ svg {
+::v-deep svg {
     margin-left: 1.5rem;
     white-space: nowrap;
 }
 
-/deep/ svg.circle-spinner path {
+::v-deep svg.circle-spinner path {
     stroke: white;
 }
 </style>

--- a/src/components/layouts/AccountOverview.vue
+++ b/src/components/layouts/AccountOverview.vue
@@ -526,7 +526,7 @@ export default defineComponent({
                 color: var(--text-30);
             }
 
-            /deep/ svg {
+            ::v-deep svg {
                 width: 3.25rem;
                 height: 3rem;
             }

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -843,7 +843,7 @@ export default defineComponent({
             opacity: 0.3;
             font-size: 2.5rem;
 
-            /deep/ svg {
+            ::v-deep svg {
                 display: block;
             }
         }

--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -512,7 +512,7 @@ section {
     }
 }
 
-.update-available /deep/ .circle-spinner {
+.update-available ::v-deep .circle-spinner {
     margin: 0.375rem;
 }
 

--- a/src/components/layouts/Sidebar.vue
+++ b/src/components/layouts/Sidebar.vue
@@ -199,11 +199,11 @@ export default defineComponent({
     }
 
     .tooltip {
-        /deep/ .trigger {
+        ::v-deep .trigger {
             display: block;
         }
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             width: 20.5rem;
             padding: 1.25rem 1.5rem;
         }
@@ -259,7 +259,7 @@ export default defineComponent({
     width: 100%;
     padding: 1.5rem;
 
-    /deep/ .timespan {
+    ::v-deep .timespan {
         left: 1.5rem;
         top: 1.5rem;
     }

--- a/src/components/modals/BtcActivationModal.vue
+++ b/src/components/modals/BtcActivationModal.vue
@@ -81,7 +81,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .modal {
-    /deep/ .small-page {
+    ::v-deep .small-page {
         // height: auto;
         text-align: center;
         background-image: url('../../assets/bitcoin-activation-background.png');
@@ -91,7 +91,7 @@ export default defineComponent({
         width: 91rem; // 728px
     }
 
-    /deep/ .close-button {
+    ::v-deep .close-button {
         display: none;
     }
 }
@@ -137,7 +137,7 @@ svg {
 
 @media (max-width: 730px) {
     .modal {
-        /deep/ .small-page {
+        ::v-deep .small-page {
             width: 52.5rem; // reset
             background-image: none;
         }

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -414,11 +414,11 @@ export default defineComponent({
         background-color: transparent;
     }
 
-    &:hover /deep/ .background {
+    &:hover ::v-deep .background {
         opacity: 0.1;
     }
 
-    & /deep/ > span {
+    & ::v-deep > span {
         position: relative;
         overflow: hidden;
         display: flex;
@@ -507,7 +507,7 @@ export default defineComponent({
     .tooltip {
         z-index: 3;
 
-        /deep/ .trigger .nq-icon {
+        ::v-deep .trigger .nq-icon {
             margin-left: 0.75rem;
         }
 
@@ -598,20 +598,20 @@ footer {
     left: 2rem;
     z-index: 3;
 
-    /deep/ .trigger svg {
+    ::v-deep .trigger svg {
         height: 2rem;
         opacity: .3;
 
         transition: opacity var(--short-transition-duration) var(--nimiq-ease);
     }
 
-    & /deep/ .trigger:hover svg,
-    & /deep/ .trigger:focus svg,
-    &.shown /deep/ .trigger svg {
+    & ::v-deep .trigger:hover svg,
+    & ::v-deep .trigger:focus svg,
+    &.shown ::v-deep .trigger svg {
         opacity: .6;
     }
 
-    /deep/ .tooltip-box {
+    ::v-deep .tooltip-box {
         width: 26.25rem;
         font-size: var(--small-size);
         font-weight: 600;

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -687,12 +687,12 @@ export default defineComponent({
             }
         }
 
-        .amount-menu /deep/ .button {
+        .amount-menu ::v-deep .button {
             margin-left: 1rem;
             margin-bottom: 1rem;
         }
 
-        .amount-menu /deep/ .menu {
+        .amount-menu ::v-deep .menu {
             position: absolute;
             right: 3rem;
             bottom: 3rem;
@@ -710,12 +710,12 @@ export default defineComponent({
         }
 
         &.insufficient-balance {
-            .amount-input /deep/,
-            .amount-input /deep/ .ticker {
+            .amount-input ::v-deep,
+            .amount-input ::v-deep .ticker {
                 color: var(--nimiq-orange);
             }
 
-            .amount-input /deep/ .nq-input {
+            .amount-input ::v-deep .nq-input {
                 color: var(--nimiq-orange);
                 --border-color: rgba(252, 135, 2, 0.3); // Based on Nimiq Orange
             }
@@ -745,11 +745,11 @@ export default defineComponent({
             margin-right: 1rem;
         }
 
-        /deep/ .trigger .nq-icon {
+        ::v-deep .trigger .nq-icon {
             opacity: 0.4;
         }
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             transform: translate(4rem, -2rem);
         }
     }
@@ -772,20 +772,20 @@ export default defineComponent({
         top: 2rem;
         left: 2rem;
 
-        /deep/ .trigger svg {
+        ::v-deep .trigger svg {
             height: 2rem;
             opacity: .3;
 
             transition: opacity var(--short-transition-duration) var(--nimiq-ease);
         }
 
-        & /deep/ .trigger:hover svg,
-        & /deep/ .trigger:focus svg,
-        &.shown /deep/ .trigger svg {
+        & ::v-deep .trigger:hover svg,
+        & ::v-deep .trigger:focus svg,
+        &.shown ::v-deep .trigger svg {
             opacity: .6;
         }
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             width: 25.875rem;
             font-size: var(--small-size);
             font-weight: 600;

--- a/src/components/modals/BtcTransactionModal.vue
+++ b/src/components/modals/BtcTransactionModal.vue
@@ -685,7 +685,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .page-header {
-    /deep/ .nq-h1 {
+    ::v-deep .nq-h1 {
         margin-left: 2rem;
         margin-right: 2rem;
         max-width: calc(100% - 4rem);
@@ -705,7 +705,7 @@ export default defineComponent({
             display: block;
         }
 
-        /deep/ .circle-spinner,
+        ::v-deep .circle-spinner,
         &.failed svg {
             margin-right: 1rem;
         }
@@ -715,7 +715,7 @@ export default defineComponent({
         display: flex;
         flex-direction: column;
 
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             align-self: center;
         }
     }
@@ -858,7 +858,7 @@ export default defineComponent({
     mask: linear-gradient(90deg , white, white calc(100% - 4rem), rgba(255,255,255, 0) calc(100% - 1rem));
 }
 
-.address-info .tooltip /deep/ {
+.address-info .tooltip ::v-deep {
     .tooltip-box {
         padding: 1rem;
         font-size: var(--small-size);
@@ -887,11 +887,11 @@ export default defineComponent({
     }
 }
 
-.tooltip.left-aligned /deep/ .tooltip-box {
+.tooltip.left-aligned ::v-deep .tooltip-box {
     transform: translate(-9.25rem, 2rem);
 }
 
-.tooltip.right-aligned /deep/ .tooltip-box {
+.tooltip.right-aligned ::v-deep .tooltip-box {
     transform: translate(9.25rem, 2rem);
 }
 
@@ -911,7 +911,7 @@ export default defineComponent({
         line-height: 1;
         margin-bottom: 0.5rem;
 
-        /deep/ .currency {
+        ::v-deep .currency {
             font-size: 0.5em;
             font-weight: bold;
             margin-right: -1.9em;
@@ -946,7 +946,7 @@ export default defineComponent({
         line-height: 1;
 
         .tooltip {
-            /deep/ .trigger {
+            ::v-deep .trigger {
                 .fiat-amount {
                     transition: color 0.2s var(--nimiq-ease);
                 }
@@ -962,12 +962,12 @@ export default defineComponent({
                 }
             }
 
-            /deep/ .tooltip-box {
+            ::v-deep .tooltip-box {
                 width: 28rem;
                 transform: translate(-10rem, -1.5rem);
             }
 
-            /deep/ [value-mask]::after{
+            ::v-deep [value-mask]::after{
                 margin-right: 0;
             }
         }
@@ -1019,7 +1019,7 @@ export default defineComponent({
     top: 2rem;
     z-index: 3; // To be above .swipe-handle
 
-    /deep/ .trigger {
+    ::v-deep .trigger {
         color: rgba(31, 35, 72, 0.25);
         font-size: 2.25rem;
 
@@ -1042,7 +1042,7 @@ export default defineComponent({
         }
     }
 
-    /deep/ .tooltip-box {
+    ::v-deep .tooltip-box {
         font-size: var(--small-size);
         white-space: nowrap;
         line-height: 1.3;
@@ -1069,16 +1069,16 @@ export default defineComponent({
 
 @media (max-width: 700px) { // Full mobile breakpoint
     .page-header {
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             mask: linear-gradient(90deg , white, white calc(100% - 3rem), rgba(255,255,255, 0));
         }
 
-        &.inline-header /deep/ .nq-h1 {
+        &.inline-header ::v-deep .nq-h1 {
             align-self: unset;
         }
 
         &:not(.inline-header) {
-            /deep/ .nq-h1 {
+            ::v-deep .nq-h1 {
                 white-space: normal;
             }
 
@@ -1092,16 +1092,16 @@ export default defineComponent({
         flex-shrink: 0;
     }
 
-    .tooltip.left-aligned /deep/ .tooltip-box {
+    .tooltip.left-aligned ::v-deep .tooltip-box {
         transform: translate(-7.75rem, 2rem);
     }
 
-    .tooltip.right-aligned /deep/ .tooltip-box {
+    .tooltip.right-aligned ::v-deep .tooltip-box {
         transform: translate(7.75rem, 2rem);
     }
 
     .tooltip {
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             transform: translate(1rem, 2rem);
         }
     }
@@ -1109,7 +1109,7 @@ export default defineComponent({
 
 @media (max-width: 450px) { // Nimiq Style breakpoint for smaller .nq-card-header padding
     .page-header {
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             margin-left: 3rem;
             margin-right: 3rem;
             // max-width: calc(100% - 6rem);

--- a/src/components/modals/BuyCryptoModal.vue
+++ b/src/components/modals/BuyCryptoModal.vue
@@ -922,7 +922,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .modal {
-    &.wider-overlay /deep/ .overlay {
+    &.wider-overlay ::v-deep .overlay {
         width: 63.5rem;
         margin-left: calc((63.5rem - 52.5rem) / -2);
 
@@ -937,7 +937,7 @@ export default defineComponent({
     }
 }
 
-.modal /deep/ .overlay .animation-overlay + .close-button {
+.modal ::v-deep .overlay .animation-overlay + .close-button {
     display: none;
 }
 
@@ -1044,7 +1044,7 @@ export default defineComponent({
         --padding-sides: 2rem;
         max-height: 100%;
 
-        /deep/ .scroll-mask.bottom {
+        ::v-deep .scroll-mask.bottom {
             bottom: -1px;
         }
     }
@@ -1102,7 +1102,7 @@ export default defineComponent({
             color: rgb(234, 166, 23);
             box-shadow: inset 0 0 0 1.5px rgba(234, 166, 23, 0.7);
 
-            /deep/ svg {
+            ::v-deep svg {
                 margin-left: 0.75rem;
                 height: 1.75rem;
                 width: 1.75rem;
@@ -1182,9 +1182,9 @@ export default defineComponent({
                     color: var(--nimiq-orange);
                     transition: color 200ms cubic-bezier(0.5, 0, 0.15, 1);
 
-                    /deep/ .nq-input,
-                    /deep/ .label-input + span,
-                    /deep/ .label-input:focus-within + span {
+                    ::v-deep .nq-input,
+                    ::v-deep .label-input + span,
+                    ::v-deep .label-input:focus-within + span {
                         --border-color: rgba(252, 135, 2, 0.3); // --nimiq-orange 0.3 opacity
                         color: var(--nimiq-orange);
 
@@ -1208,12 +1208,12 @@ export default defineComponent({
                 max-width: 100%;
                 font-weight: bold;
 
-                /deep/ .ticker {
+                ::v-deep .ticker {
                     font-size: 2.5rem;
                     margin-left: 1.25rem;
                 }
 
-                /deep/ .label-input * {
+                ::v-deep .label-input * {
                     font-weight: 600;
                     font-size: 4rem !important;
                     padding: .5rem 1rem;
@@ -1237,12 +1237,12 @@ export default defineComponent({
                     color: var(--text-60);
                 }
 
-                /deep/ .ticker {
+                ::v-deep .ticker {
                     font-weight: bold;
                     font-size: 2rem;
                 }
 
-                /deep/ .label-input * {
+                ::v-deep .label-input * {
                     font-weight: 600;
                     font-size: 2.5rem !important;
                     padding: 0.375rem 0.75rem;
@@ -1265,7 +1265,7 @@ export default defineComponent({
             cursor: pointer;
         }
 
-        & /deep/ {
+        & ::v-deep {
             .fadeY-enter {
                 transform: translateY(calc(21px / 4)) !important;
             }
@@ -1311,7 +1311,7 @@ export default defineComponent({
         top: 2.5rem;
         right: 2.5rem;
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             font-size: var(--small-size);
             padding: 1.25rem 1.5rem;
         }
@@ -1320,7 +1320,7 @@ export default defineComponent({
 
 @media (max-width: 730px) {
     .modal {
-        /deep/ .small-page {
+        ::v-deep .small-page {
             width: 52.5rem; // reset
             background-image: none;
         }

--- a/src/components/modals/BuyOptionsModal.vue
+++ b/src/components/modals/BuyOptionsModal.vue
@@ -299,7 +299,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     width: 63.5rem !important;
     min-height: 63.5rem !important;
     max-width: 100vw;
@@ -329,7 +329,7 @@ header {
         display: inline-block;
         margin-bottom: 3rem;
 
-        /deep/ .trigger {
+        ::v-deep .trigger {
             &:hover,
             &:focus {
                 .pill {
@@ -341,7 +341,7 @@ header {
     }
 
     .country-flag,
-    /deep/ .circle-spinner {
+    ::v-deep .circle-spinner {
         width: 2rem;
         height: 2rem;
         margin: 0.25rem 0.625rem 0.25rem -0.75rem;
@@ -688,7 +688,7 @@ header {
 }
 
 @media (max-width: 700px) { // Full mobile breakpoint
-    .modal /deep/ .small-page {
+    .modal ::v-deep .small-page {
         // Regular Modal size (iOS scrolling inside the BuyOptionsModal does not work without a fixed height)
         min-height: unset !important;
     }

--- a/src/components/modals/DisclaimerModal.vue
+++ b/src/components/modals/DisclaimerModal.vue
@@ -39,7 +39,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-    .modal /deep/ .small-page {
+    .modal ::v-deep .small-page {
         height: auto;
         overflow-y: auto;
     }

--- a/src/components/modals/LegacyAccountNoticeModal.vue
+++ b/src/components/modals/LegacyAccountNoticeModal.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 .modal {
     position: absolute;
 
-    /deep/ .small-page {
+    ::v-deep .small-page {
         min-height: unset;
     }
 }
@@ -57,16 +57,16 @@ export default defineComponent({
 }
 
 .legacy-account-notice {
-    /deep/ h1 {
+    ::v-deep h1 {
         margin-top: 1rem;
     }
 
-    /deep/ section {
+    ::v-deep section {
         margin-top: 2rem;
         margin-bottom: 2rem;
     }
 
-    /deep/ .future-notice {
+    ::v-deep .future-notice {
         display: none;
     }
 }

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -246,7 +246,7 @@ export default defineComponent({
 
         overflow-y: auto;
 
-        /deep/ .page-body {
+        ::v-deep .page-body {
             overflow-y: unset;
         }
     }

--- a/src/components/modals/MoonpayModal.vue
+++ b/src/components/modals/MoonpayModal.vue
@@ -81,7 +81,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     height: 83.25rem; /* Height to fit Moonpay confirmation page without iframe scrollbar, with two-line disclaimer */
 }
 
@@ -90,7 +90,7 @@ header {
     align-items: center;
     padding: 2rem 3rem;
 
-    .tooltip /deep/ {
+    .tooltip ::v-deep {
         .trigger {
             color: var(--text-30);
         }

--- a/src/components/modals/NetworkInfoModal.vue
+++ b/src/components/modals/NetworkInfoModal.vue
@@ -79,7 +79,7 @@ export default defineComponent({
     background: transparent;
     pointer-events: none;
 
-    /deep/ .wrapper {
+    ::v-deep .wrapper {
         .small-page {
             min-height: unset;
             color: white;
@@ -153,7 +153,7 @@ a {
     .modal {
         display: block;
 
-        /deep/ .wrapper {
+        ::v-deep .wrapper {
             position: absolute;
             right: 2.25rem;
             top: 2.25rem;

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -130,7 +130,7 @@ export default defineComponent({
             color .3s var(--nimiq-ease),
             background 0.3s var(--nimiq-ease);
 
-        /deep/ .background {
+        ::v-deep .background {
             display: none;
         }
 

--- a/src/components/modals/ReleaseNotesModal.vue
+++ b/src/components/modals/ReleaseNotesModal.vue
@@ -62,7 +62,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import '../../scss/mixins.scss';
 
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     width: 65rem !important;
     padding-bottom: 1rem;
 }
@@ -115,7 +115,7 @@ details .nq-text {
     color: var(--text-80);
     line-height: 1.5;
 
-    /deep/ ul {
+    ::v-deep ul {
         padding: 2rem 0 2rem 3rem;
         margin: 0;
 

--- a/src/components/modals/ScanQrModal.vue
+++ b/src/components/modals/ScanQrModal.vue
@@ -113,7 +113,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .close-button {
+.modal ::v-deep .close-button {
     display: none;
 }
 
@@ -130,7 +130,7 @@ export default defineComponent({
 }
 
 @media (max-width: 700px) { // Full mobile breakpoint
-    .modal /deep/ {
+    .modal ::v-deep {
         .wrapper,
         .small-page {
             height: 100%;
@@ -151,7 +151,7 @@ export default defineComponent({
     .qr-scanner {
         border-radius: 0;
 
-        /deep/ .cancel-button {
+        ::v-deep .cancel-button {
             bottom: 6rem;
         }
     }

--- a/src/components/modals/SellCryptoModal.vue
+++ b/src/components/modals/SellCryptoModal.vue
@@ -979,7 +979,7 @@ export default defineComponent({
 @import '../../scss/mixins.scss';
 
 .modal {
-    &.wider-overlay /deep/ .overlay {
+    &.wider-overlay ::v-deep .overlay {
         width: 63.5rem;
         margin-left: calc((63.5rem - 52.5rem) / -2);
 
@@ -994,7 +994,7 @@ export default defineComponent({
     }
 }
 
-.modal /deep/ .overlay .animation-overlay + .close-button {
+.modal ::v-deep .overlay .animation-overlay + .close-button {
     display: none;
 }
 
@@ -1101,7 +1101,7 @@ export default defineComponent({
         --padding-sides: 2rem;
         max-height: 100%;
 
-        /deep/ .scroll-mask.bottom {
+        ::v-deep .scroll-mask.bottom {
             bottom: -1px;
         }
     }
@@ -1159,7 +1159,7 @@ export default defineComponent({
             color: rgb(234, 166, 23);
             box-shadow: inset 0 0 0 1.5px rgba(234, 166, 23, 0.7);
 
-            /deep/ svg {
+            ::v-deep svg {
                 margin-left: 0.75rem;
                 height: 1.75rem;
                 width: 1.75rem;
@@ -1239,10 +1239,10 @@ export default defineComponent({
                     color: var(--nimiq-orange);
                     transition: color 200ms cubic-bezier(0.5, 0, 0.15, 1);
 
-                    /deep/ .nq-input,
-                    /deep/ .label-input + span,
-                    /deep/ .label-input + .ticker,
-                    /deep/ .label-input:focus-within + .ticker {
+                    ::v-deep .nq-input,
+                    ::v-deep .label-input + span,
+                    ::v-deep .label-input + .ticker,
+                    ::v-deep .label-input:focus-within + .ticker {
                         --border-color: rgba(252, 135, 2, 0.3); // --nimiq-orange 0.3 opacity
                         color: var(--nimiq-orange);
 
@@ -1266,12 +1266,12 @@ export default defineComponent({
                 max-width: 100%;
                 font-weight: bold;
 
-                /deep/ .ticker {
+                ::v-deep .ticker {
                     font-size: 2.5rem;
                     margin-left: 1.25rem;
                 }
 
-                /deep/ .label-input * {
+                ::v-deep .label-input * {
                     font-weight: 600;
                     font-size: 4rem !important;
                     padding: .5rem 1rem;
@@ -1357,12 +1357,12 @@ export default defineComponent({
                     color: var(--text-60);
                 }
 
-                /deep/ .ticker {
+                ::v-deep .ticker {
                     font-weight: bold;
                     font-size: 2rem;
                 }
 
-                /deep/ .label-input * {
+                ::v-deep .label-input * {
                     font-weight: 600;
                     font-size: 2.5rem !important;
                     padding: 0.375rem 0.75rem;
@@ -1387,8 +1387,8 @@ export default defineComponent({
             cursor: pointer;
         }
 
-        & /deep/ .fadeY-enter,
-        & /deep/ .fadeY-leave-to {
+        & ::v-deep .fadeY-enter,
+        & ::v-deep .fadeY-leave-to {
             transform: translateY(-25%) !important;
         }
     }
@@ -1428,7 +1428,7 @@ export default defineComponent({
         top: 2.5rem;
         right: 2.5rem;
 
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             font-size: var(--small-size);
             padding: 1.25rem 1.5rem;
         }
@@ -1437,7 +1437,7 @@ export default defineComponent({
 
 @media (max-width: 730px) {
     .modal {
-        /deep/ .small-page {
+        ::v-deep .small-page {
             width: 52.5rem; // reset
             background-image: none;
         }

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -910,7 +910,7 @@ export default defineComponent({
             padding: 0.5rem;
             margin-bottom: 4rem;
 
-            /deep/ .background {
+            ::v-deep .background {
                 border-radius: 0.625rem;
             }
 
@@ -938,7 +938,7 @@ export default defineComponent({
         .identicon-button {
             width: 14rem;
 
-            /deep/ .identicon {
+            ::v-deep .identicon {
                 width: 9rem;
                 height: 9rem;
             }
@@ -1069,12 +1069,12 @@ export default defineComponent({
             }
         }
 
-        .amount-menu /deep/ .button {
+        .amount-menu ::v-deep .button {
             margin-left: 1rem;
             margin-bottom: 1rem;
         }
 
-        .amount-menu /deep/ .menu {
+        .amount-menu ::v-deep .menu {
             position: absolute;
             right: 3rem;
             bottom: 3rem;
@@ -1102,12 +1102,12 @@ export default defineComponent({
         }
 
         &.insufficient-balance {
-            .amount-input /deep/,
-            .amount-input /deep/ .ticker {
+            .amount-input ::v-deep,
+            .amount-input ::v-deep .ticker {
                 color: var(--nimiq-orange);
             }
 
-            .amount-input /deep/ .nq-input {
+            .amount-input ::v-deep .nq-input {
                 color: var(--nimiq-orange);
                 --border-color: rgba(252, 135, 2, 0.3); // Based on Nimiq Orange
             }

--- a/src/components/modals/SimplexModal.vue
+++ b/src/components/modals/SimplexModal.vue
@@ -306,7 +306,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     height: 83.25rem; /* Height to fit Moonpay confirmation page without iframe scrollbar, with two-line disclaimer */
 }
 
@@ -319,7 +319,7 @@ export default defineComponent({
     left: 3rem;
     top: 3rem;
 
-        /deep/ {
+        ::v-deep {
         .trigger {
             color: var(--text-30);
         }
@@ -382,7 +382,7 @@ export default defineComponent({
     flex-grow: 1;
 
     #checkout-element,
-    /deep/ iframe {
+    ::v-deep iframe {
         height: 100%;
     }
 }

--- a/src/components/modals/TradeModal.vue
+++ b/src/components/modals/TradeModal.vue
@@ -114,7 +114,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     width: 65rem !important;
     min-height: 60rem !important;
     max-width: 100vw;

--- a/src/components/modals/TransactionModal.vue
+++ b/src/components/modals/TransactionModal.vue
@@ -701,7 +701,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .page-header {
-    /deep/ .nq-h1 {
+    ::v-deep .nq-h1 {
         margin-left: 2rem;
         margin-right: 2rem;
         max-width: calc(100% - 4rem);
@@ -721,7 +721,7 @@ export default defineComponent({
             display: block;
         }
 
-        /deep/ .circle-spinner,
+        ::v-deep .circle-spinner,
         &.failed svg {
             margin-right: 1rem;
         }
@@ -731,7 +731,7 @@ export default defineComponent({
         display: flex;
         flex-direction: column;
 
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             align-self: center;
         }
     }
@@ -888,7 +888,7 @@ export default defineComponent({
     transition: opacity .3s var(--nimiq-ease);
 }
 
-.address-display /deep/ .chunk {
+.address-display ::v-deep .chunk {
     margin: 0.5rem 0;
 }
 
@@ -915,7 +915,7 @@ export default defineComponent({
         line-height: 1;
         margin-bottom: 0.5rem;
 
-        /deep/ .currency {
+        ::v-deep .currency {
             font-size: 0.5em;
             font-weight: bold;
             margin-right: -1.9em;
@@ -950,7 +950,7 @@ export default defineComponent({
         line-height: 1;
 
         .tooltip {
-            /deep/ .trigger {
+            ::v-deep .trigger {
                 .fiat-amount {
                     transition: color 0.2s var(--nimiq-ease);
                 }
@@ -966,12 +966,12 @@ export default defineComponent({
                 }
             }
 
-            /deep/ .tooltip-box {
+            ::v-deep .tooltip-box {
                 width: 28rem;
                 transform: translate(-10rem, -1.5rem);
             }
 
-            /deep/ [value-mask]::after{
+            ::v-deep [value-mask]::after{
                 margin-right: 0;
             }
         }
@@ -1023,7 +1023,7 @@ export default defineComponent({
     top: 2rem;
     z-index: 3; // To be above .swipe-handle
 
-    /deep/ .trigger {
+    ::v-deep .trigger {
         color: rgba(31, 35, 72, 0.25);
         font-size: 2.25rem;
 
@@ -1046,7 +1046,7 @@ export default defineComponent({
         }
     }
 
-    /deep/ .tooltip-box {
+    ::v-deep .tooltip-box {
         font-size: var(--small-size);
         white-space: nowrap;
         line-height: 1.3;
@@ -1071,7 +1071,7 @@ export default defineComponent({
     }
 }
 
-.address-info .tooltip /deep/ {
+.address-info .tooltip ::v-deep {
     .tooltip-box {
         padding: 1rem;
         font-size: var(--small-size);
@@ -1101,11 +1101,11 @@ export default defineComponent({
     }
 }
 
-.tooltip.left-aligned /deep/ .tooltip-box {
+.tooltip.left-aligned ::v-deep .tooltip-box {
     transform: translate(-9.25rem, 2rem);
 }
 
-.tooltip.right-aligned /deep/ .tooltip-box {
+.tooltip.right-aligned ::v-deep .tooltip-box {
     transform: translate(9.25rem, 2rem);
 }
 
@@ -1117,16 +1117,16 @@ export default defineComponent({
 
 @media (max-width: 700px) { // Full mobile breakpoint
     .page-header {
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             mask: linear-gradient(90deg , white, white calc(100% - 3rem), rgba(255,255,255, 0));
         }
 
-        &.inline-header /deep/ .nq-h1 {
+        &.inline-header ::v-deep .nq-h1 {
             align-self: unset;
         }
 
         &:not(.inline-header) {
-            /deep/ .nq-h1 {
+            ::v-deep .nq-h1 {
                 white-space: normal;
             }
 
@@ -1140,16 +1140,16 @@ export default defineComponent({
         flex-shrink: 0;
     }
 
-    .tooltip.left-aligned /deep/ .tooltip-box {
+    .tooltip.left-aligned ::v-deep .tooltip-box {
         transform: translate(-7.75rem, 2rem);
     }
 
-    .tooltip.right-aligned /deep/ .tooltip-box {
+    .tooltip.right-aligned ::v-deep .tooltip-box {
         transform: translate(7.75rem, 2rem);
     }
 
     .tooltip {
-        /deep/ .tooltip-box {
+        ::v-deep .tooltip-box {
             transform: translate(1rem, 2rem);
         }
     }
@@ -1157,7 +1157,7 @@ export default defineComponent({
 
 @media (max-width: 450px) { // Nimiq Style breakpoint for smaller .nq-card-header padding
     .page-header {
-        /deep/ .nq-h1 {
+        ::v-deep .nq-h1 {
             margin-left: 3rem;
             margin-right: 3rem;
             // max-width: calc(100% - 6rem);

--- a/src/components/modals/overlays/BuyCryptoBankCheckOverlay.vue
+++ b/src/components/modals/overlays/BuyCryptoBankCheckOverlay.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 }
 
 .page-header {
-    /deep/ h1 {
+    ::v-deep h1 {
         margin-bottom: 1rem;
     }
 

--- a/src/components/modals/overlays/PaymentLinkOverlay.vue
+++ b/src/components/modals/overlays/PaymentLinkOverlay.vue
@@ -219,22 +219,22 @@ export default defineComponent({
         .amount-input {
             font-size: 5rem;
 
-            /deep/ .nim {
+            ::v-deep .nim {
                 font-size: 0.5em;
                 margin-left: 0.5rem;
                 margin-right: calc(-1.9em - 0.5rem);
             }
 
-            /deep/ .nq-input {
+            ::v-deep .nq-input {
                 padding: 0;
             }
 
-            /deep/ .width-finder {
+            ::v-deep .width-finder {
                 padding: 0 1rem;
             }
         }
 
-        .amount-menu /deep/ .menu {
+        .amount-menu ::v-deep .menu {
             position: absolute;
             right: 3rem;
             bottom: 3rem;

--- a/src/components/modals/overlays/SellCryptoBankCheckOverlay.vue
+++ b/src/components/modals/overlays/SellCryptoBankCheckOverlay.vue
@@ -197,7 +197,7 @@ export default defineComponent({
 }
 
 .page-header {
-    /deep/ h1 {
+    ::v-deep h1 {
         margin-bottom: 1rem;
     }
 
@@ -207,7 +207,7 @@ export default defineComponent({
         margin: 1.25rem auto 0;
     }
 
-    /deep/ .page-header-back-button {
+    ::v-deep .page-header-back-button {
         z-index: 3;
     }
 }
@@ -250,7 +250,7 @@ export default defineComponent({
     .double-input {
         flex-grow: 1;
 
-        /deep/ .message {
+        ::v-deep .message {
             font-weight: 600;
             margin-top: .5rem;
             font-size: 1.75rem;
@@ -261,7 +261,7 @@ export default defineComponent({
         }
     }
 
-    .label-input /deep/ input {
+    .label-input ::v-deep input {
         width: 100% !important;
         line-height: 2rem;
         font-size: 2rem;

--- a/src/components/swap/OasisLaunchModal.vue
+++ b/src/components/swap/OasisLaunchModal.vue
@@ -66,14 +66,14 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .modal {
-    /deep/ .small-page {
+    ::v-deep .small-page {
         background-image: url('../../assets/oasis-launch-background.svg');
         background-position: top left;
         background-repeat: no-repeat;
         background-size: 100% auto;
     }
 
-    /deep/ .close-button {
+    ::v-deep .close-button {
         display: none;
     }
 }

--- a/src/components/swap/SwapAnimation.vue
+++ b/src/components/swap/SwapAnimation.vue
@@ -680,13 +680,13 @@ export default defineComponent({
     padding: 2rem 2rem 1rem;
 
     .close-button {
-        /deep/ svg {
+        ::v-deep svg {
             opacity: 0.6;
         }
 
         &:hover,
         &:focus {
-            /deep/ svg {
+            ::v-deep svg {
                 opacity: 0.8;
             }
         }
@@ -731,7 +731,7 @@ export default defineComponent({
         text-align: center;
         margin: 0.5rem 0.5rem 0;
 
-        /deep/ .background {
+        ::v-deep .background {
             border-radius: inherit;
             background: white;
         }
@@ -761,16 +761,16 @@ export default defineComponent({
 }
 
 .tooltip {
-    /deep/ .trigger::after {
+    ::v-deep .trigger::after {
         background: white;
         left: 6.5rem;
     }
 
-    &.right /deep/ .trigger::after {
+    &.right ::v-deep .trigger::after {
         left: 13.5rem;
     }
 
-    /deep/ .tooltip-box {
+    ::v-deep .tooltip-box {
         background: white;
         color: var(--nimiq-blue);
         left: 0 !important;
@@ -778,7 +778,7 @@ export default defineComponent({
         transform-origin: 50% calc(100% + 7rem);
     }
 
-    &.right /deep/ .tooltip-box {
+    &.right ::v-deep .tooltip-box {
         left: auto !important;
         right: 0 !important;
     }
@@ -799,7 +799,7 @@ export default defineComponent({
         font-size: var(--small-size);
         margin-top: 1rem;
 
-        /deep/ .nq-icon {
+        ::v-deep .nq-icon {
             margin-left: 0.25rem;
         }
     }
@@ -1029,13 +1029,13 @@ export default defineComponent({
         //     transform-origin: 33.33% 50%;
         // }
 
-        // .tooltip /deep/ .tooltip-box {
+        // .tooltip ::v-deep .tooltip-box {
         //     // animation: tooltip-box-rotate 3.2s 1 var(--nimiq-ease) forwards;
         //     transform: rotate(180deg);
         //     transition: opacity .3s var(--nimiq-ease), transform 1.2s ease 1s;
         // }
 
-        // .tooltip /deep/ .trigger::after {
+        // .tooltip ::v-deep .trigger::after {
         //     // animation: tooltip-arrow-rotate 3.2s 1 var(--nimiq-ease) forwards;
         //     transform: scale(-1) /* rotate(-180deg) */ translateY(14rem);
         //     transition: opacity .3s var(--nimiq-ease) 16ms, visibility .3s, transform 1.2s ease 1s;
@@ -1180,7 +1180,7 @@ export default defineComponent({
     .animation {
         --upscale: 1.58;
 
-        .tooltip /deep/ {
+        .tooltip ::v-deep {
             .trigger::after,
             .tooltip-box {
                 transform: scale(calc(1 / var(--upscale)));
@@ -1206,7 +1206,7 @@ export default defineComponent({
         &.left-to-right {
             transform: translate(28.75rem, -18rem) scale(var(--upscale));
 
-            .tooltip /deep/ .tooltip-box {
+            .tooltip ::v-deep .tooltip-box {
                 transform-origin: 5rem 4.25rem;
             }
         }
@@ -1214,7 +1214,7 @@ export default defineComponent({
         &.right-to-left {
             transform: translate(-28.75rem, -18rem) scale(var(--upscale));
 
-            .tooltip /deep/ .tooltip-box {
+            .tooltip ::v-deep .tooltip-box {
                 transform-origin: 13rem 4.25rem;
             }
         }
@@ -1238,7 +1238,7 @@ export default defineComponent({
         &.left-to-right {
             transform: translate(-28.75rem, -18rem) scale(var(--upscale));
 
-            .tooltip /deep/ .tooltip-box {
+            .tooltip ::v-deep .tooltip-box {
                 transform-origin: 13rem 4.25rem;
             }
         }
@@ -1246,7 +1246,7 @@ export default defineComponent({
         &.right-to-left {
             transform: translate(28.75rem, -18rem) scale(var(--upscale));
 
-            .tooltip /deep/ .tooltip-box {
+            .tooltip ::v-deep .tooltip-box {
                 transform-origin: 5rem 4.25rem;
             }
         }

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -1225,7 +1225,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.modal /deep/ .small-page {
+.modal ::v-deep .small-page {
     width: 63.5rem;
     // height: 74.5rem;
     font-size: var(--body-size);
@@ -1290,7 +1290,7 @@ export default defineComponent({
         color: rgb(234, 166, 23);
         box-shadow: inset 0 0 0 1.5px rgba(234, 166, 23, 0.7);
 
-        /deep/ svg {
+        ::v-deep svg {
             margin-left: 0.75rem;
             height: 1.75rem;
             width: 1.75rem;
@@ -1331,12 +1331,12 @@ export default defineComponent({
     margin-top: 1.5rem;
 }
 
-.amount-input /deep/ form input.nq-input {
+.amount-input ::v-deep form input.nq-input {
     padding: 0.25rem;
 }
 
 .amount-input.has-value {
-    &.positive-value /deep/ form{
+    &.positive-value ::v-deep form{
         .nq-input {
             color: var(--nimiq-green);
             --border-color: rgba(33,188,165,0.3); /* Based on Nimiq Green */
@@ -1348,7 +1348,7 @@ export default defineComponent({
         }
     }
 
-    &.negative-value /deep/ form{
+    &.negative-value ::v-deep form{
         .nq-input {
             color: var(--nimiq-blue);
         }
@@ -1361,7 +1361,7 @@ export default defineComponent({
     }
 
     &.focussed {
-        &.positive-value /deep/ {
+        &.positive-value ::v-deep {
             .ticker {
                 color: var(--nimiq-green);
             }
@@ -1372,7 +1372,7 @@ export default defineComponent({
             }
         }
 
-        &.negative-value /deep/ {
+        &.negative-value ::v-deep {
             .ticker {
                 color: var(--nimiq-light-blue);
             }
@@ -1397,7 +1397,7 @@ export default defineComponent({
     font-size: var(--size);
     font-weight: bold;
 
-    /deep/ .ticker {
+    ::v-deep .ticker {
         // Sometimes this class gets lower priority than the ticker's native class, so we need to force these styles
         font-size: inherit !important;
         line-height: 1 !important;
@@ -1446,7 +1446,7 @@ export default defineComponent({
     .tooltip {
         text-align: left;
 
-        /deep/ .trigger {
+        ::v-deep .trigger {
             display: block;
             font-size: 1.75rem;
             margin-left: 0.5rem;
@@ -1458,7 +1458,7 @@ export default defineComponent({
     }
 }
 
-.modal /deep/ .overlay .animation-overlay + .close-button {
+.modal ::v-deep .overlay .animation-overlay + .close-button {
     display: none;
 }
 
@@ -1511,7 +1511,7 @@ export default defineComponent({
 }
 
 @media (max-width: 700px) { // Full mobile breakpoint
-    .modal /deep/ .small-page {
+    .modal ::v-deep .small-page {
         overflow-y: auto;
     }
 

--- a/src/components/swap/SwapModalFooter.vue
+++ b/src/components/swap/SwapModalFooter.vue
@@ -90,12 +90,12 @@ export default defineComponent({
         justify-content: center;
         text-align: center;
 
-        /deep/ .nq-link {
+        ::v-deep .nq-link {
             color: inherit;
             text-decoration: underline;
         }
 
-        /deep/ .circle-spinner {
+        ::v-deep .circle-spinner {
             margin-right: 1rem;
         }
     }

--- a/src/components/swap/SwapSepaFundingInstructions.vue
+++ b/src/components/swap/SwapSepaFundingInstructions.vue
@@ -284,7 +284,7 @@ export default defineComponent({
         color: white !important;
     }
 
-    /deep/ .background {
+    ::v-deep .background {
         pointer-events: none;
         background: white;
     }
@@ -347,7 +347,7 @@ export default defineComponent({
     }
 
     .text,
-    .tooltip /deep/ .trigger {
+    .tooltip ::v-deep .trigger {
         color: var(--nimiq-orange);
 
         .nq-icon {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2109,11 +2109,6 @@ JSONStream@^1.0.3:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -2197,11 +2192,6 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
-
 ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
@@ -2284,7 +2274,15 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-aproba@^1.0.3, aproba@^1.1.1:
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
@@ -2293,14 +2291,6 @@ arch@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2323,11 +2313,6 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
-
-array-find-index@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
 array-find@^1.0.0:
   version "1.0.0"
@@ -2441,11 +2426,6 @@ async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
-
-async-foreach@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
-  integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -2700,13 +2680,6 @@ bitcoinjs-lib@5.2.0, bitcoinjs-lib@^5.1.10:
     typeforce "^1.11.3"
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
 
 bluebird@^3.1.1, bluebird@^3.5.5:
   version "3.7.2"
@@ -3145,19 +3118,6 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-camelcase-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
-  dependencies:
-    camelcase "^2.0.0"
-    map-obj "^1.0.0"
-
-camelcase@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
-
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -3202,7 +3162,7 @@ cfb@^1.1.4:
     crc-32 "~1.2.0"
     printj "~1.1.2"
 
-chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -3271,6 +3231,21 @@ cheerio@^1.0.0-rc.6:
     htmlparser2 "^6.1.0"
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
+
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -3448,11 +3423,6 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
-
 codepage@~1.14.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.14.0.tgz#8cbe25481323559d7d307571b0fff91e7a1d2f99"
@@ -3626,11 +3596,6 @@ console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
-
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 consolidate@^0.15.1:
   version "0.15.1"
@@ -3807,14 +3772,6 @@ cross-fetch@^3.1.4:
   integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
   dependencies:
     node-fetch "2.6.1"
-
-cross-spawn@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
-  integrity sha1-ElYDfsufDF9549bvE14wdwGEuYI=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -4031,13 +3988,6 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-currently-unhandled@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
-  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
-  dependencies:
-    array-find-index "^1.0.1"
-
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -4089,7 +4039,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -4199,11 +4149,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 depd@~1.1.2:
   version "1.1.2"
@@ -5523,15 +5468,10 @@ fsevents@~2.3.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
   integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
-fstream@^1.0.0, fstream@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
-  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5542,27 +5482,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
-gaze@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
-  integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
-  dependencies:
-    globule "^1.0.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
@@ -5601,11 +5520,6 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
-
-get-stdin@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
-  integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -5686,12 +5600,19 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-"glob@5 - 7", glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+"glob@5 - 7", glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -5763,15 +5684,6 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
-
-globule@^1.0.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.3.2.tgz#d8bdd9e9e4eef8f96e245999a5dee7eb5d8529c4"
-  integrity sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==
-  dependencies:
-    glob "~7.1.1"
-    lodash "~4.17.10"
-    minimatch "~3.0.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.4"
@@ -5847,11 +5759,6 @@ has-tostringtag@^1.0.0:
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -6186,6 +6093,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immutable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
+  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -6229,18 +6141,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-in-publish@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
-  integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
-
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
-  dependencies:
-    repeating "^2.0.0"
-
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -6264,7 +6164,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6545,18 +6445,6 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-finite@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
-  integrity sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
-
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -6734,11 +6622,6 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
-
 is-weakref@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
@@ -6820,11 +6703,6 @@ jest-worker@^25.4.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
-
-js-base64@^2.1.8:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
 js-message@1.0.7:
   version "1.0.7"
@@ -7055,17 +6933,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
-
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -7205,7 +7072,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@~4.17.10:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7228,14 +7095,6 @@ loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-loud-rejection@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.0"
 
 lower-case@^1.1.1:
   version "1.1.4"
@@ -7290,11 +7149,6 @@ map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
-
-map-obj@^1.0.0, map-obj@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -7354,22 +7208,6 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
-
-meow@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
-  dependencies:
-    camelcase-keys "^2.0.0"
-    decamelize "^1.1.2"
-    loud-rejection "^1.0.0"
-    map-obj "^1.0.1"
-    minimist "^1.1.3"
-    normalize-package-data "^2.3.4"
-    object-assign "^4.0.1"
-    read-pkg-up "^1.0.1"
-    redent "^1.0.0"
-    trim-newlines "^1.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -7502,14 +7340,14 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -7571,7 +7409,7 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -7749,24 +7587,6 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
-  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
-  dependencies:
-    fstream "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    osenv "0"
-    request "^2.87.0"
-    rimraf "2"
-    semver "~5.3.0"
-    tar "^2.0.0"
-    which "1"
-
 node-ipc@^9.1.1:
   version "9.1.3"
   resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.1.3.tgz#1df3f069d103184ae9127fa885dbdaea56a4436f"
@@ -7810,29 +7630,6 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
   integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
 
-node-sass@^4.13.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
-  integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.13.2"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "2.2.5"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
 nomnom@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
@@ -7841,14 +7638,7 @@ nomnom@1.8.1:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
-"nopt@2 || 3":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
-  dependencies:
-    abbrev "1"
-
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -7909,16 +7699,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
 nth-check@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
@@ -7937,11 +7717,6 @@ num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -8136,23 +7911,10 @@ os-browserify@^0.3.0, os-browserify@~0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@0:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -8392,15 +8154,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
-
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -9148,14 +8901,6 @@ read-only-stream@^2.0.0:
   dependencies:
     readable-stream "^2.0.2"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -9163,15 +8908,6 @@ read-pkg-up@^2.0.0:
   dependencies:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
-
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
-  dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -9192,7 +8928,7 @@ read-pkg@^5.1.1:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -9230,13 +8966,12 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
-redent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
-    indent-string "^2.1.0"
-    strip-indent "^1.0.1"
+    picomatch "^2.2.1"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -9353,14 +9088,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
-  dependencies:
-    is-finite "^1.0.0"
-
-request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -9477,17 +9205,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -9550,16 +9278,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-graph@2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
-  integrity sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==
-  dependencies:
-    glob "^7.0.0"
-    lodash "^4.0.0"
-    scss-tokenizer "^0.2.3"
-    yargs "^13.3.2"
-
 sass-loader@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
@@ -9570,6 +9288,15 @@ sass-loader@^8.0.2:
     neo-async "^2.6.1"
     schema-utils "^2.6.1"
     semver "^6.3.0"
+
+sass@^1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.46.0.tgz#923117049525236026a7ede69715580eb0fac751"
+  integrity sha512-Z4BYTgioAOlMmo4LU3Ky2txR8KR0GRPLXxO38kklaYxgo7qMTgy+mpNN4eKsrXDTFlwS5vdruvazG4cihxHRVQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
 
 sax@~1.2.4:
   version "1.2.4"
@@ -9608,14 +9335,6 @@ scrollparent@^2.0.1:
   resolved "https://registry.yarnpkg.com/scrollparent/-/scrollparent-2.0.1.tgz#715d5b9cc57760fb22bdccc3befb5bfe06b1a317"
   integrity sha1-cV1bnMV3YPsivczDvvtb/gaxoxc=
 
-scss-tokenizer@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
-  integrity sha1-jrBtualyMzOCTT9VMGQRSYR85dE=
-  dependencies:
-    js-base64 "^2.1.8"
-    source-map "^0.4.2"
-
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -9649,11 +9368,6 @@ semver@^7.3.2:
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.17.1:
   version "0.17.1"
@@ -9704,7 +9418,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -9906,6 +9620,11 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+"source-map-js@>=0.6.2 <2.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -9929,13 +9648,6 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
-
-source-map@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.3:
   version "0.5.7"
@@ -10078,13 +9790,6 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stdout-stream@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.1.tgz#5ac174cdd5cd726104aa0c0b2bd83815d8d535de"
-  integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
-  dependencies:
-    readable-stream "^2.0.1"
-
 stream-browserify@^2.0.0, stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -10148,16 +9853,7 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2", string-width@^2.0.0:
+string-width@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -10271,13 +9967,6 @@ strip-ansi@~0.1.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
   integrity sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=
 
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
-  dependencies:
-    is-utf8 "^0.2.0"
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -10300,13 +9989,6 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
-strip-indent@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
-  dependencies:
-    get-stdin "^4.0.1"
 
 strip-indent@^2.0.0:
   version "2.0.0"
@@ -10410,15 +10092,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
 
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"
@@ -10614,18 +10287,6 @@ transform-ast@^2.4.3:
     magic-string "^0.23.2"
     merge-source-map "1.0.4"
     nanobench "^2.1.1"
-
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-"true-case-path@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
-  integrity sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
-  dependencies:
-    glob "^7.1.2"
 
 tryer@^1.0.1:
   version "1.0.1"
@@ -11393,7 +11054,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@^1.2.9:
+which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -11406,13 +11067,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
 
 wif@^2.0.1, wif@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
The old `node-sass` is deprecated and now produces build errors in GitHub Actions, as seen in #70.

This updates the compiler to the latest supported `sass` package and updates the relevant syntax that was throwing errors and warning post-update.