### PR TITLE
Add an arrow to identicon/bank selection buttons, to indicate interactivity

### DIFF
--- a/src/components/BankIconButton.vue
+++ b/src/components/BankIconButton.vue
@@ -1,7 +1,7 @@
 <template>
     <button class="reset bank-icon-button flex-column" v-on="$listeners">
         <BankIcon/>
-        <TriangleDownIcon class="triangle"/>
+        <TriangleDownIcon/>
         <label>{{ bankName || '' }}</label>
     </button>
 </template>
@@ -29,24 +29,28 @@ export default defineComponent({
     width: 18rem;
     border-radius: 0.75rem;
     padding: 1rem;
+    transition: background var(--attr-duration) var(--nimiq-ease);
+
+    ::v-deep svg.triangle-down-icon {
+        position: absolute;
+        right: 4rem;
+        top: 8rem;
+        opacity: 0.25;
+        transition: opacity var(--attr-duration) var(--nimiq-ease);
+    }
 
     &:hover,
     &:focus {
         background: var(--nimiq-highlight-bg);
+
+        ::v-deep svg.triangle-down-icon {
+            opacity: 0.4;
+        }
     }
 
-    svg {
+    svg.bank-icon {
         height: 8.25rem;
         width: auto;
-    }
-
-    .triangle {
-        position: absolute;
-        right: 4rem;
-        top: 8rem;
-        width: 1.25rem;
-        height: 1rem;
-        opacity: 0.25;
     }
 
     label {

--- a/src/components/BankIconButton.vue
+++ b/src/components/BankIconButton.vue
@@ -1,6 +1,7 @@
 <template>
     <button class="reset bank-icon-button flex-column" v-on="$listeners">
         <BankIcon/>
+        <TriangleDownIcon class="triangle"/>
         <label>{{ bankName || '' }}</label>
     </button>
 </template>
@@ -8,6 +9,7 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
 import BankIcon from './icons/BankIcon.vue';
+import TriangleDownIcon from './icons/TriangleDownIcon.vue';
 
 export default defineComponent({
     props: {
@@ -15,12 +17,14 @@ export default defineComponent({
     },
     components: {
         BankIcon,
+        TriangleDownIcon,
     },
 });
 </script>
 
 <style lang="scss" scoped>
 .bank-icon-button {
+    position: relative;
     align-items: center;
     width: 18rem;
     border-radius: 0.75rem;
@@ -32,9 +36,17 @@ export default defineComponent({
     }
 
     svg {
-        height: 9rem;
+        height: 8.25rem;
         width: auto;
-        margin-top: -.5rem;
+    }
+
+    .triangle {
+        position: absolute;
+        right: 4rem;
+        top: 8rem;
+        width: 1.25rem;
+        height: 1rem;
+        opacity: 0.25;
     }
 
     label {

--- a/src/components/IdenticonStack.vue
+++ b/src/components/IdenticonStack.vue
@@ -16,6 +16,9 @@
 
         <BitcoinIcon class="primary"
             v-else-if="activeCurrency === CryptoCurrency.BTC" />
+
+        <TriangleDownIcon class="triangle"/>
+
         <label>
             {{ activeCurrency === CryptoCurrency.BTC ? 'Bitcoin' : activeAddressInfo.label }}
         </label>
@@ -29,6 +32,7 @@ import { CryptoCurrency } from '../lib/Constants';
 import { useAccountStore } from '../stores/Account';
 import { useAddressStore } from '../stores/Address';
 import BitcoinIcon from './icons/BitcoinIcon.vue';
+import TriangleDownIcon from './icons/TriangleDownIcon.vue';
 
 export default defineComponent({
     props: {
@@ -61,6 +65,7 @@ export default defineComponent({
     components: {
         Identicon,
         BitcoinIcon,
+        TriangleDownIcon,
     },
 });
 </script>
@@ -124,6 +129,15 @@ export default defineComponent({
             width: 7rem;
             margin-top: 0.25rem;
         }
+    }
+
+    .triangle {
+        position: absolute;
+        right: 2.5rem;
+        top: 8rem;
+        width: 1.25rem;
+        height: 1rem;
+        opacity: 0.25;
     }
 
     &.interactive {

--- a/src/components/IdenticonStack.vue
+++ b/src/components/IdenticonStack.vue
@@ -1,5 +1,10 @@
 <template>
-    <button class="reset identicon-stack flex-column" v-on="$listeners" :class="{ interactive }">
+    <button class="reset identicon-stack flex-column" v-on="$listeners" :class="{
+        interactive,
+        'triangle-indented': (!hasBitcoinAddresses && backgroundAddresses.length === 1)
+            || (hasBitcoinAddresses && backgroundAddresses.length === 0)
+            || (activeCurrency === CryptoCurrency.BTC && backgroundAddresses.length === 1),
+    }">
         <Identicon class="secondary"
             v-if="backgroundAddresses[0]" :address="backgroundAddresses[0]"/>
 
@@ -17,7 +22,7 @@
         <BitcoinIcon class="primary"
             v-else-if="activeCurrency === CryptoCurrency.BTC" />
 
-        <TriangleDownIcon class="triangle"/>
+        <TriangleDownIcon v-if="backgroundAddresses.length || hasBitcoinAddresses"/>
 
         <label>
             {{ activeCurrency === CryptoCurrency.BTC ? 'Bitcoin' : activeAddressInfo.label }}
@@ -131,13 +136,16 @@ export default defineComponent({
         }
     }
 
-    .triangle {
+    ::v-deep svg.triangle-down-icon {
         position: absolute;
         right: 2.5rem;
         top: 8rem;
-        width: 1.25rem;
-        height: 1rem;
         opacity: 0.25;
+        transition: opacity var(--attr-duration) var(--nimiq-ease);
+    }
+
+    &.triangle-indented ::v-deep svg.triangle-down-icon {
+        right: 3.75rem;
     }
 
     &.interactive {
@@ -153,6 +161,10 @@ export default defineComponent({
             .secondary:nth-child(2) {
                 transform: translateX(0.375rem) scale(1.05);
                 opacity: 0.5;
+            }
+
+            ::v-deep svg.triangle-down-icon {
+                opacity: 0.4;
             }
         }
 

--- a/src/components/icons/TriangleDownIcon.vue
+++ b/src/components/icons/TriangleDownIcon.vue
@@ -1,5 +1,12 @@
-<template>
-    <svg width="10" height="8" viewBox="0 0 10 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="nq-icon">
+<template functional>
+    <svg class="triangle-down-icon" width="10" height="8" viewBox="0 0 10 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path d="M8.56 0a.8.8 0 0 1 .67 1.22l-3.55 5.7a.8.8 0 0 1-1.36 0L.76 1.21A.8.8 0 0 1 1.44 0h7.12Z"/>
     </svg>
 </template>
+
+<style scoped>
+.triangle-down-icon {
+    width: 1.25rem;
+    height: 1rem;
+}
+</style>

--- a/src/components/icons/TriangleDownIcon.vue
+++ b/src/components/icons/TriangleDownIcon.vue
@@ -1,0 +1,5 @@
+<template>
+    <svg width="10" height="8" viewBox="0 0 10 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="nq-icon">
+        <path d="M8.56 0a.8.8 0 0 1 .67 1.22l-3.55 5.7a.8.8 0 0 1-1.36 0L.76 1.21A.8.8 0 0 1 1.44 0h7.12Z"/>
+    </svg>
+</template>

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -104,6 +104,7 @@
                         <Identicon class="secondary" v-if="backgroundAddresses[0]" :address="backgroundAddresses[0]"/>
                         <Identicon class="secondary" v-if="backgroundAddresses[1]" :address="backgroundAddresses[1]"/>
                         <Identicon class="primary" :address="activeAddressInfo.address"/>
+                        <TriangleDownIcon class="triangle"/>
                         <label>{{ activeAddressInfo.label }}</label>
                     </button>
                     <div class="separator-wrapper">
@@ -248,6 +249,7 @@ import Modal, { disableNextModalTransition } from './Modal.vue';
 import ContactShortcuts from '../ContactShortcuts.vue';
 import ContactBook from '../ContactBook.vue';
 import IdenticonButton from '../IdenticonButton.vue';
+import TriangleDownIcon from '../icons/TriangleDownIcon.vue';
 import AddressList from '../AddressList.vue';
 import AmountInput from '../AmountInput.vue';
 import AmountMenu from '../AmountMenu.vue';
@@ -759,6 +761,7 @@ export default defineComponent({
         Copyable,
         AddressDisplay,
         IdenticonButton,
+        TriangleDownIcon,
         AddressList,
         AmountInput,
         AmountMenu,
@@ -1021,6 +1024,15 @@ export default defineComponent({
                 transform: translateX(0.375rem) scale(1.05);
                 opacity: 0.5;
             }
+        }
+
+        .triangle {
+            position: absolute;
+            right: 0.375rem;
+            top: 8rem;
+            width: 1.25rem;
+            height: 1rem;
+            opacity: 0.25;
         }
 
         label {

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -100,11 +100,13 @@
             >{{ $t('Set Amount') }}</PageHeader>
             <PageBody class="page__amount-input flex-column">
                 <section class="identicon-section flex-row">
-                    <button class="reset identicon-stack flex-column" @click="addressListOpened = true">
+                    <button class="reset identicon-stack flex-column" @click="addressListOpened = true" :class="{
+                        'triangle-indented': backgroundAddresses.length === 1,
+                    }">
                         <Identicon class="secondary" v-if="backgroundAddresses[0]" :address="backgroundAddresses[0]"/>
                         <Identicon class="secondary" v-if="backgroundAddresses[1]" :address="backgroundAddresses[1]"/>
                         <Identicon class="primary" :address="activeAddressInfo.address"/>
-                        <TriangleDownIcon class="triangle"/>
+                        <TriangleDownIcon v-if="backgroundAddresses.length"/>
                         <label>{{ activeAddressInfo.label }}</label>
                     </button>
                     <div class="separator-wrapper">
@@ -984,6 +986,7 @@ export default defineComponent({
         padding: 1rem;
         position: relative;
         width: 14rem;
+        transition: background var(--attr-duration) var(--nimiq-ease);
 
         .primary {
             position: relative;
@@ -1011,6 +1014,18 @@ export default defineComponent({
             }
         }
 
+        ::v-deep svg.triangle-down-icon {
+            position: absolute;
+            right: 0.375rem;
+            top: 8rem;
+            opacity: 0.25;
+            transition: opacity var(--attr-duration) var(--nimiq-ease);
+        }
+
+        &.triangle-indented ::v-deep svg.triangle-down-icon {
+            right: 2rem;
+        }
+
         &:hover,
         &:focus {
             background: var(--nimiq-highlight-bg);
@@ -1024,15 +1039,10 @@ export default defineComponent({
                 transform: translateX(0.375rem) scale(1.05);
                 opacity: 0.5;
             }
-        }
 
-        .triangle {
-            position: absolute;
-            right: 0.375rem;
-            top: 8rem;
-            width: 1.25rem;
-            height: 1rem;
-            opacity: 0.25;
+            ::v-deep svg.triangle-down-icon {
+                opacity: 0.4;
+            }
         }
 
         label {


### PR DESCRIPTION
This adds a little triangle to identicon-stack and bank icon buttons in NIM SendModal and the OASIS buy and sell modals, to indicate that those are "dropdowns" that can be clicked:

![image](https://user-images.githubusercontent.com/1828163/148649995-e2e71b64-2c14-4682-93ad-c31c43ad91a2.png)
![image](https://user-images.githubusercontent.com/1828163/148650002-0322cd8d-2fb2-425e-9964-782006950e87.png)
![image](https://user-images.githubusercontent.com/1828163/148650025-c19f00f3-c442-40d9-be09-82f5f0f5076c.png)
