### PR TITLE
Fix address label flickering on hover 

### DIFF
--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -31,6 +31,6 @@
 @font-face {
     font-family: 'Fira Mono';
     font-style: normal;
-    font-weight: 500;
+    font-weight: 500, 700;
     src: local('Fira Mono'), url('FiraMono-Medium.woff') format('woff');
 }


### PR DESCRIPTION
Solves #95 

## What is happening?

#### Before hovering
![image](https://user-images.githubusercontent.com/22072217/157139347-911741c4-b109-454e-910d-ade569931720.png)

#### Hovering - first phase 
![image](https://user-images.githubusercontent.com/22072217/157139385-a2551348-8e01-434e-9226-324f1fe19bb2.png)

#### Hovering - second phase
![image](https://user-images.githubusercontent.com/22072217/157139435-554e410b-19a2-459e-bc44-147274105195.png)

You can see the video here: https://www.loom.com/share/5f81a1901b9445428eee628756886efe.

## Explanation

1. User mouse hover the address
2. The browser doesn't have the font with the bold variation downloaded, so it requests the bold variation to wherever we are hosting the font. We know this because:
   - For example, you can see the character '0' in the screenshots. In the first and third you can see that the 0 has a dot. In the second screen shot it has like a '/' character in the middle
   - You can see the network panel. Once you over the address, a request is being made.
3. The default behaviour for Chromium is different to Firefox. I think, Chromium prefers to loads a font that already has a bold variation, whereas Firefox prefers wait to the response with the font and then change the variation, and that's why you don't see flickering in Firefox.

Another solution might be change the default behaviour of Chromium with `font-display`, but I couldn't make it work

