### PR TITLE
Fix issue #102

### DIFF
--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -35,7 +35,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { defineComponent, computed, ref, watch, onMounted } from '@vue/composition-api';
+import { defineComponent, computed, ref, watch, onMounted, onActivated } from '@vue/composition-api';
 
 import AddressListItem from './AddressListItem.vue';
 import AddIcon from './icons/AddIcon.vue';
@@ -45,6 +45,7 @@ import { useAccountStore } from '../stores/Account';
 import { useBtcAddressStore } from '../stores/BtcAddress';
 import { CryptoCurrency } from '../lib/Constants';
 import router from '../router';
+import { useSettingsStore } from '../stores/Settings';
 
 export default defineComponent({
     props: {
@@ -66,6 +67,7 @@ export default defineComponent({
         const { availableExternalAddresses, accountBalance } = useBtcAddressStore();
         const { activeCurrency, setActiveCurrency } = useAccountStore();
         const { state: network$ } = useNetworkStore();
+        const { amountsHidden } = useSettingsStore();
 
         function hasLockedBalance(addressInfo: AddressInfo, height: number): boolean {
             if (!addressInfo || addressInfo.type !== AddressType.VESTING) return false;
@@ -122,15 +124,16 @@ export default defineComponent({
             /* context.root.$nextTick works here except for Opera browser. Using setTimeout instead fix it. */
             /* TODO: find a better way to do it. */
             setTimeout(() => {
-                if (activeAddress.value) {
-                    adjustBackgroundOffsetAndScale(activeAddress.value);
-                }
+                if (activeAddress.value) adjustBackgroundOffsetAndScale(activeAddress.value);
             }, 0);
 
             watch(addressInfos, () => {
                 scrollbarVisible.value = !!root.value && root.value.offsetWidth > root.value.scrollWidth;
             });
         });
+
+        onActivated(() => activeAddress.value && adjustBackgroundOffsetAndScale(activeAddress.value));
+        watch(amountsHidden, () => activeAddress.value && adjustBackgroundOffsetAndScale(activeAddress.value));
 
         function selectNimAddress(address: string) {
             adjustBackgroundOffsetAndScale(address);

--- a/src/components/AddressListItem.vue
+++ b/src/components/AddressListItem.vue
@@ -105,14 +105,16 @@ export default defineComponent({
 
 .label {
     font-weight: 600;
-    margin: 0 2rem;
-    flex-grow: 1;
+    padding: 0 2rem;
     text-align: left;
+    flex-shrink: 1;
+    overflow: hidden;
+    mask: linear-gradient(90deg, white, white calc(100% - 3rem), rgba(255, 255, 255, 0));
 }
 
 .balances {
     text-align: right;
-    flex-shrink: 0;
+    flex-grow: 1;
 
     ::v-deep .circle-spinner {
         display: block;


### PR DESCRIPTION
Fix issue #102 

- Force AddressListItem content to respect padding
- Shrink the address label when it’s to long, using a mask to fade out the overflowing content
- Now update the address’ white “active box” when amount are hidden/shown and onActivated hook (so that it update once you get back to it from another view  - Settings or network view for ex.)