### PR TITLE
Add support for old safe send link format

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -336,9 +336,9 @@ const routes: RouteConfig[] = [{
             if (from.fullPath === '/' && to.hash.startsWith('#_request/')) {
                 // old safe links are in this format: /#_request/NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A/100_
                 // new wallet links are in this format: /nimiq:NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A?amount=100
-                const results = to.hash.match(/^#_request\/([A-Z0-9]+)\/?(\d+)?_$/);
-                const address = results?.[1];
-                const amount = results?.[2] ? `?amount=${results?.[2]}` : '';
+                const results = to.hash.match(/^#_request\/(?<address>[A-Z0-9]+)\/?(?<amount>\d+)?_$/);
+                const address = results?.groups?.address;
+                const amount = results?.groups?.amount ? `?amount=${results.groups.amount}` : '';
                 next({
                     name: 'send-via-uri',
                     hash: `nimiq:${address}${amount}`,

--- a/src/router.ts
+++ b/src/router.ts
@@ -332,6 +332,22 @@ const routes: RouteConfig[] = [{
             props: { modal: true },
             meta: { column: Columns.ADDRESS },
         }],
+        beforeEnter: (to, from, next) => {
+            if (from.fullPath === '/' && to.hash.startsWith('#_request/')) {
+                // old safe links are in this format: /#_request/NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A/100_
+                // new wallet links are in this format: /nimiq:NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A?amount=100
+                const results = to.hash.match(/^#_request\/(.+)\/(\d+)_$/);
+                const address = results?.[1];
+                const amount = results?.[2];
+                next({
+                    name: 'send-via-uri',
+                    hash: `nimiq:${address}?amount=${amount}`,
+                    replace: true,
+                });
+            } else {
+                next();
+            }
+        },
     }, {
         path: '/settings',
         components: {

--- a/src/router.ts
+++ b/src/router.ts
@@ -336,12 +336,12 @@ const routes: RouteConfig[] = [{
             if (from.fullPath === '/' && to.hash.startsWith('#_request/')) {
                 // old safe links are in this format: /#_request/NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A/100_
                 // new wallet links are in this format: /nimiq:NQ208P9L3YMDGQYT1TAA8D0GMC125HBQ1Q8A?amount=100
-                const results = to.hash.match(/^#_request\/(.+)\/(\d+)_$/);
+                const results = to.hash.match(/^#_request\/([A-Z0-9]+)\/?(\d+)?_$/);
                 const address = results?.[1];
-                const amount = results?.[2];
+                const amount = results?.[2] ? `?amount=${results?.[2]}` : '';
                 next({
                     name: 'send-via-uri',
-                    hash: `nimiq:${address}?amount=${amount}`,
+                    hash: `nimiq:${address}${amount}`,
                     replace: true,
                 });
             } else {


### PR DESCRIPTION
This PR fixes #24 

Changes:
- Add a route watcher, that transforms old format to new format

Tasks:
- [x] Add support for address + amount
- [x] Add support for address only
