### PR TITLE
Fading transition in groundfloor disabled if network is active

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -426,17 +426,21 @@ body {
     &.slide-right-leave-to {
         transform: translate3d(calc(100vw - var(--sidebar-width)), 0, 0);
     }
-}
 
-.address-overview {
-    &.slide-right-enter,
-    &.slide-right-leave-to {
-        transform: translate3d(calc(100vw - var(--account-column-width) - var(--sidebar-width)), 0, 0);
+    .address-overview {
+        &.slide-right-enter,
+        &.slide-right-leave-to {
+            transform: translate3d(calc(100vw - var(--account-column-width) - var(--sidebar-width)), 0, 0);
+        }
+
+        .slide-right-enter &,
+        .slide-right-leave-to & {
+            transform: translate3d(calc(-1 * var(--account-column-width)), 0, 0);
+        }
     }
 
-    .slide-right-enter &,
-    .slide-right-leave-to & {
-        transform: translate3d(calc(-1 * var(--account-column-width)), 0, 0);
+    .settings {
+        width: calc(100vw - var(--sidebar-width));
     }
 }
 
@@ -446,14 +450,19 @@ body {
         &.slide-right-leave-to {
             transform: translate3d(100vw, 0, 0);
         }
-    }
 
-    .address-overview {
-        &.slide-right-enter,
-        &.slide-right-leave-to {
-            transform: translate3d(calc(100vw - var(--account-column-width)), 0, 0);
+        .address-overview {
+            &.slide-right-enter,
+            &.slide-right-leave-to {
+                transform: translate3d(calc(100vw - var(--account-column-width)), 0, 0);
+            }
+        }
+
+        .settings {
+            width: 100vw;
         }
     }
+
 }
 
 @media (max-width: 700px) { // Full mobile breakpoint

--- a/src/components/layouts/Groundfloor.vue
+++ b/src/components/layouts/Groundfloor.vue
@@ -2,12 +2,12 @@
     <div class="groundfloor flex-row">
 
         <div>
-            <transition name="fade">
+            <transition name="fade" v-if="$route.path !== '/network'">
                 <keep-alive>
                     <router-view name="accountOverview"/>
                 </keep-alive>
             </transition>
-            <transition name="fade">
+            <transition name="fade" v-if="$route.path !== '/network'">
                 <router-view name="settings"/>
             </transition>
         </div>


### PR DESCRIPTION
## Problem

When going from network to settings, if account overview was active previously, fading transition between 'account' and 'settings' was visible.

### Before
> Transition time is 7.5s. Blue flashes is just the dev tools

https://www.loom.com/share/fc8674f0706544c9895ff3b515ee0439

### After
> Transition time is 7.5s. Blue flashes is just the dev tools

https://www.loom.com/share/d1ac5375edf04cf28f77db4155e35931