### PR TITLE
Center app columns on very large screens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -163,6 +163,7 @@ export default defineComponent({
     /* Default: >= 1500px */
     --sidebar-width: 24rem;
     --account-column-width: 70rem;
+    --settings-width: 131rem;
     --address-column-width: 150rem;
 
     @media (max-width: 1499px) {
@@ -222,7 +223,11 @@ export default defineComponent({
         }
 
         ::v-deep .address-overview {
-            width: var(--address-column-width);
+            width: clamp(
+                        0px,
+                        calc(100vw - var(--sidebar-width) - var(--account-column-width)),
+                        var(--address-column-width)
+                    );
             min-width: 0;
             z-index: 3;
         }
@@ -275,6 +280,14 @@ export default defineComponent({
                 // Account column
                 transform: translateX(calc(-1 * var(--sidebar-width)));
             }
+
+            ::v-deep .address-overview {
+                width: clamp(
+                        0px,
+                        calc(100vw - var(--account-column-width)),
+                        var(--address-column-width)
+                    );
+            }
         }
     }
 
@@ -288,11 +301,50 @@ export default defineComponent({
 
             ::v-deep .address-overview {
                 min-width: unset;
+                width: 100vw;
             }
 
             &.column-address {
                 // Address column
                 transform: translateX(calc(-1 * var(--sidebar-width) - 100vw));
+            }
+        }
+    }
+
+    @media (min-width: 2000px) {
+        ::v-deep .groundfloor {
+            display: flex;
+            justify-content: center;
+
+            // Size of both columns
+            --columns-width: calc(var(--account-column-width) + var(--address-column-width));
+
+            // Margin between columns and edges of the groundfloor
+            --columns-lateral-margin: calc((100% - var(--columns-width)) / 2);
+
+            & > div {
+                position: relative;
+
+                .account-overview {
+                    position: absolute;
+                    width: var(--account-column-width);
+                    right: calc(var(--columns-lateral-margin) + var(--address-column-width));
+                    height: 100%;
+                }
+
+                .settings {
+                    position: absolute;
+                    width: var(--settings-width);
+                    height: 100%;
+                    margin-left: calc(var(--settings-width) / -2);
+                }
+
+                .address-overview {
+                    position: absolute;
+                    width: var(--address-column-width);
+                    left: calc(var(--columns-lateral-margin) + var(--account-column-width));
+                    height: 100%;
+                }
             }
         }
     }

--- a/src/components/layouts/Groundfloor.vue
+++ b/src/components/layouts/Groundfloor.vue
@@ -1,20 +1,24 @@
 <template>
     <div class="groundfloor flex-row">
-        <transition name="fade">
-            <keep-alive>
-                <router-view name="accountOverview"/>
-            </keep-alive>
-        </transition>
 
-        <transition name="fade">
-            <router-view name="settings"/>
-        </transition>
+        <div>
+            <transition name="fade">
+                <keep-alive>
+                    <router-view name="accountOverview"/>
+                </keep-alive>
+            </transition>
+            <transition name="fade">
+                <router-view name="settings"/>
+            </transition>
+        </div>
 
-        <transition name="slide-right">
-            <keep-alive>
-                <router-view name="addressOverview"/>
-            </keep-alive>
-        </transition>
+        <div>
+            <transition name="slide-right">
+                <keep-alive>
+                    <router-view name="addressOverview"/>
+                </keep-alive>
+            </transition>
+        </div>
 
         <div class="mobile-tap-area" @click="$router.back()"></div>
     </div>


### PR DESCRIPTION
## Changes
In order to achieve centering of the app and have the animation at the same time, some elements have absolute positioning and some complex calculations are being made. Hope it is clear.

I don't know how we could achieve the same effect with less complexity.

I have tried to minimise changes to devices smaller than 2000px to reduce the likelihood of breaking something.

#### Test

This PR has been visually tested in:
- latest Chromium version in PC (Edge, Chrome and Brave) -> all screen sizes: mobile, tablet, pc and >2000px
- latest Firefox version in PC -> all screen sizes: mobile, tablet, pc and >2000px
- latest Safari version in iPhone 13
- latest version in Safari in Mac
- latest Chromium version (Brave and Chrome)

### Before:
![image](https://user-images.githubusercontent.com/22072217/153864220-bd1b4c4d-28ce-4278-956d-ee757f006c80.png)

### After
![image](https://user-images.githubusercontent.com/22072217/153864252-0535269d-66e6-4eeb-bd3a-56985e0b14f5.png)


