### PR TITLE
More specific CSS selector for .ticker class

### DIFF
--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -5,6 +5,7 @@
         || feeSelectionOpened
         || statusScreenOpened"
         @close-overlay="onCloseOverlay"
+        class="send-modal"
         :class="{'value-masked': amountsHidden}"
         ref="$modal"
     >
@@ -782,6 +783,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.send-modal {
     .page {
         flex-grow: 1;
         font-size: var(--body-size);
@@ -1187,4 +1189,5 @@ export default defineComponent({
             border-top-right-radius: 1.75rem;
         }
     }
+}
 </style>

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -1379,7 +1379,7 @@ export default defineComponent({
 }
 
 .amount-input.has-value {
-    &.positive-value ::v-deep form{
+    &.positive-value ::v-deep form {
         .nq-input {
             color: var(--nimiq-green);
             --border-color: rgba(33,188,165,0.3); /* Based on Nimiq Green */
@@ -1434,26 +1434,33 @@ export default defineComponent({
     }
 }
 
-.amount-input,
-.new-balances .amount {
+.swap-modal {
     --size: var(--h2-size);
-    font-size: var(--size);
-    font-weight: bold;
 
-    ::v-deep .ticker {
-        // Sometimes this class gets lower priority than the ticker's native class, so we need to force these styles
-        font-size: inherit !important;
-        line-height: 1 !important;
-        margin-left: 0.5rem !important;
+    & ::v-deep .amount-input {
+        font-size: var(--size);
+        font-weight: bold;
+
+        .ticker {
+            line-height: 1;
+            margin-left: 0.5rem;
+            font-size: var(--size);
+        }
     }
 
-    .nq-green & {
-        color: var(--nimiq-green);
+    .new-balances ::v-deep .amount {
+        font-size: var(--size);
+        font-weight: bold;
+
+        .nq-green & {
+            color: var(--nimiq-green);
+        }
+
+        .nq-blue & {
+            color: var(--nimiq-blue);
+        }
     }
 
-    .nq-blue & {
-        color: var(--nimiq-blue);
-    }
 }
 
 .new-balances .fiat-amount {


### PR DESCRIPTION
#### **Reported by**: _Community member_

## Reproduction
1. Open the Swap Modal and close it
2. Open the ⬆️ Send Modal and close it
3. Open the Swap modal again
![image](https://user-images.githubusercontent.com/22072217/156608711-b0c6b2a2-79b0-4c48-97fb-8807b6e2e3ec.png)

> This reproduction is not consistent, and it seems random as many times won't happen.


## What I think is going on?
Once we open the Send Modal, it loads its CSS file in a lazy way (that is way you can see it only after opening this modal). This new CSS loaded from `SendModal` also applies to `SwapModal`. Because both rules for the `.ticker` class in `SendModal` and `SwapModal` have the same specificity, the CSS from `SendModal`, which is newer, overwrites the `SwapModal` rules for `.ticker`.

## Possible solutions
1. A good solution for this, I believe it would be `@layer`, but atm, support for this feature is less than 2% in all browsers
2. Making the specificity higher in `SwapModal`. This seems to work, but not sure, as I told in the Reproduction section, this bug is not consistent and it can be happen again in the future. This PR uses this solution.