### PR TITLE
Removed vue-responsive-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
     "vue-i18n": "^8.15.5",
-    "vue-responsive-components": "^0.2.3",
     "vue-router": "^3.1.6",
     "vue-simple-markdown": "^1.1.4",
     "vue-virtual-scroller": "https://github.com/sisou/vue-virtual-scroller#nimiq/build",

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -221,16 +221,19 @@ export default defineComponent({
         const $address = ref<HTMLDivElement>(null);
         const addressMasked = ref<boolean>(false);
 
-        useElementResize($address, maskAddress);
-
         const { isMobile, isFullDesktop } = useWindowSize();
 
-        function maskAddress() {
-            let addressMaskedWidth = 322;
-            if (isFullDesktop.value) addressMaskedWidth = 396;
-            if (!isMobile.value) addressMaskedWidth = 372;
-            addressMasked.value = $address.value!.clientWidth < addressMaskedWidth;
-        }
+        useElementResize($address, () => {
+            let addressWidth: number;
+            if (isMobile.value) {
+                addressWidth = 322;
+            } else if (isFullDesktop.value) {
+                addressWidth = 396;
+            } else {
+                addressWidth = 372; // Tablet
+            }
+            addressMasked.value = $address.value!.clientWidth < addressWidth;
+        });
 
         function hideUnclaimedCashlinkList() {
             showUnclaimedCashlinkList.value = false;

--- a/src/composables/useElementResize.ts
+++ b/src/composables/useElementResize.ts
@@ -4,12 +4,13 @@ export function useElementResize(
     target: Ref<HTMLElement | null>,
     callback: () => void,
 ) {
-    const isSupported = window && 'ResizeObserver' in window;
+    const isSupported = 'ResizeObserver' in window;
 
     if (!isSupported) {
         // This is just a fallback for browsers that don't support ResizeObserver
-        window.addEventListener('resize', () => callback());
-        onUnmounted(() => window.removeEventListener('resize', () => callback));
+        window.addEventListener('resize', callback);
+        onUnmounted(() => window.removeEventListener('resize', callback));
+        return;
     }
 
     let observer: ResizeObserver | undefined;
@@ -25,9 +26,9 @@ export function useElementResize(
         (el) => {
             unobserve();
 
-            if (window && el && el) {
-                observer = new window.ResizeObserver(callback);
-                observer!.observe(el);
+            if (el) {
+                observer = new ResizeObserver(callback);
+                observer.observe(el);
             }
         },
         { flush: 'post' },

--- a/src/composables/useElementResize.ts
+++ b/src/composables/useElementResize.ts
@@ -1,0 +1,40 @@
+import { onUnmounted, Ref, watch } from '@vue/composition-api';
+
+export function useElementResize(
+    target: Ref<HTMLElement | null>,
+    callback: () => void,
+) {
+    const isSupported = window && 'ResizeObserver' in window;
+
+    if (!isSupported) {
+        // This is just a fallback for browsers that don't support ResizeObserver
+        window.addEventListener('resize', () => callback());
+        onUnmounted(() => window.removeEventListener('resize', () => callback));
+    }
+
+    let observer: ResizeObserver | undefined;
+    const unobserve = () => {
+        if (observer) {
+            observer.disconnect();
+            observer = undefined;
+        }
+    };
+
+    const stopWatch = watch(
+        target,
+        (el) => {
+            unobserve();
+
+            if (window && el && el) {
+                observer = new window.ResizeObserver(callback);
+                observer!.observe(el);
+            }
+        },
+        { flush: 'post' },
+    );
+
+    onUnmounted(() => () => {
+        unobserve();
+        stopWatch();
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6453,11 +6453,6 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -8080,11 +8075,6 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resize-observer-polyfill@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -9448,14 +9438,6 @@ vue-resize@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"
   integrity sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==
-
-vue-responsive-components@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/vue-responsive-components/-/vue-responsive-components-0.2.3.tgz#37b11e4530d9afabf8d41c9bdfced4289037c2c3"
-  integrity sha1-N7EeRTDZr6v41Byb387UKJA3wsM=
-  dependencies:
-    lodash.throttle "^4.1.1"
-    resize-observer-polyfill "^1.5.0"
 
 vue-router@^3.1.6:
   version "3.4.9"


### PR DESCRIPTION
`vue-responsive-components` is only used in one place and at the same time is ~75KB, seems unnecessary for now. 