### PR TITLE
Address selector on mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,17 +25,17 @@
 </template>
 
 <script lang="ts">
+import { defineComponent, ref, watch, computed, onMounted, Ref } from '@vue/composition-api';
 import { LoadingSpinner } from '@nimiq/vue-components';
-import { computed, defineComponent, onMounted, ref, Ref, watch } from '@vue/composition-api';
 import Sidebar from './components/layouts/Sidebar.vue';
 import SwapNotification from './components/swap/SwapNotification.vue';
 import UpdateNotification from './components/UpdateNotification.vue';
-import { useActiveMobileColumn } from './composables/useActiveMobileColumn';
-import { useSwipes } from './composables/useSwipes';
-import { useWindowSize } from './composables/useWindowSize';
 import router, { provideRouter } from './router';
 import { useAccountStore } from './stores/Account';
 import { useSettingsStore } from './stores/Settings';
+import { useWindowSize } from './composables/useWindowSize';
+import { useActiveMobileColumn } from './composables/useActiveMobileColumn';
+import { useSwipes } from './composables/useSwipes';
 
 export default defineComponent({
     name: 'app',

--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -7,13 +7,6 @@
             :class="{ 'active': activeAddress === addressInfo.address && activeCurrency === CryptoCurrency.NIM }"
             @click="selectAddress(addressInfo.address);"
             :ref="`address-button-${addressInfo.address}`"/>
-        <hr class="separator" v-if="showBitcoin"/>
-        <AddressListItem
-            v-if="showBitcoin"
-            :addressInfo="btcInfos"
-            :class="{ 'active': activeCurrency === CryptoCurrency.BTC }"
-            @click="selectBtcAddress()"
-            :ref="`address-button-${btcInfos.address}`"/>
         <button
             v-if="showAddAddressButton"
             class="address-button add-address-button reset flex-row"
@@ -24,12 +17,19 @@
             </div>
             <span class="label add-address-label">{{ $t('Add\u00a0address') }}</span>
         </button>
+        <div class="scroll-mask bottom"></div>
+        <hr class="separator" v-if="showBitcoin"/>
+        <AddressListItem
+            v-if="showBitcoin"
+            :addressInfo="btcInfos"
+            :class="{ 'active': activeCurrency === CryptoCurrency.BTC }"
+            @click="selectBtcAddress()"
+            :ref="`address-button-${btcInfos.address}`"/>
         <div v-if="!embedded"
             class="active-box"
             :class="{ enabled: activeCurrency === CryptoCurrency.NIM }"
             :style="`--backgroundYScale: ${backgroundYScale}; --backgroundYOffset: ${backgroundYOffset}px`"
         ></div>
-        <div class="scroll-mask bottom"></div>
     </div>
 </template>
 
@@ -212,6 +212,7 @@ export default defineComponent({
     }
 
     .address-list {
+        height: 100%;
         display: flex;
         flex-direction: column;
         position: relative;
@@ -230,6 +231,7 @@ export default defineComponent({
 
         hr.separator {
             margin: 15px 0 15px 0;
+            margin-top: auto;
             border-top: 1.5px solid var(--nimiq-blue);
             opacity: 0.14;
         }
@@ -378,6 +380,10 @@ export default defineComponent({
 
         .add-address-button {
             padding: 1.5rem;
+        }
+
+        .embedded /deep/ .mobile-arrow {
+            display: inherit;
         }
     }
 </style>

--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -382,7 +382,7 @@ export default defineComponent({
             padding: 1.5rem;
         }
 
-        .embedded /deep/ .mobile-arrow {
+        .embedded ::v-deep .mobile-arrow {
             display: inherit;
         }
     }

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -18,6 +18,8 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
+import { useWindowSize } from '@/composables/useWindowSize';
+import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
 import { useAddressStore } from '../stores/Address';
 import { useAccountStore } from '../stores/Account';
 import { CryptoCurrency } from '../lib/Constants';
@@ -28,6 +30,9 @@ export default defineComponent({
         const { activeAddressInfo } = useAddressStore();
         const { activeCurrency } = useAccountStore();
         const { accountBalance } = useBtcAddressStore();
+        const { width } = useWindowSize();
+
+        const { activeMobileColumn } = useActiveMobileColumn();
 
         function nimOrBtc<T>(nim: T, btc: T): T {
             switch (activeCurrency.value) {
@@ -38,7 +43,11 @@ export default defineComponent({
         }
 
         function receive() {
-            context.root.$router.push(nimOrBtc<string>('/receive', '/btc-receive'));
+            if (width.value <= 700 /* Full mobile breakpoint */ && activeMobileColumn.value !== ColumnType.ADDRESS) {
+                context.root.$router.push('/receive');
+            } else {
+                context.root.$router.push(nimOrBtc<string>('/receive/nim', '/receive/btc'));
+            }
         }
 
         function send() {

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -16,14 +16,14 @@
 </template>
 
 <script lang="ts">
-import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
-import { useWindowSize } from '@/composables/useWindowSize';
+import { defineComponent, computed } from '@vue/composition-api';
 import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
-import { computed, defineComponent } from '@vue/composition-api';
-import { CryptoCurrency } from '../lib/Constants';
-import { useAccountStore } from '../stores/Account';
 import { useAddressStore } from '../stores/Address';
+import { useAccountStore } from '../stores/Account';
+import { CryptoCurrency } from '../lib/Constants';
 import { useBtcAddressStore } from '../stores/BtcAddress';
+import { useWindowSize } from '../composables/useWindowSize';
+import { ColumnType, useActiveMobileColumn } from '../composables/useActiveMobileColumn';
 
 export default defineComponent({
     setup(props, context) {

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -16,13 +16,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
-import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
-import { useWindowSize } from '@/composables/useWindowSize';
 import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
-import { useAddressStore } from '../stores/Address';
-import { useAccountStore } from '../stores/Account';
+import { useWindowSize } from '@/composables/useWindowSize';
+import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
+import { computed, defineComponent } from '@vue/composition-api';
 import { CryptoCurrency } from '../lib/Constants';
+import { useAccountStore } from '../stores/Account';
+import { useAddressStore } from '../stores/Address';
 import { useBtcAddressStore } from '../stores/BtcAddress';
 
 export default defineComponent({
@@ -44,6 +44,7 @@ export default defineComponent({
 
         function receive() {
             if (width.value <= 700 /* Full mobile breakpoint */ && activeMobileColumn.value !== ColumnType.ADDRESS) {
+                // redirect to the address selector
                 context.root.$router.push('/receive');
             } else {
                 context.root.$router.push(nimOrBtc<string>('/receive/nim', '/receive/btc'));
@@ -51,10 +52,15 @@ export default defineComponent({
         }
 
         function send() {
-            context.root.$router.push(nimOrBtc<string>('/send', '/btc-send'));
+            if (width.value <= 700 /* Full mobile breakpoint */ && activeMobileColumn.value !== ColumnType.ADDRESS) {
+                // redirect to the address selector
+                context.root.$router.push('/send');
+            } else {
+                context.root.$router.push(nimOrBtc<string>('/send/nim', '/send/btc'));
+            }
         }
 
-        const sendDisabled = computed(() => nimOrBtc(
+        const sendDisabled = computed(() => context.root.$route.path !== '/' && nimOrBtc(
             !activeAddressInfo.value || !activeAddressInfo.value.balance,
             !accountBalance.value,
         ));

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -31,7 +31,6 @@ export default defineComponent({
         const { activeCurrency } = useAccountStore();
         const { accountBalance } = useBtcAddressStore();
         const { width } = useWindowSize();
-
         const { activeMobileColumn } = useActiveMobileColumn();
 
         function nimOrBtc<T>(nim: T, btc: T): T {

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -59,12 +59,13 @@ export default defineComponent({
             }
         }
 
-        const hasMultipleSendableAddress = computed(() => activeAccountInfo.value!.addresses.length > 1);
+        const hasMultipleSendableAddresses = computed(() =>
+            activeAccountInfo.value && activeAccountInfo.value.addresses.length > 1);
 
         function send() {
             if (width.value <= 700 /* Full mobile breakpoint */
                 && activeMobileColumn.value !== ColumnType.ADDRESS
-                && (hasMultipleSendableAddress.value || hasBitcoin.value)
+                && (hasMultipleSendableAddresses.value || hasBitcoin.value)
             ) {
                 // redirect to the address selector
                 context.root.$router.push('/send');

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -111,7 +111,7 @@
                     <ArrowRightSmallIcon />{{ $t('Send') }}
                 </button>
                 <button class="receive nq-button-s flex-row"
-                    @click="$router.push(activeCurrency === 'nim' ? '/receive' : '/btc-receive')" @mousedown.prevent
+                    @click="$router.push(`/receive/${activeCurrency}`)" @mousedown.prevent
                 >
                     <ArrowRightSmallIcon />{{ $t('Receive') }}
                 </button>
@@ -172,42 +172,34 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed } from '@vue/composition-api';
-import {
-    Identicon,
-    GearIcon,
-    Copyable,
-    ArrowRightSmallIcon,
-    ArrowLeftIcon,
-    MenuDotsIcon,
-    CrossIcon,
-} from '@nimiq/vue-components';
 // @ts-expect-error missing types for this package
 import { Portal } from '@linusborg/vue-simple-portal';
+import {
+    ArrowLeftIcon, ArrowRightSmallIcon, Copyable, CrossIcon, GearIcon, Identicon, MenuDotsIcon,
+} from '@nimiq/vue-components';
+import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 // @ts-expect-error missing types for this package
 import { ResponsiveDirective } from 'vue-responsive-components';
-
-import BitcoinIcon from '../icons/BitcoinIcon.vue';
-import Amount from '../Amount.vue';
-import FiatConvertedAmount from '../FiatConvertedAmount.vue';
-import SearchBar from '../SearchBar.vue';
-import TransactionList from '../TransactionList.vue';
-import BtcTransactionList from '../BtcTransactionList.vue';
-import MobileActionBar from '../MobileActionBar.vue';
-import RenameIcon from '../icons/AccountMenu/RenameIcon.vue';
-import RefreshIcon from '../icons/RefreshIcon.vue';
-
+import { useWindowSize } from '../../composables/useWindowSize';
+import { checkHistory } from '../../electrum';
+import { onboard, rename } from '../../hub';
+import { BTC_ADDRESS_GAP, CryptoCurrency } from '../../lib/Constants';
 import { useAccountStore } from '../../stores/Account';
 import { useAddressStore } from '../../stores/Address';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
-import { onboard, rename } from '../../hub';
-import { useWindowSize } from '../../composables/useWindowSize';
-import { BTC_ADDRESS_GAP, CryptoCurrency } from '../../lib/Constants';
-import { checkHistory } from '../../electrum';
-import HighFiveIcon from '../icons/HighFiveIcon.vue';
-import EventIcon from '../icons/EventIcon.vue';
 import { useSwapsStore } from '../../stores/Swaps';
+import Amount from '../Amount.vue';
+import BtcTransactionList from '../BtcTransactionList.vue';
 import CrossCloseButton from '../CrossCloseButton.vue';
+import FiatConvertedAmount from '../FiatConvertedAmount.vue';
+import RenameIcon from '../icons/AccountMenu/RenameIcon.vue';
+import BitcoinIcon from '../icons/BitcoinIcon.vue';
+import EventIcon from '../icons/EventIcon.vue';
+import HighFiveIcon from '../icons/HighFiveIcon.vue';
+import RefreshIcon from '../icons/RefreshIcon.vue';
+import MobileActionBar from '../MobileActionBar.vue';
+import SearchBar from '../SearchBar.vue';
+import TransactionList from '../TransactionList.vue';
 
 export default defineComponent({
     name: 'address-overview',

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -175,7 +175,13 @@
 // @ts-expect-error missing types for this package
 import { Portal } from '@linusborg/vue-simple-portal';
 import {
-    ArrowLeftIcon, ArrowRightSmallIcon, Copyable, CrossIcon, GearIcon, Identicon, MenuDotsIcon,
+    ArrowLeftIcon,
+    ArrowRightSmallIcon,
+    Copyable,
+    CrossIcon,
+    GearIcon,
+    Identicon,
+    MenuDotsIcon,
 } from '@nimiq/vue-components';
 import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 // @ts-expect-error missing types for this package

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -172,40 +172,42 @@
 </template>
 
 <script lang="ts">
+import { defineComponent, ref, watch, computed } from '@vue/composition-api';
+import {
+    Identicon,
+    GearIcon,
+    Copyable,
+    ArrowRightSmallIcon,
+    ArrowLeftIcon,
+    MenuDotsIcon,
+    CrossIcon,
+} from '@nimiq/vue-components';
 // @ts-expect-error missing types for this package
 import { Portal } from '@linusborg/vue-simple-portal';
-import {
-    ArrowLeftIcon,
-    ArrowRightSmallIcon,
-    Copyable,
-    CrossIcon,
-    GearIcon,
-    Identicon,
-    MenuDotsIcon,
-} from '@nimiq/vue-components';
-import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 // @ts-expect-error missing types for this package
 import { ResponsiveDirective } from 'vue-responsive-components';
-import { useWindowSize } from '../../composables/useWindowSize';
-import { checkHistory } from '../../electrum';
-import { onboard, rename } from '../../hub';
-import { BTC_ADDRESS_GAP, CryptoCurrency } from '../../lib/Constants';
+
+import BitcoinIcon from '../icons/BitcoinIcon.vue';
+import Amount from '../Amount.vue';
+import FiatConvertedAmount from '../FiatConvertedAmount.vue';
+import SearchBar from '../SearchBar.vue';
+import TransactionList from '../TransactionList.vue';
+import BtcTransactionList from '../BtcTransactionList.vue';
+import MobileActionBar from '../MobileActionBar.vue';
+import RenameIcon from '../icons/AccountMenu/RenameIcon.vue';
+import RefreshIcon from '../icons/RefreshIcon.vue';
+
 import { useAccountStore } from '../../stores/Account';
 import { useAddressStore } from '../../stores/Address';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
-import { useSwapsStore } from '../../stores/Swaps';
-import Amount from '../Amount.vue';
-import BtcTransactionList from '../BtcTransactionList.vue';
-import CrossCloseButton from '../CrossCloseButton.vue';
-import FiatConvertedAmount from '../FiatConvertedAmount.vue';
-import RenameIcon from '../icons/AccountMenu/RenameIcon.vue';
-import BitcoinIcon from '../icons/BitcoinIcon.vue';
-import EventIcon from '../icons/EventIcon.vue';
+import { onboard, rename } from '../../hub';
+import { useWindowSize } from '../../composables/useWindowSize';
+import { BTC_ADDRESS_GAP, CryptoCurrency } from '../../lib/Constants';
+import { checkHistory } from '../../electrum';
 import HighFiveIcon from '../icons/HighFiveIcon.vue';
-import RefreshIcon from '../icons/RefreshIcon.vue';
-import MobileActionBar from '../MobileActionBar.vue';
-import SearchBar from '../SearchBar.vue';
-import TransactionList from '../TransactionList.vue';
+import EventIcon from '../icons/EventIcon.vue';
+import { useSwapsStore } from '../../stores/Swaps';
+import CrossCloseButton from '../CrossCloseButton.vue';
 
 export default defineComponent({
     name: 'address-overview',

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -104,7 +104,7 @@
                 </button>
 
                 <button class="send nq-button-pill light-blue flex-row"
-                    @click="$router.push(activeCurrency === 'nim' ? '/send' : '/btc-send')" @mousedown.prevent
+                    @click="$router.push(`/send/${activeCurrency}`)" @mousedown.prevent
                     :disabled="(activeCurrency === 'nim' && (!activeAddressInfo || !activeAddressInfo.balance))
                         || (activeCurrency === 'btc' && !btcAccountBalance)"
                 >

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -1,22 +1,22 @@
 <template>
     <Modal>
-        <PageHeader class="header__address-list">
-            <span v-if="path === '/send'">
+        <PageHeader>
+            <template v-if="path === '/send'">
                 {{ $t("Choose a Sender")}}
-            </span>
-            <span v-else-if="path === '/receive'">
+            </template>
+            <template v-else-if="path === '/receive'">
                 {{ $t("Choose a Receiver")}}
-            </span>
-            <span v-else>
+            </template>
+            <template v-else>
                 {{ $t("Choose an Address")}}
-            </span>
+            </template>
         </PageHeader>
-        <PageBody class="page__address-list">
-        <AddressList
-            embedded
-            @address-selected="addressSelected"
-            :showBitcoin="true"
-        />
+        <PageBody>
+            <AddressList
+                embedded
+                showBitcoin
+                @address-selected="addressSelected"
+            />
         </PageBody>
     </Modal>
 </template>
@@ -56,24 +56,10 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .page-header {
-    padding-bottom: 2rem;
-
-    div {
-        font-size: var(--body-size);
-        line-height: 1.4;
-        font-weight: 600;
-        opacity: 0.6;
-        margin-top: 1rem;
-    }
-}
-// Not sure if this goes here
-.header__address-list {
-  padding-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
 }
 
-// Not sure if this goes here
-.page__address-list {
-  --padding-sides: 2rem;
-  padding: 0.375rem var(--padding-sides) 1.5rem;
+.page-body {
+    padding: 0.375rem 2rem 1.5rem;
 }
 </style>

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -1,10 +1,10 @@
 <template>
     <Modal>
         <PageHeader>
-            <template v-if="path === '/send'">
+            <template v-if="name === 'send'">
                 {{ $t("Choose a Sender")}}
             </template>
-            <template v-else-if="path === '/receive'">
+            <template v-else-if="name === 'receive'">
                 {{ $t("Choose a Recipient")}}
             </template>
             <template v-else>
@@ -32,13 +32,13 @@ export default defineComponent({
     setup(props, context) {
         const { activeCurrency } = useAccountStore();
 
-        const { path } = context.root.$router.currentRoute;
+        const { name } = context.root.$router.currentRoute;
 
         function addressSelected() {
             disableNextModalTransition();
 
             context.root.$router.push({
-                name: `receive-${activeCurrency.value}`,
+                name: `${name}-${activeCurrency.value}`,
                 params: {
                     canUserGoBack: 'true',
                 },
@@ -51,7 +51,7 @@ export default defineComponent({
             && activeAccountInfo.value.btcAddresses.external.length));
 
         return {
-            path,
+            name,
             addressSelected,
             showBitcoin,
         };

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -22,11 +22,11 @@
 </template>
 
 <script lang="ts">
-import { useAccountStore } from '@/stores/Account';
 import { PageBody, PageHeader } from '@nimiq/vue-components';
 import { defineComponent } from '@vue/composition-api';
-import AddressList from '../AddressList.vue';
 import Modal, { disableNextModalTransition } from './Modal.vue';
+import AddressList from '../AddressList.vue';
+import { useAccountStore } from '../../stores/Account';
 
 export default defineComponent({
     setup(props, context) {

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -5,7 +5,7 @@
                 {{ $t("Choose a Sender")}}
             </template>
             <template v-else-if="path === '/receive'">
-                {{ $t("Choose a Receiver")}}
+                {{ $t("Choose a Recipient")}}
             </template>
             <template v-else>
                 {{ $t("Choose an Address")}}
@@ -14,7 +14,7 @@
         <PageBody>
             <AddressList
                 embedded
-                showBitcoin
+                :showBitcoin="showBitcoin"
                 @address-selected="addressSelected"
             />
         </PageBody>
@@ -23,7 +23,7 @@
 
 <script lang="ts">
 import { PageBody, PageHeader } from '@nimiq/vue-components';
-import { defineComponent } from '@vue/composition-api';
+import { computed, defineComponent } from '@vue/composition-api';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import AddressList from '../AddressList.vue';
 import { useAccountStore } from '../../stores/Account';
@@ -37,12 +37,23 @@ export default defineComponent({
         function addressSelected() {
             disableNextModalTransition();
 
-            context.root.$router.push(`${path}/${activeCurrency.value}`);
+            context.root.$router.push({
+                name: `receive-${activeCurrency.value}`,
+                params: {
+                    canUserGoBack: 'true',
+                },
+            });
         }
+
+        const { activeAccountInfo } = useAccountStore();
+        const showBitcoin = computed(() => Boolean(activeAccountInfo.value
+            && activeAccountInfo.value.btcAddresses
+            && activeAccountInfo.value.btcAddresses.external.length));
 
         return {
             path,
             addressSelected,
+            showBitcoin,
         };
     },
     components: {

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -40,6 +40,9 @@ export default defineComponent({
             context.root.$router.push({
                 name: `${name}-${activeCurrency.value}`,
                 params: {
+                    // It has to be a string since it is a value encapsulated in Location.params
+                    // which is Dictionary<string>. Using a 'false' value will lead to the same
+                    // behaviour
                     canUserGoBack: 'true',
                 },
             });

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -1,0 +1,79 @@
+<template>
+    <Modal>
+        <PageHeader class="header__address-list">
+            <span v-if="path === '/send'">
+                {{ $t("Choose a Sender")}}
+            </span>
+            <span v-else-if="path === '/receive'">
+                {{ $t("Choose a Receiver")}}
+            </span>
+            <span v-else>
+                {{ $t("Choose an Address")}}
+            </span>
+        </PageHeader>
+        <PageBody class="page__address-list">
+        <AddressList
+            embedded
+            @address-selected="addressSelected"
+            :showBitcoin="true"
+        />
+        </PageBody>
+    </Modal>
+</template>
+
+<script lang="ts">
+import { useAccountStore } from '@/stores/Account';
+import { PageBody, PageHeader } from '@nimiq/vue-components';
+import { defineComponent } from '@vue/composition-api';
+import AddressList from '../AddressList.vue';
+import Modal, { disableNextModalTransition } from './Modal.vue';
+
+export default defineComponent({
+    setup(props, context) {
+        const { activeCurrency } = useAccountStore();
+
+        const { path } = context.root.$router.currentRoute;
+
+        function addressSelected() {
+            disableNextModalTransition();
+
+            context.root.$router.push(`${path}/${activeCurrency.value}`);
+        }
+
+        return {
+            path,
+            addressSelected,
+        };
+    },
+    components: {
+        Modal,
+        PageHeader,
+        PageBody,
+        AddressList,
+    },
+});
+</script>
+
+<style lang="scss" scoped>
+.page-header {
+    padding-bottom: 2rem;
+
+    div {
+        font-size: var(--body-size);
+        line-height: 1.4;
+        font-weight: 600;
+        opacity: 0.6;
+        margin-top: 1rem;
+    }
+}
+// Not sure if this goes here
+.header__address-list {
+  padding-bottom: 1.5rem;
+}
+
+// Not sure if this goes here
+.page__address-list {
+  --padding-sides: 2rem;
+  padding: 0.375rem var(--padding-sides) 1.5rem;
+}
+</style>

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -130,11 +130,11 @@ import {
     QrCodeIcon,
     QrCode,
 } from '@nimiq/vue-components';
-import { useWindowSize } from '@/composables/useWindowSize';
-import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
+import { useWindowSize } from '../../composables/useWindowSize';
+import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
 import RefreshIcon from '../icons/RefreshIcon.vue';
 import BracketsIcon from '../icons/BracketsIcon.vue';
 import AmountInput from '../AmountInput.vue';

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -4,33 +4,29 @@
         @close-overlay="closeOverlay"
     >
         <PageHeader :backArrow="canUserGoBack" @back="back">
-            <InfoCircleSmallIcon slot="trigger"/>
-
             {{ $t('Receive BTC') }}
-            <div slot="more" class="receive-btc__description">
-                <p>
-                    {{ $t('Share a single-use address with the sender.') }}
-                    <Tooltip class="info-tooltip" preferredPosition="bottom left">
-                        <InfoCircleSmallIcon slot="trigger"/>
+            <div slot="more" class="subheader">
+                {{ $t('Share a single-use address with the sender.') }}
+                <Tooltip class="info-tooltip" preferredPosition="bottom left">
+                    <InfoCircleSmallIcon slot="trigger"/>
+                    <div class="flex-column">
+                        <p>{{ $t('With Bitcoin, a new address is used for every transaction to improve privacy.'
+                            + ' Reuse of addresses does not result in a loss of funds.') }}</p>
                         <div class="flex-column">
-                            <p>{{ $t('With Bitcoin, a new address is used for every transaction to improve privacy.'
-                                + ' Reuse of addresses does not result in a loss of funds.') }}</p>
-                            <div class="flex-column">
-                                <div class="flex-row">
-                                    <RefreshIcon />
-                                    <p>{{ $t('Don’t reuse addresses and create a new one for every transaction.') }}</p>
-                                </div>
-                                <div class="flex-row">
-                                    <BracketsIcon />
-                                    <p>
-                                        {{ $t('Use labels instead of contacts to easily '
-                                        + 'identify transactions in your history.') }}
-                                    </p>
-                                </div>
+                            <div class="flex-row">
+                                <RefreshIcon />
+                                <p>{{ $t('Don’t reuse addresses and create a new one for every transaction.') }}</p>
+                            </div>
+                            <div class="flex-row">
+                                <BracketsIcon />
+                                <p>
+                                    {{ $t('Use labels instead of contacts to easily '
+                                    + 'identify transactions in your history.') }}
+                                </p>
                             </div>
                         </div>
-                    </Tooltip>
-                </p>
+                    </div>
+                </Tooltip>
             </div>
         </PageHeader>
         <PageBody class="flex-column">
@@ -383,39 +379,41 @@ export default defineComponent({
 .page-header {
     padding-bottom: 0;
 
-    .receive-btc__description > p {
+    .subheader {
+        display: flex;
+        margin-top: 1.5rem;
+        justify-content: center;
+        align-items: center;
         font-size: var(--body-size);
         line-height: 1.4;
         font-weight: 600;
+        text-align: initial;
         color: var(--text-60);
-        margin-top: 2rem;
 
         > .info-tooltip {
-            position: absolute;
-            margin-top: 0.4rem;
-            margin-left: 0.75rem;
+            margin-left: 1rem;
             z-index: 4;
 
             ::v-deep .trigger svg {
                 height: 2rem;
                 color: var(--text-60);
-                transition: opacity var(--short-transition-duration) var(--nimiq-ease);
+                transition: color var(--short-transition-duration) var(--nimiq-ease);
             }
 
             & ::v-deep .trigger:hover svg,
             & ::v-deep .trigger:focus svg,
             &.shown ::v-deep .trigger svg {
-                color: var(--text-90);
+                color: var(--text-80);
             }
 
             ::v-deep .tooltip-box {
                 width: 26.25rem;
                 font-size: var(--small-size);
                 font-weight: 600;
-                transform: translate(-2rem, 2rem);
+                transform: translate(1rem, 2rem);
 
                 @media (max-width: 700px) { // Full mobile breakpoint
-                    transform: translate(0.5rem, 2rem);
+                    transform: translate(0, 2rem);
                 }
 
                 p {
@@ -438,18 +436,13 @@ export default defineComponent({
                     svg {
                         opacity: 0.6;
                     }
-                }
 
-                .flex-row:first-child {
-                    svg {
+                    &:first-child svg {
                         width: 2.75rem;
                         height: 2.75rem;
                         margin-top: 0.25rem;
                     }
-                }
-
-                .flex-row:last-child {
-                    svg {
+                    &:last-child svg {
                         width: 2.25rem;
                         height: 2.25rem;
                         margin: 0.25rem 0.25rem 0;
@@ -460,82 +453,7 @@ export default defineComponent({
     }
 }
 
-.recently-copied-addresses {
-    flex-grow: 1;
-    align-self: stretch;
-    position: relative;
-    min-height: 24rem; /* Fits two copied addresses without scrolling */
-}
-
-.no-recently-copied-address {
-    color: var(--text-40);
-    font-size: var(--body-size);
-    font-weight: 600;
-    padding: 0 4.75rem;
-    text-align: center;
-    margin: auto 0;
-}
-
-.address-list {
-    flex-grow: 1;
-    align-items: center;
-    min-height: 0;
-
-    &.fade-enter-active,
-    &.fade-leave-active {
-        position: absolute;
-        width: 100%;
-    }
-
-    .nq-label {
-        text-align: center;
-        margin: 4rem 0 0;
-    }
-
-    .list {
-        @extend %custom-scrollbar;
-        $paddingTop: 2.5rem;
-
-        flex: 1 1 0;
-        width: calc(100% + 8rem);
-        padding: $paddingTop 4rem 0;
-        margin-top: 0.5rem;
-
-        &.scroll {
-            overflow-y: auto;
-        }
-
-        .scroll-mask.top {
-            transform: translateY(-#{$paddingTop});
-        }
-    }
-}
-
-footer {
-    width: 100%;
-    justify-content: center;
-    margin-top: 2rem;
-
-    .qr-button {
-        position: absolute;
-        right: 3rem;
-        bottom: 3rem;
-        opacity: .4;
-        transition: opacity 250ms var(--nimiq-ease);
-
-        svg {
-            width: 4rem;
-            height: auto;
-        }
-
-        &:hover,
-        &:focus {
-            opacity: 0.8;
-        }
-    }
-}
-
- .page-body {
+.page-body {
     --short-transition-duration: 300ms;
     --long-transition-duration: 600ms;
 
@@ -678,6 +596,81 @@ footer {
 
         .header {
             font-size: var(--small-size);
+        }
+    }
+}
+
+.recently-copied-addresses {
+    flex-grow: 1;
+    align-self: stretch;
+    position: relative;
+    min-height: 24rem; /* Fits two copied addresses without scrolling */
+}
+
+.no-recently-copied-address {
+    color: var(--text-40);
+    font-size: var(--body-size);
+    font-weight: 600;
+    padding: 0 4.75rem;
+    text-align: center;
+    margin: auto 0;
+}
+
+.address-list {
+    flex-grow: 1;
+    align-items: center;
+    min-height: 0;
+
+    &.fade-enter-active,
+    &.fade-leave-active {
+        position: absolute;
+        width: 100%;
+    }
+
+    .nq-label {
+        text-align: center;
+        margin: 4rem 0 0;
+    }
+
+    .list {
+        @extend %custom-scrollbar;
+        $paddingTop: 2.5rem;
+
+        flex: 1 1 0;
+        width: calc(100% + 8rem);
+        padding: $paddingTop 4rem 0;
+        margin-top: 0.5rem;
+
+        &.scroll {
+            overflow-y: auto;
+        }
+
+        .scroll-mask.top {
+            transform: translateY(-#{$paddingTop});
+        }
+    }
+}
+
+footer {
+    width: 100%;
+    justify-content: center;
+    margin-top: 2rem;
+
+    .qr-button {
+        position: absolute;
+        right: 3rem;
+        bottom: 3rem;
+        opacity: .4;
+        transition: opacity 250ms var(--nimiq-ease);
+
+        svg {
+            width: 4rem;
+            height: auto;
+        }
+
+        &:hover,
+        &:focus {
+            opacity: 0.8;
         }
     }
 }

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -142,13 +142,6 @@ import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
 import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
-    props: {
-        canUserGoBack: {
-            // It has to be a string since it is a value encapsulated in Location.params which is Dictionary<string>.
-            type: String,
-            default: '',
-        },
-    },
     setup(props, context) {
         const {
             availableExternalAddresses,

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -3,7 +3,7 @@
         :showOverlay="addressQrCodeOverlayOpened || receiveLinkOverlayOpened"
         @close-overlay="closeOverlay"
     >
-        <PageHeader :backArrow="canUserGoBack" @back="back">
+        <PageHeader :backArrow="!!$route.params.canUserGoBack" @back="back">
             {{ $t('Receive BTC') }}
             <div slot="more" class="subheader">
                 {{ $t('Share a single-use address with the sender.') }}
@@ -133,8 +133,6 @@ import {
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
-import { useWindowSize } from '../../composables/useWindowSize';
-import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
 import RefreshIcon from '../icons/RefreshIcon.vue';
 import BracketsIcon from '../icons/BracketsIcon.vue';
 import AmountInput from '../AmountInput.vue';
@@ -144,6 +142,13 @@ import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
 import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
+    props: {
+        canUserGoBack: {
+            // It has to be a string since it is a value encapsulated in Location.params which is Dictionary<string>.
+            type: String,
+            default: '',
+        },
+    },
     setup(props, context) {
         const {
             availableExternalAddresses,
@@ -155,9 +160,6 @@ export default defineComponent({
             senderLabels,
             setSenderLabel,
         } = useBtcLabelsStore();
-
-        const { width } = useWindowSize();
-        const { activeMobileColumn } = useActiveMobileColumn();
 
         const second = 1000;
         const minute = 60 * second;
@@ -324,9 +326,6 @@ export default defineComponent({
             window.removeEventListener('resize', updateAddressFontSizeScaleFactor);
         });
 
-        // User only can go back to the address selection if is mobile and the column shown is the account
-        const canUserGoBack = ref(width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS);
-
         function back() {
             disableNextModalTransition();
             context.root.$router.back();
@@ -347,7 +346,6 @@ export default defineComponent({
             $addressWidthFinder,
             addressFontSizeScaleFactor,
             BTC_MAX_COPYABLE_ADDRESSES,
-            canUserGoBack,
             back,
         };
     },

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -1,8 +1,6 @@
 <template>
     <Modal class="receive-modal"
         :showOverlay="addressQrCodeOverlayOpened || receiveLinkOverlayOpened"
-        emit-close
-        @close="close"
         @close-overlay="closeOverlay"
     >
         <PageHeader :backArrow="canUserGoBack" @back="back">
@@ -275,14 +273,6 @@ export default defineComponent({
             receiveLinkOverlayOpened.value = false;
         }
 
-        async function close() {
-            while (context.root.$router.currentRoute.path.startsWith('/receive')) {
-                context.root.$router.back();
-                // eslint-disable-next-line no-await-in-loop
-                await new Promise((resolve) => window.addEventListener('popstate', resolve, { once: true }));
-            }
-        }
-
         // Watching for sub-modals openings to set the actively shown address as copied
         watch([addressQrCodeOverlayOpened, receiveLinkOverlayOpened],
             (booleans, prevBooleans) => {
@@ -350,7 +340,6 @@ export default defineComponent({
             addressQrCodeOverlayOpened,
             receiveLinkOverlayOpened,
             closeOverlay,
-            close,
             copyActiveAddressCallback,
             $copiedAddresses,
             addressCopied,

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -286,11 +286,11 @@ export default defineComponent({
         fetchFeeEstimates();
 
         const feeEstimatesInterval = setInterval(fetchFeeEstimates, 60 * 1000); // Update every 60 seconds
-        let sucessCloseTimeout = 0;
+        let successCloseTimeout = 0;
 
         onBeforeUnmount(() => {
             clearInterval(feeEstimatesInterval);
-            window.clearTimeout(sucessCloseTimeout);
+            window.clearTimeout(successCloseTimeout);
         });
 
         const activeCurrency = ref<CryptoCurrency | FiatCurrency>(CryptoCurrency.BTC);
@@ -498,7 +498,7 @@ export default defineComponent({
                     }) as string;
 
                 // Close modal
-                sucessCloseTimeout = window.setTimeout(() => $modal.value!.forceClose(), SUCCESS_REDIRECT_DELAY);
+                successCloseTimeout = window.setTimeout(() => $modal.value!.forceClose(), SUCCESS_REDIRECT_DELAY);
             } catch (error) {
                 // console.debug(error);
 
@@ -521,7 +521,7 @@ export default defineComponent({
 
         const { activeMobileColumn } = useActiveMobileColumn();
 
-        // User only can go back to the address selection if is mobile and the column shown is the account
+        // User can only go back to the address selection if is mobile and the column shown is the account
         const canUserGoBack = ref(
             width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS && !props.requestUri);
 

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -132,38 +132,38 @@
 </template>
 
 <script lang="ts">
-import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
-import { /* parseRequestLink, */ CurrencyInfo } from '@nimiq/utils';
+import { defineComponent, ref, watch, computed, Ref, onMounted, onBeforeUnmount } from '@vue/composition-api';
 import {
-    AlertTriangleIcon,
-    InfoCircleSmallIcon,
-    LabelInput,
-    PageBody,
     PageHeader,
+    PageBody,
+    AlertTriangleIcon,
     ScanQrCodeIcon,
+    LabelInput,
     Tooltip,
+    InfoCircleSmallIcon,
 } from '@nimiq/vue-components';
-import { computed, defineComponent, onBeforeUnmount, onMounted, ref, Ref, watch } from '@vue/composition-api';
-import { useWindowSize } from '../../composables/useWindowSize';
-import { getElectrumClient } from '../../electrum';
-import { sendBtcTransaction } from '../../hub';
-import { estimateFees, parseBitcoinUrl, selectOutputs } from '../../lib/BitcoinTransactionUtils';
-import { CryptoCurrency, FiatCurrency, FIAT_CURRENCY_DENYLIST } from '../../lib/Constants';
+import { /* parseRequestLink, */ CurrencyInfo } from '@nimiq/utils';
+import Modal, { disableNextModalTransition } from './Modal.vue';
+import BtcAddressInput from '../BtcAddressInput.vue';
+import BtcLabelInput from '../BtcLabelInput.vue';
+import AmountInput from '../AmountInput.vue';
+import AmountMenu from '../AmountMenu.vue';
+import FeeSelector from '../FeeSelector.vue';
+import FiatConvertedAmount from '../FiatConvertedAmount.vue';
+import StatusScreen, { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
 import { useAccountStore } from '../../stores/Account';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
 import { useBtcNetworkStore } from '../../stores/BtcNetwork';
 import { useFiatStore } from '../../stores/Fiat';
 import { useSettingsStore } from '../../stores/Settings';
-import AmountInput from '../AmountInput.vue';
-import AmountMenu from '../AmountMenu.vue';
-import BtcAddressInput from '../BtcAddressInput.vue';
-import BtcLabelInput from '../BtcLabelInput.vue';
+import { CryptoCurrency, FiatCurrency, FIAT_CURRENCY_DENYLIST } from '../../lib/Constants';
+import { sendBtcTransaction } from '../../hub';
+import { useWindowSize } from '../../composables/useWindowSize';
+import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
+import { selectOutputs, estimateFees, parseBitcoinUrl } from '../../lib/BitcoinTransactionUtils';
+import { getElectrumClient } from '../../electrum';
 import DoubleInput from '../DoubleInput.vue';
-import FeeSelector from '../FeeSelector.vue';
-import FiatConvertedAmount from '../FiatConvertedAmount.vue';
-import StatusScreen, { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
-import Modal, { disableNextModalTransition } from './Modal.vue';
 
 export enum RecipientType {
     NEW_CONTACT,

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -21,7 +21,7 @@
                             @input="resetAddress"
                             @address="onAddressEntered"
                             @domain-address="onDomainEntered"
-                            @scan="goToScanner"/>
+                            @scan="$router.push('/scan')"/>
                     </template>
                 </DoubleInput>
 
@@ -135,7 +135,13 @@
 import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
 import { /* parseRequestLink, */ CurrencyInfo } from '@nimiq/utils';
 import {
-    AlertTriangleIcon, InfoCircleSmallIcon, LabelInput, PageBody, PageHeader, ScanQrCodeIcon, Tooltip,
+    AlertTriangleIcon,
+    InfoCircleSmallIcon,
+    LabelInput,
+    PageBody,
+    PageHeader,
+    ScanQrCodeIcon,
+    Tooltip,
 } from '@nimiq/vue-components';
 import { computed, defineComponent, onBeforeUnmount, onMounted, ref, Ref, watch } from '@vue/composition-api';
 import { useWindowSize } from '../../composables/useWindowSize';
@@ -492,9 +498,7 @@ export default defineComponent({
                     }) as string;
 
                 // Close modal
-                sucessCloseTimeout = window.setTimeout(async () => {
-                    $modal.value!.forceClose();
-                }, SUCCESS_REDIRECT_DELAY);
+                sucessCloseTimeout = window.setTimeout(() => $modal.value!.forceClose(), SUCCESS_REDIRECT_DELAY);
             } catch (error) {
                 // console.debug(error);
 
@@ -514,10 +518,6 @@ export default defineComponent({
         }
 
         const { btcUnit } = useSettingsStore();
-
-        function goToScanner() {
-            context.root.$router.push('/scan');
-        }
 
         const { activeMobileColumn } = useActiveMobileColumn();
 
@@ -544,7 +544,6 @@ export default defineComponent({
             recipientWithLabel,
             onPaste,
             parseRequestUri,
-            goToScanner,
 
             // Amount Input
             amount,

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -522,7 +522,8 @@ export default defineComponent({
         const { activeMobileColumn } = useActiveMobileColumn();
 
         // User only can go back to the address selection if is mobile and the column shown is the account
-        const canUserGoBack = ref(width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS);
+        const canUserGoBack = ref(
+            width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS && !props.requestUri);
 
         function back() {
             disableNextModalTransition();

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -1,7 +1,7 @@
 <template>
     <Modal :showOverlay="statusScreenOpened" ref="$modal">
         <div class="page flex-column" @click="amountMenuOpened = false">
-            <PageHeader :backArrow="canUserGoBack" @back="back">
+            <PageHeader :backArrow="!!$route.params.canUserGoBack" @back="back">
                 {{ $t('Send Transaction') }}
             </PageHeader>
             <PageBody class="flex-column">
@@ -160,7 +160,6 @@ import { useSettingsStore } from '../../stores/Settings';
 import { CryptoCurrency, FiatCurrency, FIAT_CURRENCY_DENYLIST } from '../../lib/Constants';
 import { sendBtcTransaction } from '../../hub';
 import { useWindowSize } from '../../composables/useWindowSize';
-import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
 import { selectOutputs, estimateFees, parseBitcoinUrl } from '../../lib/BitcoinTransactionUtils';
 import { getElectrumClient } from '../../electrum';
 import DoubleInput from '../DoubleInput.vue';
@@ -519,12 +518,6 @@ export default defineComponent({
 
         const { btcUnit } = useSettingsStore();
 
-        const { activeMobileColumn } = useActiveMobileColumn();
-
-        // User can only go back to the address selection if is mobile and the column shown is the account
-        const canUserGoBack = ref(
-            width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS && !props.requestUri);
-
         function back() {
             disableNextModalTransition();
             context.root.$router.back();
@@ -580,8 +573,6 @@ export default defineComponent({
             onStatusMainAction,
             onStatusAlternativeAction,
 
-            // User can choose address in mobile
-            canUserGoBack,
             back,
         };
     },

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -26,12 +26,12 @@
 </template>
 
 <script lang="ts">
-import { CloseButton, SmallPage } from '@nimiq/vue-components';
 import { computed, defineComponent, onMounted, onUnmounted, Ref, ref, watch } from '@vue/composition-api';
-import { useSwipes } from '../../composables/useSwipes';
+import { SmallPage, CloseButton } from '@nimiq/vue-components';
 import { useWindowSize } from '../../composables/useWindowSize';
-import { pointerdown } from '../../directives/PointerEvents';
+import { useSwipes } from '../../composables/useSwipes';
 import { useSettingsStore } from '../../stores/Settings';
+import { pointerdown } from '../../directives/PointerEvents';
 
 export function enableModalTransition() {
     document.body.classList.remove('modal-transition-disabled');

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-    class="modal backdrop flex-column"
-    v-pointerdown="checkTouchStart"
-    @click.self="onBackdropClick">
+    <div class="modal backdrop flex-column" v-pointerdown="checkTouchStart" @click.self="onBackdropClick">
         <div class="wrapper flex-column" @click.self="onBackdropClick" ref="$main">
             <SmallPage
                 class="main"
@@ -83,11 +80,15 @@ export default defineComponent({
         }
 
         async function forceClose() {
-            // ensures that we close all the modals, so flows that opens multiple modals in different steps
-            // are closed one after the other
-            // For example: choose a sender -> choose a recipient -> set amount
+            // Ensures that we close all the modals that we navigated through, so flows that opens multiple modals in
+            // different steps are closed one after the other.
+            // For example: choose a sender via AddressSelectorModal -> open qr scanner from SendModal -> after scan in
+            // ScanQrModal return to SendModal -> abort the action in SendModal
 
-            while (context.root.$route.matched.find((routeRecord) => 'modal' in routeRecord.components)) {
+            while (context.root.$route.matched.find((routeRecord) => 'modal' in routeRecord.components
+                || 'persistent-modal' in routeRecord.components
+                || Object.values(routeRecord.components).some((component) => /modal/i.test(component.name || '')))
+            ) {
                 context.root.$router.back();
 
                 // eslint-disable-next-line no-await-in-loop

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -78,7 +78,20 @@ export default defineComponent({
             if (props.emitClose) {
                 context.emit('close');
             } else {
+                forceClose();
+            }
+        }
+
+        async function forceClose() {
+            // ensures that we close all the modals, so flows that opens multiple modals in different steps
+            // are closed one after the other
+            // For example: choose a sender -> choose a recipient -> set amount
+
+            while (context.root.$route.matched.find((routeRecord) => 'modal' in routeRecord.components)) {
                 context.root.$router.back();
+
+                // eslint-disable-next-line no-await-in-loop
+                await new Promise((resolve) => window.addEventListener('popstate', resolve, { once: true }));
             }
         }
 
@@ -170,6 +183,7 @@ export default defineComponent({
 
         return {
             close,
+            forceClose, // used by other components
             $main,
             $handle,
             showSwipeHandle,

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="modal backdrop flex-column" v-pointerdown="checkTouchStart" @click.self="onBackdropClick">
+    <div
+    class="modal backdrop flex-column"
+    v-pointerdown="checkTouchStart"
+    @click.self="onBackdropClick">
         <div class="wrapper flex-column" @click.self="onBackdropClick" ref="$main">
             <SmallPage
                 class="main"
@@ -26,12 +29,21 @@
 </template>
 
 <script lang="ts">
+import { CloseButton, SmallPage } from '@nimiq/vue-components';
 import { computed, defineComponent, onMounted, onUnmounted, Ref, ref, watch } from '@vue/composition-api';
-import { SmallPage, CloseButton } from '@nimiq/vue-components';
-import { useWindowSize } from '../../composables/useWindowSize';
 import { useSwipes } from '../../composables/useSwipes';
-import { useSettingsStore } from '../../stores/Settings';
+import { useWindowSize } from '../../composables/useWindowSize';
 import { pointerdown } from '../../directives/PointerEvents';
+import { useSettingsStore } from '../../stores/Settings';
+
+export function enableModalTransition() {
+    document.body.classList.remove('modal-transition-disabled');
+}
+
+export function disableNextModalTransition() {
+    document.body.classList.add('modal-transition-disabled');
+    // the modal transitions are enabled again in onMounted in the next modal component instance
+}
 
 export default defineComponent({
     props: {
@@ -149,6 +161,12 @@ export default defineComponent({
             if (!touchStartedOnBackdrop) return;
             close();
         }
+
+        onMounted(() => {
+            setTimeout(() => {
+                enableModalTransition();
+            }, 100);
+        });
 
         return {
             close,
@@ -293,6 +311,10 @@ export default defineComponent({
 :root {
     --modal-transition-time: 0.45s;
     --overlay-transition-time: 0.65s;
+}
+
+.modal-transition-disabled {
+    --modal-transition-time: 0;
 }
 
 .wrapper {

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -43,7 +43,13 @@
 import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
 import { useWindowSize } from '@/composables/useWindowSize';
 import {
-    AddressDisplay, Copyable, Identicon, PageBody, PageHeader, QrCode, QrCodeIcon,
+    AddressDisplay,
+    Copyable,
+    Identicon,
+    PageBody,
+    PageHeader,
+    QrCode,
+    QrCodeIcon,
 } from '@nimiq/vue-components';
 import { defineComponent, ref } from '@vue/composition-api';
 import { AddressType, useAddressStore } from '../../stores/Address';

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -40,20 +40,20 @@
 </template>
 
 <script lang="ts">
-import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
-import { useWindowSize } from '@/composables/useWindowSize';
-import {
-    AddressDisplay,
-    Copyable,
-    Identicon,
-    PageBody,
-    PageHeader,
-    QrCode,
-    QrCodeIcon,
-} from '@nimiq/vue-components';
 import { defineComponent, ref } from '@vue/composition-api';
-import { AddressType, useAddressStore } from '../../stores/Address';
+import {
+    PageHeader,
+    PageBody,
+    Identicon,
+    AddressDisplay,
+    QrCodeIcon,
+    QrCode,
+    Copyable,
+} from '@nimiq/vue-components';
 import Modal, { disableNextModalTransition } from './Modal.vue';
+import { useAddressStore, AddressType } from '../../stores/Address';
+import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
+import { useWindowSize } from '../../composables/useWindowSize';
 import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
 import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -1,9 +1,7 @@
 <template>
     <Modal class="receive-modal"
         :showOverlay="addressQrCodeOverlayOpened || receiveLinkOverlayOpened"
-        emit-close
         @close-overlay="closeOverlays"
-        @close="close"
     >
         <PageHeader :backArrow="canUserGoBack" @back="back">
             {{ $t('Receive NIM') }}
@@ -63,15 +61,6 @@ export default defineComponent({
         const { activeMobileColumn } = useActiveMobileColumn();
         const { activeAddressInfo } = useAddressStore();
 
-        async function close() {
-            while (context.root.$router.currentRoute.path.startsWith('/receive')) {
-                context.root.$router.back();
-
-                // eslint-disable-next-line no-await-in-loop
-                await new Promise((resolve) => window.addEventListener('popstate', resolve, { once: true }));
-            }
-        }
-
         function closeOverlays() {
             addressQrCodeOverlayOpened.value = false;
             receiveLinkOverlayOpened.value = false;
@@ -91,7 +80,6 @@ export default defineComponent({
             receiveLinkOverlayOpened,
             AddressType,
             closeOverlays,
-            close,
             canUserGoBack,
             back,
         };

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -3,7 +3,7 @@
         :showOverlay="addressQrCodeOverlayOpened || receiveLinkOverlayOpened"
         @close-overlay="closeOverlays"
     >
-        <PageHeader :backArrow="canUserGoBack" @back="back">
+        <PageHeader :backArrow="!!$route.params.canUserGoBack" @back="back">
             {{ $t('Receive NIM') }}
             <div slot="more">{{ $t('Share your address with the sender.') }}</div>
         </PageHeader>
@@ -52,28 +52,28 @@ import {
 } from '@nimiq/vue-components';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useAddressStore, AddressType } from '../../stores/Address';
-import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
-import { useWindowSize } from '../../composables/useWindowSize';
 import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
 import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
     name: 'receive-modal',
+    props: {
+        canUserGoBack: {
+            // It has to be a string since it is a value encapsulated in Location.params which is Dictionary<string>.
+            type: String,
+            default: '',
+        },
+    },
     setup(props, context) {
         const addressQrCodeOverlayOpened = ref(false);
         const receiveLinkOverlayOpened = ref(false);
 
-        const { width } = useWindowSize();
-        const { activeMobileColumn } = useActiveMobileColumn();
         const { activeAddressInfo } = useAddressStore();
 
         function closeOverlays() {
             addressQrCodeOverlayOpened.value = false;
             receiveLinkOverlayOpened.value = false;
         }
-
-        // User only can go back to the address selection if is mobile and the column shown is the account
-        const canUserGoBack = ref(width.value <= 700 && activeMobileColumn.value !== ColumnType.ADDRESS);
 
         function back() {
             disableNextModalTransition();
@@ -86,7 +86,6 @@ export default defineComponent({
             receiveLinkOverlayOpened,
             AddressType,
             closeOverlays,
-            canUserGoBack,
             back,
         };
     },

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -57,13 +57,6 @@ import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
     name: 'receive-modal',
-    props: {
-        canUserGoBack: {
-            // It has to be a string since it is a value encapsulated in Location.params which is Dictionary<string>.
-            type: String,
-            default: '',
-        },
-    },
     setup(props, context) {
         const addressQrCodeOverlayOpened = ref(false);
         const receiveLinkOverlayOpened = ref(false);

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -95,7 +95,7 @@
             :key="Pages.AMOUNT_INPUT" @click="amountMenuOpened = false"
         >
             <PageHeader
-                :backArrow="true"
+                :backArrow="!!requestUri"
                 @back="page = Pages.RECIPIENT_INPUT; resetRecipient();"
             >{{ $t('Set Amount') }}</PageHeader>
             <PageBody class="page__amount-input flex-column">
@@ -530,8 +530,11 @@ export default defineComponent({
             }
         }
 
-        if (props.requestUri) {
-            parseRequestUri(props.requestUri);
+        const { requestUri } = props;
+        const hasRequestUri = !!requestUri;
+
+        if (hasRequestUri) {
+            parseRequestUri(requestUri);
         }
 
         /**
@@ -695,6 +698,7 @@ export default defineComponent({
             recipientDetailsOpened,
             recipientWithLabel,
             closeRecipientDetails,
+            hasRequestUri,
             parseRequestUri,
             amountsHidden,
             goToScanner,

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -632,7 +632,7 @@ export default defineComponent({
                     });
 
                 // Close modal
-                sucessCloseTimeout = window.setTimeout(() => $modal.value!.forceClose(), SUCCESS_REDIRECT_DELAY);
+                successCloseTimeout = window.setTimeout(() => $modal.value!.forceClose(), SUCCESS_REDIRECT_DELAY);
             } catch (error: any) {
                 if (Config.reportToSentry) captureException(error);
                 else console.error(error); // eslint-disable-line no-console
@@ -660,14 +660,14 @@ export default defineComponent({
             addressListOpened.value = false;
             feeSelectionOpened.value = false;
 
-            // Do nothing when the success status overlay is shown, it will be closed by sucessCloseTimeout
+            // Do nothing when the success status overlay is shown, it will be closed by successCloseTimeout
         }
 
         const { amountsHidden } = useSettingsStore();
 
         const { activeMobileColumn } = useActiveMobileColumn();
 
-        // User only can go back to the address selection if is mobile and the column shown is the account
+        // User can only go back to the address selection if is mobile and the column shown is the account
         const canUserGoBackToAddressSelection = ref(width.value <= 700
             && activeMobileColumn.value !== ColumnType.ADDRESS);
 
@@ -676,10 +676,10 @@ export default defineComponent({
             context.root.$router.back();
         }
 
-        let sucessCloseTimeout = 0;
+        let successCloseTimeout = 0;
 
         onBeforeUnmount(() => {
-            window.clearTimeout(sucessCloseTimeout);
+            window.clearTimeout(successCloseTimeout);
         });
 
         return {

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -228,45 +228,45 @@
 </template>
 
 <script lang="ts">
-import { ColumnType, useActiveMobileColumn } from '@/composables/useActiveMobileColumn';
-import { AddressBook, CurrencyInfo, parseRequestLink, Utf8Tools, ValidationUtils } from '@nimiq/utils';
+import { defineComponent, ref, watch, computed, Ref, onBeforeUnmount } from '@vue/composition-api';
 import {
-    AddressDisplay,
+    PageHeader,
+    PageBody,
     AddressInput,
-    Amount,
-    Copyable,
+    ScanQrCodeIcon,
     Identicon,
     LabelInput,
-    PageBody,
-    PageHeader,
-    ScanQrCodeIcon,
+    Copyable,
+    AddressDisplay,
     SelectBar,
+    Amount,
 } from '@nimiq/vue-components';
+import { parseRequestLink, AddressBook, Utf8Tools, CurrencyInfo, ValidationUtils } from '@nimiq/utils';
 import { captureException } from '@sentry/vue';
-import { computed, defineComponent, onBeforeUnmount, ref, Ref, watch } from '@vue/composition-api';
 import Config from 'config';
-import { useWindowSize } from '../../composables/useWindowSize';
-import { createCashlink, sendTransaction } from '../../hub';
-import { i18n } from '../../i18n/i18n-setup';
+import Modal, { disableNextModalTransition } from './Modal.vue';
+import ContactShortcuts from '../ContactShortcuts.vue';
+import ContactBook from '../ContactBook.vue';
+import IdenticonButton from '../IdenticonButton.vue';
+import AddressList from '../AddressList.vue';
+import AmountInput from '../AmountInput.vue';
+import AmountMenu from '../AmountMenu.vue';
+import FiatConvertedAmount from '../FiatConvertedAmount.vue';
+import StatusScreen, { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
+import { useContactsStore } from '../../stores/Contacts';
+import { useAddressStore } from '../../stores/Address';
+import { useNetworkStore } from '../../stores/Network';
+import { useFiatStore } from '../../stores/Fiat';
+import { useSettingsStore } from '../../stores/Settings';
 import { FiatCurrency, FIAT_CURRENCY_DENYLIST } from '../../lib/Constants';
+import { createCashlink, sendTransaction } from '../../hub';
+import { useWindowSize } from '../../composables/useWindowSize';
+import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
+import { i18n } from '../../i18n/i18n-setup';
 import {
     isValidDomain as isValidUnstoppableDomain,
     resolve as resolveUnstoppableDomain,
 } from '../../lib/UnstoppableDomains';
-import { useAddressStore } from '../../stores/Address';
-import { useContactsStore } from '../../stores/Contacts';
-import { useFiatStore } from '../../stores/Fiat';
-import { useNetworkStore } from '../../stores/Network';
-import { useSettingsStore } from '../../stores/Settings';
-import AddressList from '../AddressList.vue';
-import AmountInput from '../AmountInput.vue';
-import AmountMenu from '../AmountMenu.vue';
-import ContactBook from '../ContactBook.vue';
-import ContactShortcuts from '../ContactShortcuts.vue';
-import FiatConvertedAmount from '../FiatConvertedAmount.vue';
-import IdenticonButton from '../IdenticonButton.vue';
-import StatusScreen, { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
-import Modal, { disableNextModalTransition } from './Modal.vue';
 
 export enum RecipientType {
     CONTACT,

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -9,7 +9,7 @@
         ref="$modal"
     >
         <div v-if="page === Pages.RECIPIENT_INPUT" class="page flex-column" :key="Pages.RECIPIENT_INPUT">
-            <PageHeader :backArrow="canUserGoBackToAddressSelection" @back="back">
+            <PageHeader :backArrow="!!$route.params.canUserGoBack" @back="back">
                 {{ $t('Send Transaction') }}
             </PageHeader>
             <PageBody class="page__recipient-input flex-column">
@@ -261,7 +261,6 @@ import { useSettingsStore } from '../../stores/Settings';
 import { FiatCurrency, FIAT_CURRENCY_DENYLIST } from '../../lib/Constants';
 import { createCashlink, sendTransaction } from '../../hub';
 import { useWindowSize } from '../../composables/useWindowSize';
-import { ColumnType, useActiveMobileColumn } from '../../composables/useActiveMobileColumn';
 import { i18n } from '../../i18n/i18n-setup';
 import {
     isValidDomain as isValidUnstoppableDomain,
@@ -665,12 +664,6 @@ export default defineComponent({
 
         const { amountsHidden } = useSettingsStore();
 
-        const { activeMobileColumn } = useActiveMobileColumn();
-
-        // User can only go back to the address selection if is mobile and the column shown is the account
-        const canUserGoBackToAddressSelection = ref(width.value <= 700
-            && activeMobileColumn.value !== ColumnType.ADDRESS);
-
         function back() {
             disableNextModalTransition();
             context.root.$router.back();
@@ -748,8 +741,6 @@ export default defineComponent({
             onStatusMainAction,
             onStatusAlternativeAction,
 
-            // User can choose address in mobile
-            canUserGoBackToAddressSelection,
             back,
 
             onCloseOverlay,

--- a/src/composables/useActiveMobileColumn.ts
+++ b/src/composables/useActiveMobileColumn.ts
@@ -1,5 +1,5 @@
-import router, { Columns } from '@/router';
 import { Ref, ref } from '@vue/composition-api';
+import router, { Columns } from '../router';
 
 export enum ColumnType {
     ADDRESS = 'column-address',

--- a/src/composables/useActiveMobileColumn.ts
+++ b/src/composables/useActiveMobileColumn.ts
@@ -12,26 +12,28 @@ let activeMobileColumn: Ref<ColumnType> | null = null;
 // Adding this code at the end of the call stack so router is not undefined
 setTimeout(() => {
     router.beforeResolve((to, from, next) => {
-        if (!activeMobileColumn) activeMobileColumn = ref(ColumnType.ACCOUNT);
+        if (!activeMobileColumn) {
+            activeMobileColumn = ref(ColumnType.ACCOUNT);
+        }
 
         const { meta, path, query: newQuery } = to;
         const { query: oldQuery } = from;
 
         if (newQuery && newQuery.sidebar) {
-            activeMobileColumn!.value = ColumnType.SIDEBAR;
+            activeMobileColumn.value = ColumnType.SIDEBAR;
         } else if (oldQuery && oldQuery.sidebar) {
-            activeMobileColumn!.value = ColumnType.ACCOUNT;
+            activeMobileColumn.value = ColumnType.ACCOUNT;
         } else if (meta) {
             switch (meta.column) {
                 case Columns.DYNAMIC:
                     switch (path) {
-                        case '/': activeMobileColumn!.value = ColumnType.ACCOUNT; break;
-                        case '/transactions': activeMobileColumn!.value = ColumnType.ADDRESS; break;
+                        case '/': activeMobileColumn.value = ColumnType.ACCOUNT; break;
+                        case '/transactions': activeMobileColumn.value = ColumnType.ADDRESS; break;
                         default: break; // Don't change column
                     }
                     break;
-                case Columns.ACCOUNT: activeMobileColumn!.value = ColumnType.ACCOUNT; break;
-                case Columns.ADDRESS: activeMobileColumn!.value = ColumnType.ADDRESS; break;
+                case Columns.ACCOUNT: activeMobileColumn.value = ColumnType.ACCOUNT; break;
+                case Columns.ADDRESS: activeMobileColumn.value = ColumnType.ADDRESS; break;
                 default: break;
             }
         }
@@ -41,7 +43,9 @@ setTimeout(() => {
 }, 0);
 
 export function useActiveMobileColumn() {
-    if (!activeMobileColumn) activeMobileColumn = ref(ColumnType.ACCOUNT);
+    if (!activeMobileColumn) {
+        activeMobileColumn = ref(ColumnType.ACCOUNT);
+    }
 
     return {
         activeMobileColumn,

--- a/src/composables/useActiveMobileColumn.ts
+++ b/src/composables/useActiveMobileColumn.ts
@@ -1,0 +1,49 @@
+import router, { Columns } from '@/router';
+import { Ref, ref } from '@vue/composition-api';
+
+export enum ColumnType {
+    ADDRESS = 'column-address',
+    ACCOUNT = 'column-account',
+    SIDEBAR = 'column-sidebar',
+}
+
+let activeMobileColumn: Ref<ColumnType> | null = null;
+
+// Adding this code at the end of the call stack so router is not undefined
+setTimeout(() => {
+    router.beforeResolve((to, from, next) => {
+        if (!activeMobileColumn) activeMobileColumn = ref(ColumnType.ACCOUNT);
+
+        const { meta, path, query: newQuery } = to;
+        const { query: oldQuery } = from;
+
+        if (newQuery && newQuery.sidebar) {
+            activeMobileColumn!.value = ColumnType.SIDEBAR;
+        } else if (oldQuery && oldQuery.sidebar) {
+            activeMobileColumn!.value = ColumnType.ACCOUNT;
+        } else if (meta) {
+            switch (meta.column) {
+                case Columns.DYNAMIC:
+                    switch (path) {
+                        case '/': activeMobileColumn!.value = ColumnType.ACCOUNT; break;
+                        case '/transactions': activeMobileColumn!.value = ColumnType.ADDRESS; break;
+                        default: break; // Don't change column
+                    }
+                    break;
+                case Columns.ACCOUNT: activeMobileColumn!.value = ColumnType.ACCOUNT; break;
+                case Columns.ADDRESS: activeMobileColumn!.value = ColumnType.ADDRESS; break;
+                default: break;
+            }
+        }
+
+        next();
+    });
+}, 0);
+
+export function useActiveMobileColumn() {
+    if (!activeMobileColumn) activeMobileColumn = ref(ColumnType.ACCOUNT);
+
+    return {
+        activeMobileColumn,
+    };
+}

--- a/src/composables/useActiveMobileColumn.ts
+++ b/src/composables/useActiveMobileColumn.ts
@@ -7,6 +7,9 @@ export enum ColumnType {
     SIDEBAR = 'column-sidebar',
 }
 
+// FIXME: In Vue 2, composition-api methods cannot be used before the plugin is activated.
+//        When switching to Vue 3, the activeMobileColumn variable can be directly instantiated
+//        as ref.
 let activeMobileColumn: Ref<ColumnType> | null = null;
 
 // Adding this code at the end of the call stack so router is not undefined

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Add a label to quickly find the transaction in your history."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:174
+#: src/components/modals/SendModal.vue:176
 msgid "Add a public message..."
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Add contact"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:46
+#: src/components/modals/SendModal.vue:48
 msgid "Address unavailable?"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "All translations are for information purposes only. The English text is the controlling version."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:63
+#: src/components/modals/BtcReceiveModal.vue:61
 msgid "Although reusing addresses won’t result in a loss of funds, it is highly recommended not to do so."
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "Bitcoin"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:109
+#: src/components/modals/BtcSendModal.vue:111
 msgid "Bitcoin addresses are used only once, so there are no contacts. Use labels instead to find transactions in your history easily."
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Buy with Simplex"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:200
+#: src/components/modals/SendModal.vue:202
 msgid "By adding a transaction fee, you can influence how fast your transaction will be processed."
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Choose a Receiver"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:58
+#: src/components/modals/SendModal.vue:60
 msgid "Choose a Recipient"
 msgstr ""
 
@@ -481,7 +481,7 @@ msgstr ""
 #: src/components/modals/AddressSelectorModal.vue:11
 #: src/components/modals/BuyCryptoModal.vue:262
 #: src/components/modals/SellCryptoModal.vue:243
-#: src/components/modals/SendModal.vue:190
+#: src/components/modals/SendModal.vue:192
 #: src/components/swap/SwapModal.vue:181
 msgid "Choose an Address"
 msgstr ""
@@ -574,7 +574,7 @@ msgid "Contacts"
 msgstr ""
 
 #: src/components/modals/MigrationWelcomeModal.vue:87
-#: src/components/modals/SendModal.vue:84
+#: src/components/modals/SendModal.vue:86
 #: src/components/modals/WelcomeModal.vue:63
 msgid "Continue"
 msgstr ""
@@ -595,7 +595,7 @@ msgid ""
 "the Simplex interface below."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:48
+#: src/components/modals/SendModal.vue:50
 msgid "Create a Cashlink"
 msgstr ""
 
@@ -607,32 +607,32 @@ msgstr ""
 msgid "Create a new account and transfer your funds. New features and possibilities await."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:71
+#: src/components/modals/BtcReceiveModal.vue:69
 msgid "Create a new single-use address."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:109
-#: src/components/modals/ReceiveModal.vue:30
+#: src/components/modals/BtcReceiveModal.vue:107
+#: src/components/modals/ReceiveModal.vue:28
 msgid "Create request link"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:206
+#: src/components/modals/BtcReceiveModal.vue:204
 msgid "Created {count} day ago | Created {count} days ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:196
+#: src/components/modals/BtcReceiveModal.vue:194
 msgid "Created {count} hour ago | Created {count} hours ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:190
+#: src/components/modals/BtcReceiveModal.vue:188
 msgid "Created {count} minute ago | Created {count} minutes ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:187
+#: src/components/modals/BtcReceiveModal.vue:185
 msgid "Created just now"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:204
+#: src/components/modals/BtcReceiveModal.vue:202
 msgid "Created yesterday"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgid "Disclaimer"
 msgstr ""
 
 #: src/components/BtcAddressInput.vue:85
-#: src/components/modals/SendModal.vue:346
+#: src/components/modals/SendModal.vue:341
 msgid "Domain does not resolve to a valid address"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Don't close your wallet!"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:23
+#: src/components/modals/BtcReceiveModal.vue:21
 msgid "Don’t reuse addresses and create a new one for every transaction."
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:95
+#: src/components/modals/BtcSendModal.vue:97
 msgid "Duration and fees are estimates."
 msgstr ""
 
@@ -705,8 +705,8 @@ msgstr ""
 msgid "Edit the amount of decimals visible for NIM values."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:438
-#: src/components/modals/SendModal.vue:590
+#: src/components/modals/BtcSendModal.vue:435
+#: src/components/modals/SendModal.vue:585
 msgid "Edit transaction"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Enter account holder name"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:20
+#: src/components/modals/SendModal.vue:22
 msgid "Enter address"
 msgstr ""
 
@@ -733,7 +733,7 @@ msgstr ""
 msgid "Enter IBAN"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:16
+#: src/components/modals/BtcSendModal.vue:18
 msgid "Enter recipient address..."
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:445
+#: src/components/modals/SendModal.vue:440
 msgid "express"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Faucet unavailable (wrong network)"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:156
+#: src/components/modals/SendModal.vue:158
 msgid "fee"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "For beginners"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:435
+#: src/components/modals/SendModal.vue:430
 msgid "free"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "In case of any issues, like exceeded limits or insufficient amounts, the automatic refunds will only work for individual IBAN addresses."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:91
+#: src/components/modals/BtcSendModal.vue:93
 msgid "Increase the speed of your transaction by paying a higher network fee. The fees go directly to the miners."
 msgstr ""
 
@@ -968,9 +968,9 @@ msgstr ""
 msgid "Install Web App"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:72
+#: src/components/modals/BtcSendModal.vue:74
 #: src/components/modals/SellCryptoModal.vue:165
-#: src/components/modals/SendModal.vue:164
+#: src/components/modals/SendModal.vue:166
 msgid "Insufficient balance."
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Light Node"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:74
+#: src/components/modals/BtcReceiveModal.vue:72
 msgid "Limit of copied addresses reached."
 msgstr ""
 
@@ -1121,11 +1121,11 @@ msgid ""
 "are supported by new accounts only."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:72
+#: src/components/modals/SendModal.vue:74
 msgid "Name this contact..."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:10
+#: src/components/modals/BtcSendModal.vue:12
 msgid "Name this recipient..."
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:88
+#: src/components/modals/BtcSendModal.vue:90
 msgid "Network fee: {sats} sat/vByte"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Nimiq is working on a PRO feature with increased limits after user registration."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:111
+#: src/components/modals/BtcSendModal.vue:113
 msgid "Nimiq wallet does not support transaction messages for Bitcoin."
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:11
+#: src/components/modals/BtcReceiveModal.vue:9
 msgid "Receive BTC"
 msgstr ""
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Receive free NIM"
 msgstr ""
 
-#: src/components/modals/ReceiveModal.vue:9
+#: src/components/modals/ReceiveModal.vue:7
 msgid "Receive NIM"
 msgstr ""
 
@@ -1346,11 +1346,11 @@ msgstr ""
 msgid "Received at {dateAndTime}"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:82
+#: src/components/modals/BtcReceiveModal.vue:80
 msgid "Recent addresses will be listed here, until they receive a transaction."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:85
+#: src/components/modals/BtcReceiveModal.vue:83
 msgid "Recently copied"
 msgstr ""
 
@@ -1421,12 +1421,12 @@ msgid "Reset your wallet settings and reload data from the blockchain."
 msgstr ""
 
 #: src/components/BtcAddressInput.vue:23
-#: src/components/modals/SendModal.vue:35
+#: src/components/modals/SendModal.vue:37
 msgid "Resolving Unstoppable Domain..."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:437
-#: src/components/modals/SendModal.vue:589
+#: src/components/modals/BtcSendModal.vue:434
+#: src/components/modals/SendModal.vue:584
 msgid "Retry"
 msgstr ""
 
@@ -1501,8 +1501,8 @@ msgid "Send"
 msgstr ""
 
 #: src/components/AmountMenu.vue:13
-#: src/components/modals/BtcSendModal.vue:74
-#: src/components/modals/SendModal.vue:166
+#: src/components/modals/BtcSendModal.vue:76
+#: src/components/modals/SendModal.vue:168
 msgid "Send all"
 msgstr ""
 
@@ -1524,10 +1524,10 @@ msgstr ""
 msgid "Send max"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:105
-#: src/components/modals/BtcSendModal.vue:4
-#: src/components/modals/SendModal.vue:11
-#: src/components/modals/SendModal.vue:185
+#: src/components/modals/BtcSendModal.vue:107
+#: src/components/modals/BtcSendModal.vue:5
+#: src/components/modals/SendModal.vue:12
+#: src/components/modals/SendModal.vue:187
 msgid "Send Transaction"
 msgstr ""
 
@@ -1535,16 +1535,16 @@ msgstr ""
 msgid "Send, receive and hold BTC in your wallet."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:434
-#: src/components/modals/SendModal.vue:586
+#: src/components/modals/BtcSendModal.vue:431
+#: src/components/modals/SendModal.vue:581
 msgid "Sending Transaction"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:492
+#: src/components/modals/BtcSendModal.vue:489
 msgid "Sent {btc} BTC"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:488
+#: src/components/modals/BtcSendModal.vue:485
 msgid "Sent {btc} BTC to {name}"
 msgstr ""
 
@@ -1553,11 +1553,11 @@ msgstr ""
 msgid "Sent {fromAsset} – Received {toAsset}"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:621
+#: src/components/modals/SendModal.vue:616
 msgid "Sent {nim} NIM"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:617
+#: src/components/modals/SendModal.vue:612
 msgid "Sent {nim} NIM to {name}"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 msgid "SEPA Instant transaction"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:85
-#: src/components/modals/SendModal.vue:97
+#: src/components/modals/SendModal.vue:87
+#: src/components/modals/SendModal.vue:99
 msgid "Set Amount"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:14
+#: src/components/modals/BtcReceiveModal.vue:12
 msgid "Share a single-use address with the sender."
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgid ""
 "Optionally include an amount. "
 msgstr ""
 
-#: src/components/modals/ReceiveModal.vue:10
+#: src/components/modals/ReceiveModal.vue:8
 msgid "Share your address with the sender."
 msgstr ""
 
@@ -1646,8 +1646,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:512
-#: src/components/modals/SendModal.vue:642
+#: src/components/modals/BtcSendModal.vue:509
+#: src/components/modals/SendModal.vue:637
 msgid "Something went wrong"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgstr ""
 msgid "Something went wrong with your transaction"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:198
+#: src/components/modals/SendModal.vue:200
 msgid "Speed up your Transaction"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Staking"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:440
+#: src/components/modals/SendModal.vue:435
 msgid "standard"
 msgstr ""
 
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "The rate might change depending on the swap volume."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:117
+#: src/components/modals/SendModal.vue:119
 msgid "The sender and recipient cannot be identical."
 msgstr ""
 
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "This is a Legacy Account"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:55
+#: src/components/modals/BtcReceiveModal.vue:53
 msgid "This is a single-use address"
 msgstr ""
 
@@ -1894,7 +1894,7 @@ msgstr ""
 msgid "Transaction to {address}"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:112
+#: src/components/modals/BtcSendModal.vue:114
 msgid "Transactions take >10 min. due to Bitcoin’s block time."
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "Use {NIM}, the super performant and browser- based payment coin."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:61
+#: src/components/modals/BtcReceiveModal.vue:59
 msgid "Use a new Bitcoin address for every transaction to improve privacy."
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Use a SEPA Instant account to get payouts in minutes."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:28
+#: src/components/modals/BtcReceiveModal.vue:26
 msgid "Use labels instead of contacts to easily identify transactions in your history."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgstr ""
 msgid "When ready"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:18
+#: src/components/modals/BtcReceiveModal.vue:16
 msgid "With Bitcoin, a new address is used for every transaction to improve privacy. Reuse of addresses does not result in a loss of funds."
 msgstr ""
 
@@ -2050,11 +2050,11 @@ msgstr ""
 msgid "You will finalize your purchase by bank transfer."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:65
+#: src/components/modals/BtcSendModal.vue:67
 msgid "You will send {amount}"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:160
+#: src/components/modals/SendModal.vue:162
 msgid "You will send {amount} NIM"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -467,9 +467,6 @@ msgid "Change your language setting."
 msgstr ""
 
 #: src/components/modals/AddressSelectorModal.vue:8
-msgid "Choose a Receiver"
-msgstr ""
-
 #: src/components/modals/SendModal.vue:61
 msgid "Choose a Recipient"
 msgstr ""
@@ -616,23 +613,23 @@ msgstr ""
 msgid "Create request link"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:200
+#: src/components/modals/BtcReceiveModal.vue:202
 msgid "Created {count} day ago | Created {count} days ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:190
+#: src/components/modals/BtcReceiveModal.vue:192
 msgid "Created {count} hour ago | Created {count} hours ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:184
+#: src/components/modals/BtcReceiveModal.vue:186
 msgid "Created {count} minute ago | Created {count} minutes ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:181
+#: src/components/modals/BtcReceiveModal.vue:183
 msgid "Created just now"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:198
+#: src/components/modals/BtcReceiveModal.vue:200
 msgid "Created yesterday"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Add a label to quickly find the transaction in your history."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:176
+#: src/components/modals/SendModal.vue:177
 msgid "Add a public message..."
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Add contact"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:48
+#: src/components/modals/SendModal.vue:49
 msgid "Address unavailable?"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "All translations are for information purposes only. The English text is the controlling version."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:61
+#: src/components/modals/BtcReceiveModal.vue:57
 msgid "Although reusing addresses won’t result in a loss of funds, it is highly recommended not to do so."
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Buy with Simplex"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:202
+#: src/components/modals/SendModal.vue:203
 msgid "By adding a transaction fee, you can influence how fast your transaction will be processed."
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Choose a Receiver"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:60
+#: src/components/modals/SendModal.vue:61
 msgid "Choose a Recipient"
 msgstr ""
 
@@ -481,7 +481,7 @@ msgstr ""
 #: src/components/modals/AddressSelectorModal.vue:11
 #: src/components/modals/BuyCryptoModal.vue:262
 #: src/components/modals/SellCryptoModal.vue:243
-#: src/components/modals/SendModal.vue:192
+#: src/components/modals/SendModal.vue:193
 #: src/components/swap/SwapModal.vue:181
 msgid "Choose an Address"
 msgstr ""
@@ -574,7 +574,7 @@ msgid "Contacts"
 msgstr ""
 
 #: src/components/modals/MigrationWelcomeModal.vue:87
-#: src/components/modals/SendModal.vue:86
+#: src/components/modals/SendModal.vue:87
 #: src/components/modals/WelcomeModal.vue:63
 msgid "Continue"
 msgstr ""
@@ -595,7 +595,7 @@ msgid ""
 "the Simplex interface below."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:50
+#: src/components/modals/SendModal.vue:51
 msgid "Create a Cashlink"
 msgstr ""
 
@@ -607,32 +607,32 @@ msgstr ""
 msgid "Create a new account and transfer your funds. New features and possibilities await."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:69
+#: src/components/modals/BtcReceiveModal.vue:65
 msgid "Create a new single-use address."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:107
+#: src/components/modals/BtcReceiveModal.vue:103
 #: src/components/modals/ReceiveModal.vue:28
 msgid "Create request link"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:204
+#: src/components/modals/BtcReceiveModal.vue:200
 msgid "Created {count} day ago | Created {count} days ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:194
+#: src/components/modals/BtcReceiveModal.vue:190
 msgid "Created {count} hour ago | Created {count} hours ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:188
+#: src/components/modals/BtcReceiveModal.vue:184
 msgid "Created {count} minute ago | Created {count} minutes ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:185
+#: src/components/modals/BtcReceiveModal.vue:181
 msgid "Created just now"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:202
+#: src/components/modals/BtcReceiveModal.vue:198
 msgid "Created yesterday"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgid "Disclaimer"
 msgstr ""
 
 #: src/components/BtcAddressInput.vue:85
-#: src/components/modals/SendModal.vue:341
+#: src/components/modals/SendModal.vue:352
 msgid "Domain does not resolve to a valid address"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Don't close your wallet!"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:21
+#: src/components/modals/BtcReceiveModal.vue:18
 msgid "Don’t reuse addresses and create a new one for every transaction."
 msgstr ""
 
@@ -705,8 +705,8 @@ msgstr ""
 msgid "Edit the amount of decimals visible for NIM values."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:435
-#: src/components/modals/SendModal.vue:585
+#: src/components/modals/BtcSendModal.vue:441
+#: src/components/modals/SendModal.vue:599
 msgid "Edit transaction"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Enter account holder name"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:22
+#: src/components/modals/SendModal.vue:23
 msgid "Enter address"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:440
+#: src/components/modals/SendModal.vue:451
 msgid "express"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Faucet unavailable (wrong network)"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:158
+#: src/components/modals/SendModal.vue:159
 msgid "fee"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgstr ""
 msgid "For beginners"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:430
+#: src/components/modals/SendModal.vue:441
 msgid "free"
 msgstr ""
 
@@ -970,7 +970,7 @@ msgstr ""
 
 #: src/components/modals/BtcSendModal.vue:74
 #: src/components/modals/SellCryptoModal.vue:165
-#: src/components/modals/SendModal.vue:166
+#: src/components/modals/SendModal.vue:167
 msgid "Insufficient balance."
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Light Node"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:72
+#: src/components/modals/BtcReceiveModal.vue:68
 msgid "Limit of copied addresses reached."
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgid ""
 "are supported by new accounts only."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:74
+#: src/components/modals/SendModal.vue:75
 msgid "Name this contact..."
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:9
+#: src/components/modals/BtcReceiveModal.vue:7
 msgid "Receive BTC"
 msgstr ""
 
@@ -1346,11 +1346,11 @@ msgstr ""
 msgid "Received at {dateAndTime}"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:80
+#: src/components/modals/BtcReceiveModal.vue:76
 msgid "Recent addresses will be listed here, until they receive a transaction."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:83
+#: src/components/modals/BtcReceiveModal.vue:79
 msgid "Recently copied"
 msgstr ""
 
@@ -1421,12 +1421,12 @@ msgid "Reset your wallet settings and reload data from the blockchain."
 msgstr ""
 
 #: src/components/BtcAddressInput.vue:23
-#: src/components/modals/SendModal.vue:37
+#: src/components/modals/SendModal.vue:38
 msgid "Resolving Unstoppable Domain..."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:434
-#: src/components/modals/SendModal.vue:584
+#: src/components/modals/BtcSendModal.vue:440
+#: src/components/modals/SendModal.vue:598
 msgid "Retry"
 msgstr ""
 
@@ -1502,7 +1502,7 @@ msgstr ""
 
 #: src/components/AmountMenu.vue:13
 #: src/components/modals/BtcSendModal.vue:76
-#: src/components/modals/SendModal.vue:168
+#: src/components/modals/SendModal.vue:169
 msgid "Send all"
 msgstr ""
 
@@ -1526,8 +1526,8 @@ msgstr ""
 
 #: src/components/modals/BtcSendModal.vue:107
 #: src/components/modals/BtcSendModal.vue:5
-#: src/components/modals/SendModal.vue:12
-#: src/components/modals/SendModal.vue:187
+#: src/components/modals/SendModal.vue:13
+#: src/components/modals/SendModal.vue:188
 msgid "Send Transaction"
 msgstr ""
 
@@ -1535,16 +1535,16 @@ msgstr ""
 msgid "Send, receive and hold BTC in your wallet."
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:431
-#: src/components/modals/SendModal.vue:581
+#: src/components/modals/BtcSendModal.vue:437
+#: src/components/modals/SendModal.vue:595
 msgid "Sending Transaction"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:489
+#: src/components/modals/BtcSendModal.vue:496
 msgid "Sent {btc} BTC"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:485
+#: src/components/modals/BtcSendModal.vue:492
 msgid "Sent {btc} BTC to {name}"
 msgstr ""
 
@@ -1553,11 +1553,11 @@ msgstr ""
 msgid "Sent {fromAsset} – Received {toAsset}"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:616
+#: src/components/modals/SendModal.vue:630
 msgid "Sent {nim} NIM"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:612
+#: src/components/modals/SendModal.vue:626
 msgid "Sent {nim} NIM to {name}"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 msgid "SEPA Instant transaction"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:87
-#: src/components/modals/SendModal.vue:99
+#: src/components/modals/SendModal.vue:100
+#: src/components/modals/SendModal.vue:88
 msgid "Set Amount"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:12
+#: src/components/modals/BtcReceiveModal.vue:9
 msgid "Share a single-use address with the sender."
 msgstr ""
 
@@ -1646,8 +1646,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: src/components/modals/BtcSendModal.vue:509
-#: src/components/modals/SendModal.vue:637
+#: src/components/modals/BtcSendModal.vue:507
+#: src/components/modals/SendModal.vue:642
 msgid "Something went wrong"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgstr ""
 msgid "Something went wrong with your transaction"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:200
+#: src/components/modals/SendModal.vue:201
 msgid "Speed up your Transaction"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Staking"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:435
+#: src/components/modals/SendModal.vue:446
 msgid "standard"
 msgstr ""
 
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "The rate might change depending on the swap volume."
 msgstr ""
 
-#: src/components/modals/SendModal.vue:119
+#: src/components/modals/SendModal.vue:120
 msgid "The sender and recipient cannot be identical."
 msgstr ""
 
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "This is a Legacy Account"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:53
+#: src/components/modals/BtcReceiveModal.vue:49
 msgid "This is a single-use address"
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "Use {NIM}, the super performant and browser- based payment coin."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:59
+#: src/components/modals/BtcReceiveModal.vue:55
 msgid "Use a new Bitcoin address for every transaction to improve privacy."
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Use a SEPA Instant account to get payouts in minutes."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:26
+#: src/components/modals/BtcReceiveModal.vue:23
 msgid "Use labels instead of contacts to easily identify transactions in your history."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgstr ""
 msgid "When ready"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:16
+#: src/components/modals/BtcReceiveModal.vue:13
 msgid "With Bitcoin, a new address is used for every transaction to improve privacy. Reuse of addresses does not result in a loss of funds."
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "You will send {amount}"
 msgstr ""
 
-#: src/components/modals/SendModal.vue:162
+#: src/components/modals/SendModal.vue:163
 msgid "You will send {amount} NIM"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Add account"
 msgstr ""
 
-#: src/components/AddressList.vue:25
+#: src/components/AddressList.vue:18
 msgid "Add address"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "All translations are for information purposes only. The English text is the controlling version."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:55
+#: src/components/modals/BtcReceiveModal.vue:63
 msgid "Although reusing addresses won’t result in a loss of funds, it is highly recommended not to do so."
 msgstr ""
 
@@ -466,10 +466,19 @@ msgstr ""
 msgid "Change your language setting."
 msgstr ""
 
+#: src/components/modals/AddressSelectorModal.vue:8
+msgid "Choose a Receiver"
+msgstr ""
+
 #: src/components/modals/SendModal.vue:58
 msgid "Choose a Recipient"
 msgstr ""
 
+#: src/components/modals/AddressSelectorModal.vue:5
+msgid "Choose a Sender"
+msgstr ""
+
+#: src/components/modals/AddressSelectorModal.vue:11
 #: src/components/modals/BuyCryptoModal.vue:262
 #: src/components/modals/SellCryptoModal.vue:243
 #: src/components/modals/SendModal.vue:190
@@ -598,32 +607,32 @@ msgstr ""
 msgid "Create a new account and transfer your funds. New features and possibilities await."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:63
+#: src/components/modals/BtcReceiveModal.vue:71
 msgid "Create a new single-use address."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:101
-#: src/components/modals/ReceiveModal.vue:28
+#: src/components/modals/BtcReceiveModal.vue:109
+#: src/components/modals/ReceiveModal.vue:30
 msgid "Create request link"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:193
+#: src/components/modals/BtcReceiveModal.vue:206
 msgid "Created {count} day ago | Created {count} days ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:183
+#: src/components/modals/BtcReceiveModal.vue:196
 msgid "Created {count} hour ago | Created {count} hours ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:177
+#: src/components/modals/BtcReceiveModal.vue:190
 msgid "Created {count} minute ago | Created {count} minutes ago"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:174
+#: src/components/modals/BtcReceiveModal.vue:187
 msgid "Created just now"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:191
+#: src/components/modals/BtcReceiveModal.vue:204
 msgid "Created yesterday"
 msgstr ""
 
@@ -664,7 +673,7 @@ msgstr ""
 msgid "Don't close your wallet!"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:14
+#: src/components/modals/BtcReceiveModal.vue:23
 msgid "Don’t reuse addresses and create a new one for every transaction."
 msgstr ""
 
@@ -1023,7 +1032,7 @@ msgstr ""
 msgid "Light Node"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:66
+#: src/components/modals/BtcReceiveModal.vue:74
 msgid "Limit of copied addresses reached."
 msgstr ""
 
@@ -1311,7 +1320,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:27
+#: src/components/modals/BtcReceiveModal.vue:11
 msgid "Receive BTC"
 msgstr ""
 
@@ -1324,7 +1333,7 @@ msgstr ""
 msgid "Receive free NIM"
 msgstr ""
 
-#: src/components/modals/ReceiveModal.vue:7
+#: src/components/modals/ReceiveModal.vue:9
 msgid "Receive NIM"
 msgstr ""
 
@@ -1337,11 +1346,11 @@ msgstr ""
 msgid "Received at {dateAndTime}"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:74
+#: src/components/modals/BtcReceiveModal.vue:82
 msgid "Recent addresses will be listed here, until they receive a transaction."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:77
+#: src/components/modals/BtcReceiveModal.vue:85
 msgid "Recently copied"
 msgstr ""
 
@@ -1590,7 +1599,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:28
+#: src/components/modals/BtcReceiveModal.vue:14
 msgid "Share a single-use address with the sender."
 msgstr ""
 
@@ -1600,7 +1609,7 @@ msgid ""
 "Optionally include an amount. "
 msgstr ""
 
-#: src/components/modals/ReceiveModal.vue:8
+#: src/components/modals/ReceiveModal.vue:10
 msgid "Share your address with the sender."
 msgstr ""
 
@@ -1804,7 +1813,7 @@ msgstr ""
 msgid "This is a Legacy Account"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:47
+#: src/components/modals/BtcReceiveModal.vue:55
 msgid "This is a single-use address"
 msgstr ""
 
@@ -1935,7 +1944,7 @@ msgstr ""
 msgid "Use {NIM}, the super performant and browser- based payment coin."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:53
+#: src/components/modals/BtcReceiveModal.vue:61
 msgid "Use a new Bitcoin address for every transaction to improve privacy."
 msgstr ""
 
@@ -1943,7 +1952,7 @@ msgstr ""
 msgid "Use a SEPA Instant account to get payouts in minutes."
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:19
+#: src/components/modals/BtcReceiveModal.vue:28
 msgid "Use labels instead of contacts to easily identify transactions in your history."
 msgstr ""
 
@@ -1987,7 +1996,7 @@ msgstr ""
 msgid "When ready"
 msgstr ""
 
-#: src/components/modals/BtcReceiveModal.vue:9
+#: src/components/modals/BtcReceiveModal.vue:18
 msgid "With Bitcoin, a new address is used for every transaction to improve privacy. Reuse of addresses does not result in a loss of funds."
 msgstr ""
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -80,9 +80,23 @@ const routes: RouteConfig[] = [{
         children: [{
             path: '/send',
             components: {
-                modal: SendModal,
+                modal: AddressSelectorModal,
             },
             name: 'send',
+            meta: { column: Columns.DYNAMIC },
+        }, {
+                path: '/send/nim',
+                components: {
+                modal: SendModal,
+            },
+                name: 'send-nim',
+                meta: { column: Columns.DYNAMIC },
+            }, {
+                path: '/send/btc',
+                components: {
+                    modal: BtcSendModal,
+                },
+                name: 'send-btc',
             meta: { column: Columns.DYNAMIC },
         }, {
             path: '/receive',
@@ -184,13 +198,6 @@ const routes: RouteConfig[] = [{
             name: 'btc-activation',
             props: { modal: true },
             meta: { column: Columns.ACCOUNT },
-        }, {
-            path: '/btc-send',
-            components: {
-                modal: BtcSendModal,
-            },
-            name: 'btc-send',
-            meta: { column: Columns.DYNAMIC },
         }, {
             path: '/btc-transaction/:hash',
             components: {

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,6 +16,8 @@ const Network = () =>
 // Modals
 const SendModal = () => import(/* webpackChunkName: "send-modal" */ './components/modals/SendModal.vue');
 const ReceiveModal = () => import(/* webpackChunkName: "receive-modal" */ './components/modals/ReceiveModal.vue');
+const AddressSelectorModal = () =>
+    import(/* webpackChunkName: "address-selector-modal" */ './components/modals/AddressSelectorModal.vue');
 const TransactionModal = () =>
     import(/* webpackChunkName: "transaction-modal" */ './components/modals/TransactionModal.vue');
 const TradeModal = () => import(/* webpackChunkName: "trade-modal" */ './components/modals/TradeModal.vue');
@@ -85,9 +87,23 @@ const routes: RouteConfig[] = [{
         }, {
             path: '/receive',
             components: {
-                modal: ReceiveModal,
+                modal: AddressSelectorModal,
             },
             name: 'receive',
+            meta: { column: Columns.DYNAMIC },
+        }, {
+            path: '/receive/nim',
+            components: {
+                modal: ReceiveModal,
+            },
+            name: 'receive-nim',
+            meta: { column: Columns.DYNAMIC },
+        }, {
+            path: '/receive/btc',
+            components: {
+                modal: BtcReceiveModal,
+            },
+            name: 'receive-btc',
             meta: { column: Columns.DYNAMIC },
         }, {
             path: '/transaction/:hash',
@@ -174,13 +190,6 @@ const routes: RouteConfig[] = [{
                 modal: BtcSendModal,
             },
             name: 'btc-send',
-            meta: { column: Columns.DYNAMIC },
-        }, {
-            path: '/btc-receive',
-            components: {
-                modal: BtcReceiveModal,
-            },
-            name: 'btc-receive',
             meta: { column: Columns.DYNAMIC },
         }, {
             path: '/btc-transaction/:hash',

--- a/src/router.ts
+++ b/src/router.ts
@@ -85,18 +85,18 @@ const routes: RouteConfig[] = [{
             name: 'send',
             meta: { column: Columns.DYNAMIC },
         }, {
-                path: '/send/nim',
-                components: {
+            path: '/send/nim',
+            components: {
                 modal: SendModal,
             },
-                name: 'send-nim',
-                meta: { column: Columns.DYNAMIC },
-            }, {
-                path: '/send/btc',
-                components: {
-                    modal: BtcSendModal,
-                },
-                name: 'send-btc',
+            name: 'send-nim',
+            meta: { column: Columns.DYNAMIC },
+        }, {
+            path: '/send/btc',
+            components: {
+                modal: BtcSendModal,
+            },
+            name: 'send-btc',
             meta: { column: Columns.DYNAMIC },
         }, {
             path: '/receive',


### PR DESCRIPTION
## Current state

If user is using a mobile device and the account column is active, the buttons "receive" and "send" will use the last selected address as a recipient or as a sender. This is not very intuitive.

[See video](https://www.loom.com/share/d5dec9857bc54d538aeb7811a47df6d1)

## Changes in this PR

With this PR, if the user is using a mobile device and account column is active, when clicking "receive" and "send", user can select a NIM address or BTC

[See video](https://www.loom.com/share/a3d0fcc419fc429192979211c8412bcf)

## Changes in code

1. Added new composable `useActiveMobileColumn`
2. New way to close modal to support user stories that contain multiple modal one after the other
3. Added `AddressSelectorModal`
4. Refactor `/send` and `/receive` paths
5. Added back arrow to some screens if the user is coming from the address selector and updated some screens repositioning some icons

## Future work

- User in 'Choose a Sender' should not be able to select addresses with 0 assets
- In `BTCSendModal`, back arrow and info icon are shown very close to each other, it might be subject of change in the future