### PR TITLE
Improved UX in swap when user only has NIM or BTC

### DIFF
--- a/src/components/AmountInput.vue
+++ b/src/components/AmountInput.vue
@@ -8,8 +8,10 @@
             <input type="text" inputmode="decimal" class="nq-input" :class="{ vanishing }"
                 :placeholder="placeholder"
                 :style="{width: `${width}px`, fontSize: `${fontSize}rem`}"
-                :value="liveValue" @input="onInput"
-                @focus="isFocussed = true" @blur="isFocussed = false"
+                :value="liveValue"
+                @input="onInput"
+                @focus="onToggleFocus(true)"
+                @blur="onToggleFocus(false)"
                 ref="$input">
         </form>
         <slot v-if="$slots.suffix" name="suffix"/>
@@ -124,6 +126,11 @@ export default defineComponent({
             }
         }
 
+        function onToggleFocus(_isFocussed: boolean) {
+            isFocussed.value = _isFocussed;
+            context.emit(_isFocussed ? 'focus' : 'blur', context.refs.$input);
+        }
+
         watch(() => props.value, (newValue: number | undefined) => {
             if (newValue === valueInLuna.value) return;
             lastEmittedValue.value = newValue || 0;
@@ -146,6 +153,7 @@ export default defineComponent({
             liveValue,
             fontSize,
             onInput,
+            onToggleFocus,
             $fullWidth,
             $input,
             $widthPlaceholder,

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -645,7 +645,7 @@ export default defineComponent({
                 wantNim.value = Math.min(limit, Math.max(-limit, amount));
                 wantBtc.value = 0;
 
-                // If user has has 0 assets in BTC, then only accept negative values
+                // If user has 0 assets in BTC, then only accept negative values
                 if (accountBtcBalance.value === 0 && wantNim.value > 0) {
                     wantNim.value *= -1;
                 }
@@ -662,8 +662,8 @@ export default defineComponent({
                 wantBtc.value = Math.min(limit, Math.max(-limit, amount));
                 wantNim.value = 0;
 
-                // If user has has 0 assets in NIM, then only accept negative values
-                if (activeAddressInfo?.value?.balance === 0 && wantBtc.value > 0) {
+                // If user has 0 assets in NIM, then only accept negative values
+                if (activeAddressInfo.value?.balance === 0 && wantBtc.value > 0) {
                     wantBtc.value *= -1;
                 }
 
@@ -676,20 +676,22 @@ export default defineComponent({
             }
         }
 
-        // If user only has one asset, the we know that there is only available operation,
+        // If user only has one asset, then we know that there is only one available operation,
         // so we show only one icon: '-' or '+' depending on the asset
         function getPlaceholder(asset: SwapAsset) {
             if (asset === SwapAsset.NIM) {
                 if (accountBtcBalance.value === 0) {
                     return '- 0';
-                } if (activeAddressInfo?.value?.balance === 0) {
+                }
+                if (activeAddressInfo.value?.balance === 0) {
                     return '+ 0';
                 }
             }
             if (asset === SwapAsset.BTC) {
-                if (activeAddressInfo?.value?.balance === 0) {
+                if (activeAddressInfo.value?.balance === 0) {
                     return '- 0';
-                } if (accountBtcBalance.value === 0) {
+                }
+                if (accountBtcBalance.value === 0) {
                     return '+ 0';
                 }
             }
@@ -703,16 +705,17 @@ export default defineComponent({
             // If user has already changed the input, do nothing
             if (input.value !== '') return;
 
-            if (asset === SwapAsset.NIM && accountBtcBalance.value === 0) {
-                input.value = '-';
-            }
-            if (asset === SwapAsset.BTC && activeAddressInfo?.value?.balance === 0) {
+            if (
+                // eslint-disable-next-line operator-linebreak
+                (asset === SwapAsset.NIM && accountBtcBalance.value === 0) ||
+                (asset === SwapAsset.BTC && activeAddressInfo.value?.balance === 0)
+            ) {
                 input.value = '-';
             }
         }
 
         function onBlur(input: HTMLInputElement) {
-            if (input?.value === '-') {
+            if (input.value === '-') {
                 input.value = '';
             }
         }

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -86,12 +86,15 @@
                 >
                     <AmountInput
                         :value="wantNim || capDecimals(getNim, SwapAsset.NIM)"
+                        @focus="onFocus(SwapAsset.NIM, $event)"
                         @input="onInput(SwapAsset.NIM, $event)"
+                        @blur="onBlur($event)"
                         :class="{
                             'positive-value': wantNim > 0 || capDecimals(getNim, SwapAsset.NIM) > 0,
                             'negative-value': wantNim < 0 || capDecimals(getNim, SwapAsset.NIM) < 0,
                         }"
-                        :maxFontSize="2.5" :decimals="5" placeholder="± 0" preserveSign>
+                        :placeholder="getPlaceholder(SwapAsset.NIM)"
+                        :maxFontSize="2.5" :decimals="5" preserveSign>
                     </AmountInput>
                     <FiatConvertedAmount :amount="Math.abs(wantNim || getNim)" currency="nim"/>
                 </div>
@@ -101,12 +104,15 @@
                 >
                     <AmountInput
                         :value="wantBtc || capDecimals(getBtc, SwapAsset.BTC)"
+                        @focus="onFocus(SwapAsset.BTC, $event)"
                         @input="onInput(SwapAsset.BTC, $event)"
+                        @blur="onBlur($event)"
                         :class="{
                             'positive-value': wantBtc > 0 || capDecimals(getBtc, SwapAsset.BTC) > 0,
                             'negative-value': wantBtc < 0 || capDecimals(getBtc, SwapAsset.BTC) < 0,
                         }"
-                        :maxFontSize="2.5" :decimals="btcUnit.decimals" placeholder="± 0" preserveSign>
+                        :placeholder="getPlaceholder(SwapAsset.BTC)"
+                        :maxFontSize="2.5" :decimals="btcUnit.decimals" preserveSign>
                         <span slot="suffix" class="ticker">{{ btcUnit.ticker }}</span>
                     </AmountInput>
                     <FiatConvertedAmount :amount="Math.abs(wantBtc || getBtc)" currency="btc"/>
@@ -639,6 +645,11 @@ export default defineComponent({
                 wantNim.value = Math.min(limit, Math.max(-limit, amount));
                 wantBtc.value = 0;
 
+                // If user has has 0 assets in BTC, then only accept negative values
+                if (accountBtcBalance.value === 0 && wantNim.value > 0) {
+                    wantNim.value *= -1;
+                }
+
                 isLimitReached.value = Math.abs(originalAmount || wantNim.value) === limit;
                 if (limit === 0) openLimitsTooltip();
             }
@@ -651,12 +662,58 @@ export default defineComponent({
                 wantBtc.value = Math.min(limit, Math.max(-limit, amount));
                 wantNim.value = 0;
 
+                // If user has has 0 assets in NIM, then only accept negative values
+                if (activeAddressInfo?.value?.balance === 0 && wantBtc.value > 0) {
+                    wantBtc.value *= -1;
+                }
+
                 isLimitReached.value = Math.abs(originalAmount || wantBtc.value) === limit;
                 if (limit === 0) openLimitsTooltip();
             }
 
             if (!amount) {
                 updateEstimate(); // Skip debounce and update instantly
+            }
+        }
+
+        // If user only has one asset, the we know that there is only available operation,
+        // so we show only one icon: '-' or '+' depending on the asset
+        function getPlaceholder(asset: SwapAsset) {
+            if (asset === SwapAsset.NIM) {
+                if (accountBtcBalance.value === 0) {
+                    return '- 0';
+                } if (activeAddressInfo?.value?.balance === 0) {
+                    return '+ 0';
+                }
+            }
+            if (asset === SwapAsset.BTC) {
+                if (activeAddressInfo?.value?.balance === 0) {
+                    return '- 0';
+                } if (accountBtcBalance.value === 0) {
+                    return '+ 0';
+                }
+            }
+            return '± 0';
+        }
+
+        function onFocus(asset: SwapAsset, input: HTMLInputElement) {
+            // If user has selected NIM and has 0 assets in BTC, then the input should start with a - symbol,
+            // and viceversa
+
+            // If user has already changed the input, do nothing
+            if (input.value !== '') return;
+
+            if (asset === SwapAsset.NIM && accountBtcBalance.value === 0) {
+                input.value = '-';
+            }
+            if (asset === SwapAsset.BTC && activeAddressInfo?.value?.balance === 0) {
+                input.value = '-';
+            }
+        }
+
+        function onBlur(input: HTMLInputElement) {
+            if (input?.value === '-') {
+                input.value = '';
             }
         }
 
@@ -1155,7 +1212,10 @@ export default defineComponent({
             serviceSwapFeeFiat,
             serviceSwapFeePercentage,
             isHighRelativeFees,
+            getPlaceholder,
             onInput,
+            onFocus,
+            onBlur,
             onSwapBalanceBarChange,
             newNimBalance,
             newBtcBalance,


### PR DESCRIPTION
## Problem

When user wants to swap assets but only owns one of them, inputs can be confusing as they show that user can put whether positive or negative values. 

This is not true, as if I have for example 1000 NIM and 0 BTC, then I cannot do:
a. +1000 NIM 
b. -0.1 BTC

The expected behaviour in this case would be to **only** allow negative values in the NIM input and positive values in BTC.

This also happens the if the situation is that user owns BTC but no NIM.

## Solution

- Updated UI, so it shows what actions the user can take. Therefore, a new function has been implemented called `getPlaceholder()`
- Updated UX, so even though the user tries to put an invalid value in the inputs, we correct it for him/her

### Some screenshots:

#### User only has BTC
![only-btc](https://user-images.githubusercontent.com/22072217/153731696-35845ba7-6544-4818-9e57-9fd13b2d3edd.png)

#### User only has NIM
![only-nim](https://user-images.githubusercontent.com/22072217/153731747-896e8673-fd6e-43a3-b471-601fc7c145aa.png)


## Updated AmountInput

I realised that we have two versions of `AmountInput`. I updated only the one that comes with this project as it was more convenient but should I update also `AmountInput` from `vue-component?`
