### PR TITLE
Updated BalanceDistribution NIM addresses tooltips

### DIFF
--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -9,6 +9,7 @@
                         : account.percentage
                     ) * 100 + '%'}">
                     <Tooltip
+                        class="nim"
                         preferredPosition="top right"
                         :container="$el ? {$el: $el.parentNode.parentNode} : undefined"
                         @show="highlightBar(i)"
@@ -48,7 +49,7 @@
                 value-mask/>
         </div>
         <div v-if="hasBitcoinAddresses" class="exchange" ref="$exchange">
-            <Tooltip preferredPosition="top right" :disabled="hasActiveSwap" ref="swapTooltip" noFocus>
+            <Tooltip class="btc" preferredPosition="top right" :disabled="hasActiveSwap" ref="swapTooltip" noFocus>
                 <button
                     :disabled="!totalFiatAccountBalance || hasActiveSwap || !canUseSwaps"
                     @focus.stop="$refs.swapTooltip.show()"
@@ -325,6 +326,10 @@ export default defineComponent({
                     display: flex;
                     height: 8px;
                     padding: 0 0.25rem;
+                }
+
+                &.nim ::v-deep .trigger::after {
+                    background: #1F2046; // Color at the bottom left of the tooltip
                 }
 
                 ::v-deep .tooltip-box {

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -7,8 +7,7 @@
                     :style="{width: (nimPercentageSum < 0.99
                         ? 1 / nimBalanceDistribution.length
                         : account.percentage
-                    ) * 100 + '%'}"
-                    ref="$nimBalanceDistribution">
+                    ) * 100 + '%'}">
                     <Tooltip
                         preferredPosition="top right"
                         :container="$el ? {$el: $el.parentNode.parentNode} : undefined"
@@ -21,7 +20,9 @@
                                 getBackgroundClass(account.addressInfo.address),
                                 {'empty': !account.addressInfo.balance},
                             ]"
-                            slot="trigger"></div>
+                            slot="trigger"
+                            ref="$nimBalanceDistributionBars"
+                        ></div>
                         <div class="flex-row">
                             <Identicon :address="account.addressInfo.address"/>
                             <div class="flex-column">
@@ -182,16 +183,14 @@ export default defineComponent({
         const hasActiveSwap = computed(() => activeSwap.value !== null);
 
         // List of NIM addresses bar elements
-        const $nimBalanceDistribution = ref<null | HTMLDivElement[]>(null);
+        const $nimBalanceDistributionBars = ref<null | HTMLDivElement[]>(null);
 
         // When user hovers over a NIM balance distribution bar, we want to highlight it fading the rest of
         // NIM addresses bars
         function highlightBar(activeChild: number) {
-            if (!$nimBalanceDistribution.value) return;
+            if (!$nimBalanceDistributionBars.value) return;
 
-            $nimBalanceDistribution.value.forEach((nimAddress, i) => {
-                const bar = nimAddress.querySelector('.bar');
-                if (!bar) return;
+            $nimBalanceDistributionBars.value.forEach((bar, i) => {
                 setTimeout(() => {
                     bar.classList[i !== activeChild ? 'add' : 'remove']('faded');
                 }, 100 + 1 /** Tooltip takes 100ms to emit hide event */);
@@ -200,11 +199,9 @@ export default defineComponent({
 
         // Remove all faded classes from NIM balance distribution bars
         function resetBars() {
-            if (!$nimBalanceDistribution.value) return;
+            if (!$nimBalanceDistributionBars.value) return;
 
-            $nimBalanceDistribution.value.forEach((nimAddress) => {
-                const bar = nimAddress.querySelector('.bar');
-                if (!bar) return;
+            $nimBalanceDistributionBars.value.forEach((bar) => {
                 bar.classList.remove('faded');
             });
         }
@@ -225,7 +222,7 @@ export default defineComponent({
             doElsTouch,
             hasActiveSwap,
             canUseSwaps,
-            $nimBalanceDistribution,
+            $nimBalanceDistributionBars,
             highlightBar,
             resetBars,
         };

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -13,7 +13,7 @@
                         preferredPosition="top right"
                         :container="$el ? {$el: $el.parentNode.parentNode} : undefined"
                         @show="highlightBar(i)"
-                        @hide="resetBars()"
+                        @hide="resetBar(i)"
                     >
                         <div
                             class="bar"
@@ -189,15 +189,15 @@ export default defineComponent({
 
         // When user hovers over a NIM balance distribution bar, we want to highlight it fading the rest of
         // NIM addresses bars
-        function highlightBar(activeChild: number) {
-            setTimeout(() => {
-                highlightedBar.value = activeChild;
-            }, 100 + 1 /* Tooltip takes 100ms to emit hide event */);
+        function highlightBar(index: number) {
+            highlightedBar.value = index;
         }
 
         // Remove all faded classes from NIM balance distribution bars
-        function resetBars() {
-            highlightedBar.value = null;
+        function resetBar(index: number) {
+            if (highlightedBar.value === index) {
+                highlightedBar.value = null;
+            }
         }
 
         return {
@@ -217,7 +217,7 @@ export default defineComponent({
             hasActiveSwap,
             canUseSwaps,
             highlightBar,
-            resetBars,
+            resetBar,
             highlightedBar,
         };
     },

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -345,14 +345,12 @@ export default defineComponent({
                 .nq-text-s {
                     white-space: nowrap;
                     margin: 0 0 0.25rem;
-                    font-weight: 600;
                 }
 
                 .fiat-amount {
                     --size: var(--small-label-size);
                     font-size: var(--small-label-size);
                     opacity: .6;
-                    font-weight: 500;
                     text-align: left;
                 }
             }
@@ -366,7 +364,7 @@ export default defineComponent({
                 transition: opacity var(--transition-time) var(--nimiq-ease);
 
                 &.faded {
-                    opacity: 0.5;
+                    opacity: 0.4;
                 }
 
                 &.btc {

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -327,6 +327,10 @@ export default defineComponent({
                     padding: 0 0.25rem;
                 }
 
+                ::v-deep .tooltip-box {
+                    padding: 1.5rem;
+                }
+
                 .flex-row {
                     align-items: center;
                 }
@@ -343,13 +347,14 @@ export default defineComponent({
                 .nq-text-s {
                     white-space: nowrap;
                     margin: 0 0 0.25rem;
+                    font-weight: 600;
                 }
 
                 .fiat-amount {
                     --size: var(--small-label-size);
                     font-size: var(--small-label-size);
                     opacity: .6;
-                    font-weight: 600;
+                    font-weight: 500;
                     text-align: left;
                 }
             }

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -19,10 +19,12 @@
                             class="bar"
                             :class="[
                                 getBackgroundClass(account.addressInfo.address),
-                                {'empty': !account.addressInfo.balance},
+                                {
+                                    'empty': !account.addressInfo.balance,
+                                    'faded': highlightedBar !== null && i !== highlightedBar,
+                                },
                             ]"
                             slot="trigger"
-                            ref="$nimBalanceDistributionBars"
                         ></div>
                         <div class="flex-row">
                             <Identicon :address="account.addressInfo.address"/>
@@ -183,28 +185,19 @@ export default defineComponent({
         const { activeSwap } = useSwapsStore();
         const hasActiveSwap = computed(() => activeSwap.value !== null);
 
-        // List of NIM addresses bar elements
-        const $nimBalanceDistributionBars = ref<null | HTMLDivElement[]>(null);
+        const highlightedBar = ref<number>(null);
 
         // When user hovers over a NIM balance distribution bar, we want to highlight it fading the rest of
         // NIM addresses bars
         function highlightBar(activeChild: number) {
-            if (!$nimBalanceDistributionBars.value) return;
-
-            $nimBalanceDistributionBars.value.forEach((bar, i) => {
-                setTimeout(() => {
-                    bar.classList[i !== activeChild ? 'add' : 'remove']('faded');
-                }, 100 + 1 /** Tooltip takes 100ms to emit hide event */);
-            });
+            setTimeout(() => {
+                highlightedBar.value = activeChild;
+            }, 100 + 1 /* Tooltip takes 100ms to emit hide event */);
         }
 
         // Remove all faded classes from NIM balance distribution bars
         function resetBars() {
-            if (!$nimBalanceDistributionBars.value) return;
-
-            $nimBalanceDistributionBars.value.forEach((bar) => {
-                bar.classList.remove('faded');
-            });
+            highlightedBar.value = null;
         }
 
         return {
@@ -223,9 +216,9 @@ export default defineComponent({
             doElsTouch,
             hasActiveSwap,
             canUseSwaps,
-            $nimBalanceDistributionBars,
             highlightBar,
             resetBars,
+            highlightedBar,
         };
     },
     components: {

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -304,7 +304,7 @@ msgstr ""
 msgid "BIC works, too."
 msgstr ""
 
-#: src/components/BalanceDistribution.vue:77
+#: src/components/BalanceDistribution.vue:82
 #: src/components/layouts/AccountOverview.vue:64
 #: src/components/layouts/AddressOverview.vue:68
 #: src/components/layouts/Settings.vue:119
@@ -1691,7 +1691,7 @@ msgstr ""
 msgid "Swap has expired"
 msgstr ""
 
-#: src/components/BalanceDistribution.vue:54
+#: src/components/BalanceDistribution.vue:59
 msgid "Swap NIM {arrow} BTC"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -304,7 +304,7 @@ msgstr ""
 msgid "BIC works, too."
 msgstr ""
 
-#: src/components/BalanceDistribution.vue:82
+#: src/components/BalanceDistribution.vue:84
 #: src/components/layouts/AccountOverview.vue:64
 #: src/components/layouts/AddressOverview.vue:68
 #: src/components/layouts/Settings.vue:119
@@ -1691,7 +1691,7 @@ msgstr ""
 msgid "Swap has expired"
 msgstr ""
 
-#: src/components/BalanceDistribution.vue:59
+#: src/components/BalanceDistribution.vue:61
 msgid "Swap NIM {arrow} BTC"
 msgstr ""
 


### PR DESCRIPTION
## Distribution NIM bar tooltips

_This is a copy and paste from the original task_
- [ ]  Triangle alignment: triangles should either be centered, or aligned to the whole width of the bar, visually
_Not exactly sure what this mean..._
- [X]  Trigger area: Increase Distribution bar tooltips trigger area. Right now it's just the 4px bar itself, which makes it hard to get to the tooltip. Let's increase the trigger area vertically – and, esp. for small accounts, also fill the gaps between bars.
- [X]  Introduce hover state for bars (decrease opacity for non-hovered bars on hover, see examples below)
- [X]  Invert color to be consistent with the rest of the tooltips

## Before
![image](https://user-images.githubusercontent.com/22072217/153901495-4d4c3fc5-91cc-4db0-8a76-ba7ab0e6fb78.png)

## After
![image](https://user-images.githubusercontent.com/22072217/153901548-c248efa7-c00e-4c9e-9c7b-734386d62b3a.png)

## Things to be done

- The first task: "Triangle alignment: triangles should either be centered, or aligned to the whole width of the bar, visually" has not been developed as I am not sure what _aligned to the whole width of the bar_ means
- The opacity for fading the bar not being hovered is 0.5, but I don't know if that's the right value
