### PR TITLE
Allow search bar to search for label and extradata

### DIFF
--- a/src/components/BtcTransactionListItem.vue
+++ b/src/components/BtcTransactionListItem.vue
@@ -118,6 +118,8 @@ export default defineComponent({
         const transaction = computed(() => props.transaction);
 
         const {
+            amountReceived,
+            amountSent,
             data,
             isCancelledSwap,
             isIncoming,
@@ -129,10 +131,6 @@ export default defineComponent({
             swapInfo,
             swapTransaction,
         } = useBtcTransactionInfo(transaction);
-
-        const amountReceived = computed(() => outputsReceived.value.reduce((sum, output) => sum + output.value, 0));
-
-        const amountSent = computed(() => outputsSent.value.reduce((sum, output) => sum + output.value, 0));
 
         // Date
         const date = computed(() => props.transaction.timestamp && new Date(props.transaction.timestamp * 1000));

--- a/src/components/BtcTransactionListItem.vue
+++ b/src/components/BtcTransactionListItem.vue
@@ -13,7 +13,7 @@
             <CircleSpinner/>
         </div>
         <div
-            v-else-if="state === TransactionState.EXPIRED || state === TransactionState.INVALIDATED"
+            v-else-if="state === TransactionState.INVALIDATED"
             class="invalid nq-red"
         >
             <CrossIcon/>
@@ -42,7 +42,6 @@
             <div class="time-and-message">
                 <span v-if="state === TransactionState.NEW">{{ $t('not sent') }}</span>
                 <span v-else-if="state === TransactionState.PENDING">{{ $t('pending') }}</span>
-                <span v-else-if="state === TransactionState.EXPIRED">{{ $t('expired') }}</span>
                 <span v-else-if="state === TransactionState.INVALIDATED">{{ $t('invalid') }}</span>
                 <span v-else-if="dateTime">{{ dateTime }}</span>
 
@@ -90,12 +89,8 @@ import {
 } from '@nimiq/vue-components';
 import { TransactionState } from '@nimiq/electrum-client';
 import { SwapAsset } from '@nimiq/fastspot-api';
-import { SettlementStatus } from '@nimiq/oasis-api';
-import { useBtcAddressStore } from '../stores/BtcAddress';
 import { useFiatStore } from '../stores/Fiat';
 import { Transaction } from '../stores/BtcTransactions';
-import { useBtcLabelsStore } from '../stores/BtcLabels';
-import { useAccountStore } from '../stores/Account';
 import { twoDigit } from '../lib/NumberFormatting';
 import Avatar from './Avatar.vue';
 import Amount from './Amount.vue';
@@ -105,10 +100,7 @@ import UsdcIcon from './icons/UsdcIcon.vue';
 import BankIcon from './icons/BankIcon.vue';
 import SwapSmallIcon from './icons/SwapSmallIcon.vue';
 import { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS } from '../lib/Constants';
-import { useSwapsStore } from '../stores/Swaps';
-import { useTransactionsStore } from '../stores/Transactions';
-import { useAddressStore } from '../stores/Address';
-import { useOasisPayoutStatusUpdater } from '../composables/useOasisPayoutStatusUpdater';
+import { useBtcTransactionInfo } from '../composables/useBtcTransactionInfo';
 import TransactionListOasisPayoutStatus from './TransactionListOasisPayoutStatus.vue';
 
 export default defineComponent({
@@ -121,186 +113,26 @@ export default defineComponent({
     setup(props, context) {
         const constants = { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS };
 
-        const {
-            state: btcAddresses$,
-            activeInternalAddresses,
-            activeExternalAddresses,
-        } = useBtcAddressStore();
-
-        const {
-            getRecipientLabel,
-            getSenderLabel,
-        } = useBtcLabelsStore();
-
         const state = computed(() => props.transaction.state);
 
-        const inputsSent = computed(() => props.transaction.inputs.filter((input) =>
-            input.address && (activeInternalAddresses.value.includes(input.address)
-                || activeExternalAddresses.value.includes(input.address)
-            ),
-        ));
+        const transaction = computed(() => props.transaction);
 
-        const isIncoming = computed(() => inputsSent.value.length === 0);
+        const {
+            data,
+            isCancelledSwap,
+            isIncoming,
+            peerAddresses,
+            peerLabel,
+            outputsReceived,
+            outputsSent,
+            swapData,
+            swapInfo,
+            swapTransaction,
+        } = useBtcTransactionInfo(transaction);
 
-        const outputsReceived = computed(() => {
-            if (!isIncoming.value) return [];
-
-            const receivedToExternal = props.transaction.outputs
-                .filter((output) => output.address && activeExternalAddresses.value.includes(output.address));
-
-            if (receivedToExternal.length > 0) return receivedToExternal;
-
-            return props.transaction.outputs
-                .filter((output) => output.address && activeInternalAddresses.value.includes(output.address));
-        });
         const amountReceived = computed(() => outputsReceived.value.reduce((sum, output) => sum + output.value, 0));
 
-        const outputsSent = computed(() => isIncoming.value
-            ? []
-            : props.transaction.outputs.filter((output) =>
-                !output.address || !activeInternalAddresses.value.includes(output.address)),
-        );
         const amountSent = computed(() => outputsSent.value.reduce((sum, output) => sum + output.value, 0));
-
-        const { getSwapByTransactionHash } = useSwapsStore();
-        const swapInfo = computed(() => getSwapByTransactionHash.value(props.transaction.transactionHash));
-        const swapData = computed(() => (isIncoming.value ? swapInfo.value?.in : swapInfo.value?.out) || null);
-        useOasisPayoutStatusUpdater(swapData);
-        const isCancelledSwap = computed(() =>
-            swapInfo.value?.in && swapInfo.value?.out && swapInfo.value.in.asset === swapInfo.value.out.asset);
-
-        const swapTransaction = computed(() => {
-            if (!swapData.value) return null;
-
-            if (swapData.value.asset === SwapAsset.NIM) {
-                let swapTx = useTransactionsStore().state.transactions[swapData.value.transactionHash];
-                if (swapTx?.relatedTransactionHash) {
-                    // Avoid showing the swap proxy, instead show our related address. Note that we don't test for
-                    // the swap proxy detection extra data here as the swap tx holds htlc data instead. Only the related
-                    // tx holds the proxy identifying extra data.
-                    swapTx = useTransactionsStore().state.transactions[swapTx.relatedTransactionHash];
-                }
-                return swapTx || null;
-            }
-
-            return null;
-        });
-
-        // Data
-        const data = computed(() => {
-            if (swapData.value) {
-                if (!isCancelledSwap.value) {
-                    const message = context.root.$t('Sent {fromAsset} – Received {toAsset}', {
-                        fromAsset: isIncoming.value ? swapData.value.asset : SwapAsset.BTC,
-                        toAsset: isIncoming.value ? SwapAsset.BTC : swapData.value.asset,
-                    }) as string;
-
-                    // The TransactionListOasisPayoutStatus takes care of the second half of the message
-                    if (
-                        swapData.value.asset === SwapAsset.EUR
-                        && swapData.value.htlc?.settlement
-                        && swapData.value.htlc.settlement.status !== SettlementStatus.CONFIRMED
-                    ) return `${message.split('–')[0]} –`;
-
-                    return message;
-                }
-
-                return isIncoming.value ? context.root.$t('HTLC Refund') : context.root.$t('HTLC Creation');
-            }
-
-            // if ('hashRoot' in props.transaction.data) {
-            //     return context.root.$t('HTLC Creation');
-            // }
-            // if ('creator' in props.transaction.proof) {
-            //     return context.root.$t('HTLC Refund');
-            // }
-            // if ('hashRoot' in props.transaction.proof) {
-            //     return context.root.$t('HTLC Settlement');
-            // }
-
-            return '';
-        });
-
-        // Peer
-        const peerAddresses = computed(() => {
-            if (swapData.value) {
-                if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
-                    const swapPeerAddress = isIncoming.value
-                        ? swapTransaction.value.sender
-                        : swapTransaction.value.recipient;
-                    if (!useAddressStore().state.addressInfos[swapPeerAddress] // not one of our addresses -> proxy
-                        && !swapTransaction.value.relatedTransactionHash) {
-                        // Avoid displaying proxy address identicon until we know related address.
-                        return [''];
-                    }
-                    return [swapPeerAddress];
-                }
-                if (swapData.value.asset === SwapAsset.EUR) return [constants.BANK_ADDRESS];
-            }
-
-            return (isIncoming.value
-                ? props.transaction.inputs.map((input) => input.address || input.script)
-                : outputsSent.value.map((output) => output.address || output.script)
-            ).filter((address, index, array) => array.indexOf(address) === index); // dedupe
-        });
-        const peerLabel = computed(() => {
-            if (isCancelledSwap.value) {
-                return context.root.$t('Cancelled Swap') as string;
-            }
-
-            if (swapData.value) {
-                if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
-                    return useAddressStore().state.addressInfos[peerAddresses.value[0]]?.label
-                        // avoid displaying proxy address until we know related peer address
-                        || context.root.$t('Swap') as string;
-                }
-
-                if (swapData.value.asset === SwapAsset.USDC) {
-                    return context.root.$t('USD Coin') as string;
-                }
-
-                if (swapData.value.asset === SwapAsset.EUR) {
-                    return swapData.value.bankLabel || context.root.$t('Bank Account') as string;
-                }
-
-                return swapData.value.asset.toUpperCase();
-            }
-
-            if (isIncoming.value) {
-                // Search sender labels
-                const ownAddresses = outputsReceived.value.map((output) => output.address);
-                for (const address of ownAddresses) {
-                    if (!address) continue;
-                    const label = getSenderLabel.value(address);
-                    if (label) return label;
-                }
-            } else {
-                // Search recipient labels
-                for (const address of peerAddresses.value) {
-                    const label = getRecipientLabel.value(address);
-                    if (label) return label;
-                }
-            }
-
-            // Search other stored addresses
-            for (const address of peerAddresses.value) {
-                const ownedAddressInfo = btcAddresses$.addressInfos[address];
-                if (ownedAddressInfo) {
-                    // Find account label
-                    const { accountInfos } = useAccountStore();
-                    return Object.values(accountInfos.value)
-                        .find((accountInfo) => accountInfo.btcAddresses.external.includes(address))?.label
-                        || Object.values(accountInfos.value)
-                            .find((accountInfo) => accountInfo.btcAddresses.internal.includes(address))!.label;
-                }
-            }
-
-            // TODO: Search global address book
-            // const globalLabel = AddressBook.getLabel(peerAddress.value);
-            // if (globalLabel) return globalLabel;
-
-            return false;
-        });
 
         // Date
         const date = computed(() => props.transaction.timestamp && new Date(props.transaction.timestamp * 1000));

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -90,7 +90,7 @@ import TransactionListItem from '@/components/TransactionListItem.vue';
 import TestnetFaucet from './TestnetFaucet.vue';
 import CrossCloseButton from './CrossCloseButton.vue';
 import { useAddressStore } from '../stores/Address';
-import { useTransactionsStore /* , Transaction */, TransactionState } from '../stores/Transactions';
+import { useTransactionsStore, Transaction, TransactionState } from '../stores/Transactions';
 import { useContactsStore } from '../stores/Contacts';
 import { useNetworkStore } from '../stores/Network';
 import { parseData } from '../lib/DataFormatting';
@@ -99,6 +99,7 @@ import { isProxyData, ProxyType, ProxyTransactionDirection } from '../lib/ProxyD
 import { createCashlink } from '../hub';
 import { useConfig } from '../composables/useConfig';
 import { useWindowSize } from '../composables/useWindowSize';
+import { useTransactionInfo } from '../composables/useTransactionInfo';
 
 function processTimestamp(timestamp: number) {
     const date: Date = new Date(timestamp);
@@ -190,6 +191,9 @@ export default defineComponent({
             const searchStrings = props.searchString.toUpperCase().split(' ').filter((value) => value !== '');
 
             return txsForActiveAddress.value.filter((tx) => {
+                const transaction = ref<Readonly<Transaction>>(tx);
+                const { peerLabel, data } = useTransactionInfo(transaction);
+
                 const senderLabel = addresses$.addressInfos[tx.sender]
                     ? addresses$.addressInfos[tx.sender].label
                     : getContactLabel.value(tx.sender) || AddressBook.getLabel(tx.sender) || '';
@@ -201,8 +205,10 @@ export default defineComponent({
                 const concatenatedTxStrings = `
                     ${tx.sender.replace(/\s/g, '')}
                     ${tx.recipient.replace(/\s/g, '')}
+                    ${peerLabel.value ? (peerLabel.value as string).toUpperCase() : ''}
                     ${senderLabel ? senderLabel.toUpperCase() : ''}
                     ${recipientLabel ? recipientLabel.toUpperCase() : ''}
+                    ${data.value.toUpperCase()}
                     ${parseData(tx.data.raw).toUpperCase()}
                 `;
                 return searchStrings.every((searchString) => concatenatedTxStrings.includes(searchString));

--- a/src/components/UsdcTransactionList.vue
+++ b/src/components/UsdcTransactionList.vue
@@ -69,12 +69,13 @@ import { defineComponent, computed, ref, Ref, watch, onMounted, onUnmounted } fr
 import { CircleSpinner, HexagonIcon } from '@nimiq/vue-components';
 import UsdcTransactionListItem from '@/components/UsdcTransactionListItem.vue';
 import { useUsdcAddressStore } from '../stores/UsdcAddress';
-import { useUsdcTransactionsStore /* , Transaction */, TransactionState } from '../stores/UsdcTransactions';
+import { useUsdcTransactionsStore, Transaction, TransactionState } from '../stores/UsdcTransactions';
 import { useUsdcContactsStore } from '../stores/UsdcContacts';
 import { useUsdcNetworkStore } from '../stores/UsdcNetwork';
 import { ENV_MAIN } from '../lib/Constants';
 import { useConfig } from '../composables/useConfig';
 import { useWindowSize } from '../composables/useWindowSize';
+import { useUsdcTransactionInfo } from '../composables/useUsdcTransactionInfo';
 
 function processTimestamp(timestamp: number) {
     const date: Date = new Date(timestamp);
@@ -151,6 +152,9 @@ export default defineComponent({
             const searchStrings = props.searchString.toUpperCase().split(' ').filter((value) => value !== '');
 
             return txsForActiveAddress.value.filter((tx) => {
+                const transaction = ref<Readonly<Transaction>>(tx);
+                const { peerLabel, data } = useUsdcTransactionInfo(transaction);
+
                 const senderLabel = getContactLabel.value(tx.sender) || '';
 
                 const recipientLabel = getContactLabel.value(tx.recipient) || '';
@@ -158,6 +162,8 @@ export default defineComponent({
                 const concatenatedTxStrings = `
                     ${tx.sender.replace(/\s/g, '')}
                     ${tx.recipient.replace(/\s/g, '')}
+                    ${peerLabel.value ? (peerLabel.value as string).toUpperCase() : ''}
+                    ${data.value ? (data.value as string).toUpperCase() : ''}
                     ${senderLabel.toUpperCase()}
                     ${recipientLabel.toUpperCase()}
                 `;

--- a/src/composables/useBtcTransactionInfo.ts
+++ b/src/composables/useBtcTransactionInfo.ts
@@ -1,0 +1,211 @@
+import { Ref, computed } from '@vue/composition-api';
+import { SwapAsset } from '@nimiq/fastspot-api';
+import { SettlementStatus } from '@nimiq/oasis-api';
+
+import { useSwapsStore } from '@/stores/Swaps';
+import { Transaction } from '@/stores/BtcTransactions';
+import { useTransactionsStore } from '@/stores/Transactions';
+import { useBtcLabelsStore } from '@/stores/BtcLabels';
+import { useBtcAddressStore } from '@/stores/BtcAddress';
+import { useAddressStore } from '@/stores/Address';
+import { useAccountStore } from '@/stores/Account';
+
+import { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS } from '@/lib/Constants';
+
+import { i18n } from '@/i18n/i18n-setup';
+import { useOasisPayoutStatusUpdater } from './useOasisPayoutStatusUpdater';
+
+export function useBtcTransactionInfo(transaction: Ref<Transaction>) {
+    const constants = { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS };
+
+    const {
+        state: btcAddresses$,
+        activeInternalAddresses,
+        activeExternalAddresses,
+    } = useBtcAddressStore();
+
+    const {
+        getRecipientLabel,
+        getSenderLabel,
+    } = useBtcLabelsStore();
+
+    const inputsSent = computed(() => transaction.value.inputs.filter((input) =>
+        input.address && (activeInternalAddresses.value.includes(input.address)
+            || activeExternalAddresses.value.includes(input.address)
+        ),
+    ));
+
+    const isIncoming = computed(() => inputsSent.value.length === 0);
+
+    const { getSwapByTransactionHash } = useSwapsStore();
+    const swapInfo = computed(() => getSwapByTransactionHash.value(transaction.value.transactionHash));
+    const swapData = computed(() => (isIncoming.value ? swapInfo.value?.in : swapInfo.value?.out) || null);
+    useOasisPayoutStatusUpdater(swapData);
+    const isCancelledSwap = computed(() =>
+        swapInfo.value?.in && swapInfo.value?.out && swapInfo.value.in.asset === swapInfo.value.out.asset);
+
+    const swapTransaction = computed(() => {
+        if (!swapData.value) return null;
+
+        if (swapData.value.asset === SwapAsset.NIM) {
+            let swapTx = useTransactionsStore().state.transactions[swapData.value.transactionHash];
+            if (swapTx?.relatedTransactionHash) {
+                // Avoid showing the swap proxy, instead show our related address. Note that we don't test for
+                // the swap proxy detection extra data here as the swap tx holds htlc data instead. Only the related
+                // tx holds the proxy identifying extra data.
+                swapTx = useTransactionsStore().state.transactions[swapTx.relatedTransactionHash];
+            }
+            return swapTx || null;
+        }
+
+        return null;
+    });
+
+    const outputsReceived = computed(() => {
+        if (!isIncoming.value) return [];
+
+        const receivedToExternal = transaction.value.outputs
+            .filter((output) => output.address && activeExternalAddresses.value.includes(output.address));
+
+        if (receivedToExternal.length > 0) return receivedToExternal;
+
+        return transaction.value.outputs
+            .filter((output) => output.address && activeInternalAddresses.value.includes(output.address));
+    });
+
+    const outputsSent = computed(() => isIncoming.value
+        ? []
+        : transaction.value.outputs.filter((output) =>
+            !output.address || !activeInternalAddresses.value.includes(output.address)),
+    );
+
+    // Peer
+    const peerAddresses = computed(() => {
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
+                const swapPeerAddress = isIncoming.value
+                    ? swapTransaction.value.sender
+                    : swapTransaction.value.recipient;
+                if (!useAddressStore().state.addressInfos[swapPeerAddress] // not one of our addresses -> proxy
+                    && !swapTransaction.value.relatedTransactionHash) {
+                    // Avoid displaying proxy address identicon until we know related address.
+                    return [''];
+                }
+                return [swapPeerAddress];
+            }
+            if (swapData.value.asset === SwapAsset.EUR) return [constants.BANK_ADDRESS];
+        }
+
+        return (isIncoming.value
+            ? transaction.value.inputs.map((input) => input.address || input.script)
+            : outputsSent.value.map((output) => output.address || output.script)
+        ).filter((address, index, array) => array.indexOf(address) === index); // dedupe
+    });
+
+    const peerLabel = computed(() => {
+        if (isCancelledSwap.value) {
+            return i18n.t('Cancelled Swap') as string;
+        }
+
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
+                return useAddressStore().state.addressInfos[peerAddresses.value[0]]?.label
+                    // avoid displaying proxy address until we know related peer address
+                    || i18n.t('Swap') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.USDC) {
+                return i18n.t('USD Coin') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.EUR) {
+                return swapData.value.bankLabel || i18n.t('Bank Account') as string;
+            }
+
+            return swapData.value.asset.toUpperCase();
+        }
+
+        if (isIncoming.value) {
+            // Search sender labels
+            const ownAddresses = outputsReceived.value.map((output) => output.address);
+            for (const address of ownAddresses) {
+                if (!address) continue;
+                const label = getSenderLabel.value(address);
+                if (label) return label;
+            }
+        } else {
+            // Search recipient labels
+            for (const address of peerAddresses.value) {
+                const label = getRecipientLabel.value(address);
+                if (label) return label;
+            }
+        }
+
+        // Search other stored addresses
+        for (const address of peerAddresses.value) {
+            const ownedAddressInfo = btcAddresses$.addressInfos[address];
+            if (ownedAddressInfo) {
+                // Find account label
+                const { accountInfos } = useAccountStore();
+                return Object.values(accountInfos.value)
+                    .find((accountInfo) => accountInfo.btcAddresses.external.includes(address))?.label
+                    || Object.values(accountInfos.value)
+                        .find((accountInfo) => accountInfo.btcAddresses.internal.includes(address))!.label;
+            }
+        }
+
+        // TODO: Search global address book
+        // const globalLabel = AddressBook.getLabel(peerAddress.value);
+        // if (globalLabel) return globalLabel;
+
+        return false;
+    });
+
+    // Data
+    const data = computed(() => {
+        if (swapData.value) {
+            if (!isCancelledSwap.value) {
+                const message = i18n.t('Sent {fromAsset} – Received {toAsset}', {
+                    fromAsset: isIncoming.value ? swapData.value.asset : SwapAsset.BTC,
+                    toAsset: isIncoming.value ? SwapAsset.BTC : swapData.value.asset,
+                }) as string;
+
+                // The TransactionListOasisPayoutStatus takes care of the second half of the message
+                if (
+                    swapData.value.asset === SwapAsset.EUR
+                    && swapData.value.htlc?.settlement
+                    && swapData.value.htlc.settlement.status !== SettlementStatus.CONFIRMED
+                ) return `${message.split('–')[0]} –`;
+
+                return message;
+            }
+
+            return isIncoming.value ? i18n.t('HTLC Refund') : i18n.t('HTLC Creation');
+        }
+
+        // if ('hashRoot' in props.transaction.data) {
+        //     return context.root.$t('HTLC Creation');
+        // }
+        // if ('creator' in props.transaction.proof) {
+        //     return context.root.$t('HTLC Refund');
+        // }
+        // if ('hashRoot' in props.transaction.proof) {
+        //     return context.root.$t('HTLC Settlement');
+        // }
+
+        return '';
+    });
+
+    return {
+        data,
+        isCancelledSwap,
+        isIncoming,
+        peerAddresses,
+        peerLabel,
+        outputsReceived,
+        outputsSent,
+        swapData,
+        swapInfo,
+        swapTransaction,
+    };
+}

--- a/src/composables/useTransactionInfo.ts
+++ b/src/composables/useTransactionInfo.ts
@@ -1,0 +1,186 @@
+import { Ref, computed } from '@vue/composition-api';
+import { SwapAsset } from '@nimiq/fastspot-api';
+import { AddressBook } from '@nimiq/utils';
+import { SettlementStatus } from '@nimiq/oasis-api';
+
+import { useSwapsStore } from '@/stores/Swaps';
+import { Transaction, useTransactionsStore } from '@/stores/Transactions';
+import { useAddressStore } from '@/stores/Address';
+import { useContactsStore } from '@/stores/Contacts';
+import { useProxyStore } from '@/stores/Proxy';
+
+import { FIAT_PRICE_UNAVAILABLE, CASHLINK_ADDRESS, BANK_ADDRESS } from '@/lib/Constants';
+import { isProxyData, ProxyType } from '@/lib/ProxyDetection';
+import { parseData } from '@/lib/DataFormatting';
+
+import { i18n } from '@/i18n/i18n-setup';
+import { useOasisPayoutStatusUpdater } from './useOasisPayoutStatusUpdater';
+
+export function useTransactionInfo(transaction: Ref<Transaction>) {
+    const constants = { FIAT_PRICE_UNAVAILABLE, CASHLINK_ADDRESS, BANK_ADDRESS };
+
+    const { activeAddress, state: addresses$ } = useAddressStore();
+    const { getLabel } = useContactsStore();
+
+    const isIncoming = computed(() => { // eslint-disable-line arrow-body-style
+        // const haveSender = !!addresses$.addressInfos[props.transaction.sender];
+        // const haveRecipient = !!addresses$.addressInfos[props.transaction.recipient];
+
+        // if (haveSender && !haveRecipient) return false;
+        // if (!haveSender && haveRecipient) return true;
+
+        // Fall back to comparing with active address
+        return transaction.value.recipient === activeAddress.value;
+    });
+
+    // Related Transaction
+    const { state: transactions$ } = useTransactionsStore();
+    const relatedTx = computed(() => {
+        if (!transaction.value.relatedTransactionHash) return null;
+        return transactions$.transactions[transaction.value.relatedTransactionHash] || null;
+    });
+
+    const { getSwapByTransactionHash } = useSwapsStore();
+    const swapInfo = computed(() => getSwapByTransactionHash.value(transaction.value.transactionHash)
+            || (transaction.value.relatedTransactionHash
+                ? getSwapByTransactionHash.value(transaction.value.relatedTransactionHash)
+                : null));
+    const swapData = computed(() => (isIncoming.value ? swapInfo.value?.in : swapInfo.value?.out) || null);
+    useOasisPayoutStatusUpdater(swapData);
+
+    // Note: the htlc proxy tx that is not funding or redeeming the htlc itself, i.e. the one we are displaying here
+    // related to our address, always holds the proxy data.
+    const isSwapProxy = computed(() => isProxyData(transaction.value.data.raw, ProxyType.HTLC_PROXY));
+    const isCancelledSwap = computed(() =>
+        (swapInfo.value?.in && swapInfo.value?.out && swapInfo.value.in.asset === swapInfo.value.out.asset)
+            // Funded proxy and then refunded without creating an actual htlc?
+            || (isSwapProxy.value && (isIncoming.value
+                ? transaction.value.recipient === relatedTx.value?.sender
+                : transaction.value.sender === relatedTx.value?.recipient)));
+
+    // Data
+    const isCashlink = computed(() => isProxyData(transaction.value.data.raw, ProxyType.CASHLINK));
+
+    // Peer
+    const peerAddress = computed(() => {
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.BTC) return 'bitcoin';
+            if (swapData.value.asset === SwapAsset.EUR) return constants.BANK_ADDRESS;
+        }
+
+        // For Cashlinks and swap proxies
+        if (relatedTx.value) {
+            return isIncoming.value
+                ? relatedTx.value.sender // This is a claiming tx, so the related tx is the funding one
+                : relatedTx.value.recipient; // This is a funding tx, so the related tx is the claiming one
+        }
+
+        if (isSwapProxy.value) return ''; // avoid displaying proxy address identicon until we know related address
+
+        if (isCashlink.value) return constants.CASHLINK_ADDRESS; // No related tx yet, show placeholder
+
+        return isIncoming.value ? transaction.value.sender : transaction.value.recipient;
+    });
+    const peerLabel = computed(() => {
+        if (isSwapProxy.value && !relatedTx.value) {
+            return i18n.t('Swap'); // avoid displaying the proxy address until we know related peer address
+        }
+
+        if (isCancelledSwap.value) {
+            return i18n.t('Cancelled Swap');
+        }
+
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.BTC) {
+                return i18n.t('Bitcoin') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.USDC) {
+                return i18n.t('USD Coin') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.EUR) {
+                return swapData.value.bankLabel || i18n.t('Bank Account') as string;
+            }
+
+            return swapData.value.asset.toUpperCase();
+        }
+
+        // Label cashlinks
+        if (peerAddress.value === constants.CASHLINK_ADDRESS) {
+            return isIncoming.value
+                ? i18n.t('Cashlink') as string
+                : i18n.t('Unclaimed Cashlink') as string;
+        }
+
+        // Search other stored addresses
+        const ownedAddressInfo = addresses$.addressInfos[peerAddress.value];
+        if (ownedAddressInfo) return ownedAddressInfo.label;
+
+        // Search contacts
+        if (getLabel.value(peerAddress.value)) return getLabel.value(peerAddress.value)!;
+
+        // Search global address book
+        const globalLabel = AddressBook.getLabel(peerAddress.value);
+        if (globalLabel) return globalLabel;
+
+        return false;
+    });
+
+    // Data
+    const data = computed(() => {
+        if (isCashlink.value) {
+            const { state: proxies$ } = useProxyStore();
+            const cashlinkAddress = isIncoming.value ? transaction.value.sender : transaction.value.recipient;
+            const hubCashlink = proxies$.hubCashlinks[cashlinkAddress];
+            if (hubCashlink && hubCashlink.message) return hubCashlink.message;
+        }
+
+        if (swapData.value && !isCancelledSwap.value) {
+            const message = i18n.t('Sent {fromAsset} – Received {toAsset}', {
+                fromAsset: isIncoming.value ? swapData.value.asset : SwapAsset.NIM,
+                toAsset: isIncoming.value ? SwapAsset.NIM : swapData.value.asset,
+            }) as string;
+
+            // The TransactionListOasisPayoutStatus takes care of the second half of the message
+            if (
+                swapData.value.asset === SwapAsset.EUR
+                && swapData.value.htlc?.settlement
+                && swapData.value.htlc.settlement.status !== SettlementStatus.CONFIRMED
+            ) return `${message.split('–')[0]} –`;
+
+            return message;
+        }
+
+        if ('hashRoot' in transaction.value.data
+            || (relatedTx.value && 'hashRoot' in relatedTx.value.data)) {
+            return i18n.t('HTLC Creation') as string;
+        }
+        if ('hashRoot' in transaction.value.proof
+            || (relatedTx.value && 'hashRoot' in relatedTx.value.proof)) {
+            return i18n.t('HTLC Settlement') as string;
+        }
+        if ('creator' in transaction.value.proof
+            || (relatedTx.value && 'creator' in relatedTx.value.proof)
+            // if we have an incoming tx from a HTLC proxy but none of the above conditions met, the tx and related
+            // tx are regular transactions and we regard the tx from the proxy as refund
+            || (relatedTx.value && isSwapProxy.value && isIncoming.value)) {
+            return i18n.t('HTLC Refund') as string;
+        }
+
+        return parseData(transaction.value.data.raw);
+    });
+
+    return {
+        data,
+        isCancelledSwap,
+        isCashlink,
+        isIncoming,
+        isSwapProxy,
+        peerAddress,
+        peerLabel,
+        relatedTx,
+        swapData,
+        swapInfo,
+    };
+}

--- a/src/composables/useUsdcTransactionInfo.ts
+++ b/src/composables/useUsdcTransactionInfo.ts
@@ -1,0 +1,197 @@
+import { Ref, computed } from '@vue/composition-api';
+import { SwapAsset } from '@nimiq/fastspot-api';
+import { SettlementStatus } from '@nimiq/oasis-api';
+
+import { useSwapsStore } from '@/stores/Swaps';
+import { Transaction } from '@/stores/UsdcTransactions';
+import { useTransactionsStore } from '@/stores/Transactions';
+import { useUsdcContactsStore } from '@/stores/UsdcContacts';
+import { useUsdcAddressStore } from '@/stores/UsdcAddress';
+import { useAddressStore } from '@/stores/Address';
+import { useAccountStore } from '@/stores/Account';
+
+import { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS } from '@/lib/Constants';
+
+import { i18n } from '@/i18n/i18n-setup';
+import { useOasisPayoutStatusUpdater } from './useOasisPayoutStatusUpdater';
+
+export function useUsdcTransactionInfo(transaction: Ref<Transaction>) {
+    const constants = { FIAT_PRICE_UNAVAILABLE, BANK_ADDRESS };
+
+    const { addressInfo, state: addresses$ } = useUsdcAddressStore();
+    const { getLabel } = useUsdcContactsStore();
+
+    const isIncoming = computed(() => { // eslint-disable-line arrow-body-style
+        // const haveSender = !!addresses$.addressInfos[props.transaction.sender];
+        // const haveRecipient = !!addresses$.addressInfos[props.transaction.recipient];
+
+        // if (haveSender && !haveRecipient) return false;
+        // if (!haveSender && haveRecipient) return true;
+
+        // Fall back to comparing with active address
+        return transaction.value.recipient === addressInfo.value?.address;
+    });
+
+    // Related Transaction
+    // const { state: transactions$ } = useUsdcTransactionsStore();
+    // const relatedTx = computed(() => {
+    //     if (!props.transaction.relatedTransactionHash) return null;
+    //     return transactions$.transactions[props.transaction.relatedTransactionHash] || null;
+    // });
+
+    const { getSwapByTransactionHash } = useSwapsStore();
+    const swapInfo = computed(() => getSwapByTransactionHash.value(transaction.value.transactionHash),
+        /* || (props.transaction.relatedTransactionHash
+                ? getSwapByTransactionHash.value(props.transaction.relatedTransactionHash)
+                : null) */);
+    const swapData = computed(() => (isIncoming.value ? swapInfo.value?.in : swapInfo.value?.out) || null);
+    useOasisPayoutStatusUpdater(swapData);
+    // // Note: the htlc proxy tx that is not funding or redeeming the htlc itself, i.e. the one we
+    // // are displaying here related to our address, always holds the proxy data.
+    // const isSwapProxy = computed(() => isProxyData(props.transaction.data.raw, ProxyType.HTLC_PROXY));
+    const isCancelledSwap = computed(() =>
+        (swapInfo.value?.in && swapInfo.value?.out && swapInfo.value.in.asset === swapInfo.value.out.asset));
+    // // Funded proxy and then refunded without creating an actual htlc?
+    // || (isSwapProxy.value && (isIncoming.value
+    //     ? props.transaction.recipient === relatedTx.value?.sender
+    //     : props.transaction.sender === relatedTx.value?.recipient)));
+
+    const swapTransaction = computed(() => {
+        if (!swapData.value) return null;
+
+        if (swapData.value.asset === SwapAsset.NIM) {
+            let swapTx = useTransactionsStore().state.transactions[swapData.value.transactionHash];
+            if (swapTx?.relatedTransactionHash) {
+                // Avoid showing the swap proxy, instead show our related address. Note that we don't test for
+                // the swap proxy detection extra data here as the swap tx holds htlc data instead. Only the related
+                // tx holds the proxy identifying extra data.
+                swapTx = useTransactionsStore().state.transactions[swapTx.relatedTransactionHash];
+            }
+            return swapTx || null;
+        }
+
+        return null;
+    });
+
+    // Peer
+    const peerAddress = computed(() => {
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
+                const swapPeerAddress = isIncoming.value
+                    ? swapTransaction.value.sender
+                    : swapTransaction.value.recipient;
+                if (!useAddressStore().state.addressInfos[swapPeerAddress] // not one of our addresses -> proxy
+                    && !swapTransaction.value.relatedTransactionHash) {
+                    // Avoid displaying proxy address identicon until we know related address.
+                    return '';
+                }
+                return swapPeerAddress;
+            }
+            if (swapData.value.asset === SwapAsset.BTC) return 'bitcoin';
+            if (swapData.value.asset === SwapAsset.EUR) return constants.BANK_ADDRESS;
+        }
+
+        // For swap proxies
+        // if (relatedTx.value) {
+        //     return isIncoming.value
+        //         ? relatedTx.value.sender // This is a claiming tx, so the related tx is the funding one
+        //         : relatedTx.value.recipient; // This is a funding tx, so the related tx is the claiming one
+        // }
+
+        // eslint-disable-next-line max-len
+        // if (isSwapProxy.value) return ''; // avoid displaying proxy address identicon until we know related address
+
+        return isIncoming.value ? transaction.value.sender : transaction.value.recipient;
+    });
+    const peerLabel = computed(() => {
+        /* eslint-disable max-len */
+        // if (isSwapProxy.value && !relatedTx.value) {
+        //     return context.root.$t('Swap'); // avoid displaying the proxy address until we know related peer address
+        // }
+        /* eslint-enable max-len */
+
+        if (isCancelledSwap.value) {
+            return i18n.t('Cancelled Swap') as string;
+        }
+
+        if (swapData.value) {
+            if (swapData.value.asset === SwapAsset.NIM && swapTransaction.value) {
+                return useAddressStore().state.addressInfos[peerAddress.value]?.label
+                    // avoid displaying proxy address until we know related peer address
+                    || i18n.t('Swap') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.BTC) {
+                return i18n.t('Bitcoin') as string;
+            }
+
+            if (swapData.value.asset === SwapAsset.EUR) {
+                return swapData.value.bankLabel || i18n.t('Bank Account') as string;
+            }
+
+            return swapData.value.asset.toUpperCase();
+        }
+
+        // Search other stored addresses
+        const ownedAddressInfo = addresses$.addressInfos[peerAddress.value];
+        if (ownedAddressInfo) {
+            // Find account label
+            const { accountInfos } = useAccountStore();
+            return Object.values(accountInfos.value)
+                .find((accountInfo) => accountInfo
+                    .polygonAddresses?.includes(ownedAddressInfo.address))?.label || false;
+        }
+
+        // Search contacts
+        if (getLabel.value(peerAddress.value)) return getLabel.value(peerAddress.value)!;
+
+        return false;
+    });
+
+    // Data
+    const data = computed(() => { // eslint-disable-line arrow-body-style
+        if (swapData.value && !isCancelledSwap.value) {
+            const message = i18n.t('Sent {fromAsset} – Received {toAsset}', {
+                fromAsset: isIncoming.value ? swapData.value.asset : SwapAsset.USDC,
+                toAsset: isIncoming.value ? SwapAsset.USDC : swapData.value.asset,
+            }) as string;
+
+            // The TransactionListOasisPayoutStatus takes care of the second half of the message
+            if (
+                swapData.value.asset === SwapAsset.EUR
+                && swapData.value.htlc?.settlement
+                && swapData.value.htlc.settlement.status !== SettlementStatus.CONFIRMED
+            ) return `${message.split('–')[0]} –`;
+
+            return message;
+        }
+
+        if (transaction.value.event?.name === 'Open'
+        /* || (relatedTx.value && 'hashRoot' in relatedTx.value.data) */) {
+            return i18n.t('HTLC Creation') as string;
+        }
+        if (transaction.value.event?.name === 'Redeem'
+        /* || (relatedTx.value && 'hashRoot' in relatedTx.value.proof) */) {
+            return i18n.t('HTLC Settlement') as string;
+        }
+        if (transaction.value.event?.name === 'Refund'
+        /* || (relatedTx.value && 'creator' in relatedTx.value.proof)
+            // if we have an incoming tx from a HTLC proxy but none of the above conditions met, the tx and related
+            // tx are regular transactions and we regard the tx from the proxy as refund
+            || (relatedTx.value && isSwapProxy.value && isIncoming.value) */) {
+            return i18n.t('HTLC Refund') as string;
+        }
+
+        return null;
+    });
+
+    return {
+        data,
+        isCancelledSwap,
+        isIncoming,
+        peerAddress,
+        peerLabel,
+        swapData,
+        swapInfo,
+    };
+}

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -372,12 +372,12 @@ msgstr ""
 msgid "Back to Bank Details"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:263
 #: src/components/modals/BtcTransactionModal.vue:505
 #: src/components/modals/TransactionModal.vue:562
 #: src/components/modals/UsdcTransactionModal.vue:421
-#: src/components/TransactionListItem.vue:242
-#: src/components/UsdcTransactionListItem.vue:260
+#: src/composables/useBtcTransactionInfo.ts:121
+#: src/composables/useTransactionInfo.ts:100
+#: src/composables/useUsdcTransactionInfo.ts:129
 msgid "Bank Account"
 msgstr ""
 
@@ -404,8 +404,8 @@ msgstr ""
 #: src/components/modals/BtcTransactionModal.vue:128
 #: src/components/modals/TransactionModal.vue:554
 #: src/components/modals/UsdcTransactionModal.vue:417
-#: src/components/TransactionListItem.vue:234
-#: src/components/UsdcTransactionListItem.vue:256
+#: src/composables/useTransactionInfo.ts:92
+#: src/composables/useUsdcTransactionInfo.ts:125
 msgid "Bitcoin"
 msgstr ""
 
@@ -525,15 +525,15 @@ msgstr ""
 msgid "Cancel Swap"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:248
 #: src/components/modals/BtcTransactionModal.vue:490
 #: src/components/modals/BtcTransactionModal.vue:6
 #: src/components/modals/TransactionModal.vue:5
 #: src/components/modals/TransactionModal.vue:549
 #: src/components/modals/UsdcTransactionModal.vue:406
 #: src/components/modals/UsdcTransactionModal.vue:6
-#: src/components/TransactionListItem.vue:229
-#: src/components/UsdcTransactionListItem.vue:245
+#: src/composables/useBtcTransactionInfo.ts:106
+#: src/composables/useTransactionInfo.ts:87
+#: src/composables/useUsdcTransactionInfo.ts:114
 msgid "Cancelled Swap"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 
 #: src/components/modals/TransactionModal.vue:571
 #: src/components/TransactionList.vue:62
-#: src/components/TransactionListItem.vue:251
+#: src/composables/useTransactionInfo.ts:109
 msgid "Cashlink"
 msgstr ""
 
@@ -925,7 +925,6 @@ msgstr ""
 msgid "Exchange rate"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:45
 #: src/components/TransactionListItem.vue:39
 #: src/components/UsdcTransactionListItem.vue:37
 msgid "expired"
@@ -1003,7 +1002,7 @@ msgstr ""
 msgid "Fetching"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:66
+#: src/components/BtcTransactionListItem.vue:65
 #: src/components/modals/TransactionModal.vue:206
 #: src/components/TransactionListItem.vue:57
 #: src/components/UsdcTransactionListItem.vue:55
@@ -1129,26 +1128,26 @@ msgstr ""
 msgid "Historic value"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:208
+#: src/components/BtcTransactionListItem.vue:156
 #: src/components/modals/BtcTransactionModal.vue:454
 #: src/components/modals/TransactionModal.vue:488
-#: src/components/TransactionListItem.vue:186
-#: src/components/UsdcTransactionListItem.vue:190
+#: src/components/TransactionListItem.vue:156
+#: src/composables/useUsdcTransactionInfo.ts:171
 #: src/lib/DataFormatting.ts:21
 msgid "HTLC Creation"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:208
+#: src/components/BtcTransactionListItem.vue:156
 #: src/components/modals/BtcTransactionModal.vue:454
 #: src/components/modals/TransactionModal.vue:499
-#: src/components/TransactionListItem.vue:197
-#: src/components/UsdcTransactionListItem.vue:201
+#: src/components/TransactionListItem.vue:167
+#: src/composables/useUsdcTransactionInfo.ts:182
 msgid "HTLC Refund"
 msgstr ""
 
 #: src/components/modals/TransactionModal.vue:492
-#: src/components/TransactionListItem.vue:190
-#: src/components/UsdcTransactionListItem.vue:194
+#: src/components/TransactionListItem.vue:160
+#: src/composables/useUsdcTransactionInfo.ts:175
 msgid "HTLC Settlement"
 msgstr ""
 
@@ -1223,7 +1222,7 @@ msgstr ""
 msgid "Insufficient balance."
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:46
+#: src/components/BtcTransactionListItem.vue:45
 #: src/components/TransactionListItem.vue:40
 #: src/components/UsdcTransactionListItem.vue:38
 msgid "invalid"
@@ -1880,9 +1879,9 @@ msgstr ""
 msgid "Sent {btc} BTC to {name}"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:193
-#: src/components/TransactionListItem.vue:169
-#: src/components/UsdcTransactionListItem.vue:173
+#: src/components/BtcTransactionListItem.vue:141
+#: src/components/TransactionListItem.vue:139
+#: src/composables/useUsdcTransactionInfo.ts:154
 msgid "Sent {fromAsset} – Received {toAsset}"
 msgstr ""
 
@@ -2044,7 +2043,6 @@ msgid "Super low fees, super fast payments"
 msgstr ""
 
 #. avoid displaying the proxy address until we know related peer address
-#: src/components/BtcTransactionListItem.vue:255
 #: src/components/layouts/Sidebar.vue:115
 #: src/components/modals/BtcTransactionModal.vue:497
 #: src/components/modals/BtcTransactionModal.vue:9
@@ -2052,8 +2050,9 @@ msgstr ""
 #: src/components/modals/TransactionModal.vue:7
 #: src/components/modals/UsdcTransactionModal.vue:413
 #: src/components/modals/UsdcTransactionModal.vue:9
-#: src/components/TransactionListItem.vue:225
-#: src/components/UsdcTransactionListItem.vue:252
+#: src/composables/useBtcTransactionInfo.ts:113
+#: src/composables/useTransactionInfo.ts:83
+#: src/composables/useUsdcTransactionInfo.ts:121
 msgid "Swap"
 msgstr ""
 
@@ -2253,12 +2252,12 @@ msgstr ""
 msgid "This might take up to {min} minutes."
 msgstr ""
 
-#: src/components/BtcTransactionList.vue:232
-#: src/components/BtcTransactionList.vue:254
-#: src/components/TransactionList.vue:247
-#: src/components/TransactionList.vue:269
-#: src/components/UsdcTransactionList.vue:197
-#: src/components/UsdcTransactionList.vue:219
+#: src/components/BtcTransactionList.vue:240
+#: src/components/BtcTransactionList.vue:262
+#: src/components/TransactionList.vue:252
+#: src/components/TransactionList.vue:274
+#: src/components/UsdcTransactionList.vue:202
+#: src/components/UsdcTransactionList.vue:224
 msgid "This month"
 msgstr ""
 
@@ -2351,7 +2350,7 @@ msgid "Tx time"
 msgstr ""
 
 #: src/components/modals/TransactionModal.vue:572
-#: src/components/TransactionListItem.vue:252
+#: src/composables/useTransactionInfo.ts:110
 msgid "Unclaimed Cashlink"
 msgstr ""
 
@@ -2393,13 +2392,13 @@ msgid "Update now"
 msgstr ""
 
 #: src/components/AddressList.vue:179
-#: src/components/BtcTransactionListItem.vue:259
 #: src/components/layouts/AccountOverview.vue:158
 #: src/components/layouts/AddressOverview.vue:84
 #: src/components/modals/BtcTransactionModal.vue:501
 #: src/components/modals/TransactionModal.vue:558
-#: src/components/TransactionListItem.vue:238
 #: src/components/UsdcAddressInfo.vue:12
+#: src/composables/useBtcTransactionInfo.ts:117
+#: src/composables/useTransactionInfo.ts:96
 msgid "USD Coin"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -372,11 +372,8 @@ msgstr ""
 msgid "Back to Bank Details"
 msgstr ""
 
-#: src/components/modals/BtcTransactionModal.vue:505
-#: src/components/modals/TransactionModal.vue:562
-#: src/components/modals/UsdcTransactionModal.vue:421
-#: src/composables/useBtcTransactionInfo.ts:121
-#: src/composables/useTransactionInfo.ts:100
+#: src/composables/useBtcTransactionInfo.ts:125
+#: src/composables/useTransactionInfo.ts:103
 #: src/composables/useUsdcTransactionInfo.ts:129
 msgid "Bank Account"
 msgstr ""
@@ -402,9 +399,7 @@ msgstr ""
 #: src/components/LegacyAccountNotice.vue:21
 #: src/components/modals/BtcTransactionModal.vue:116
 #: src/components/modals/BtcTransactionModal.vue:128
-#: src/components/modals/TransactionModal.vue:554
-#: src/components/modals/UsdcTransactionModal.vue:417
-#: src/composables/useTransactionInfo.ts:92
+#: src/composables/useTransactionInfo.ts:95
 #: src/composables/useUsdcTransactionInfo.ts:125
 msgid "Bitcoin"
 msgstr ""
@@ -525,14 +520,11 @@ msgstr ""
 msgid "Cancel Swap"
 msgstr ""
 
-#: src/components/modals/BtcTransactionModal.vue:490
 #: src/components/modals/BtcTransactionModal.vue:6
 #: src/components/modals/TransactionModal.vue:5
-#: src/components/modals/TransactionModal.vue:549
-#: src/components/modals/UsdcTransactionModal.vue:406
 #: src/components/modals/UsdcTransactionModal.vue:6
-#: src/composables/useBtcTransactionInfo.ts:106
-#: src/composables/useTransactionInfo.ts:87
+#: src/composables/useBtcTransactionInfo.ts:110
+#: src/composables/useTransactionInfo.ts:90
 #: src/composables/useUsdcTransactionInfo.ts:114
 msgid "Cancelled Swap"
 msgstr ""
@@ -541,9 +533,8 @@ msgstr ""
 msgid "Cannot import contacts, wrong file format."
 msgstr ""
 
-#: src/components/modals/TransactionModal.vue:571
 #: src/components/TransactionList.vue:62
-#: src/composables/useTransactionInfo.ts:109
+#: src/composables/useTransactionInfo.ts:112
 msgid "Cashlink"
 msgstr ""
 
@@ -1128,25 +1119,25 @@ msgstr ""
 msgid "Historic value"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:156
-#: src/components/modals/BtcTransactionModal.vue:454
-#: src/components/modals/TransactionModal.vue:488
-#: src/components/TransactionListItem.vue:156
+#: src/components/modals/BtcTransactionModal.vue:434
+#: src/components/modals/TransactionModal.vue:474
+#: src/composables/useBtcTransactionInfo.ts:186
+#: src/composables/useTransactionInfo.ts:157
 #: src/composables/useUsdcTransactionInfo.ts:171
 #: src/lib/DataFormatting.ts:21
 msgid "HTLC Creation"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:156
-#: src/components/modals/BtcTransactionModal.vue:454
-#: src/components/modals/TransactionModal.vue:499
-#: src/components/TransactionListItem.vue:167
+#: src/components/modals/BtcTransactionModal.vue:434
+#: src/components/modals/TransactionModal.vue:485
+#: src/composables/useBtcTransactionInfo.ts:186
+#: src/composables/useTransactionInfo.ts:168
 #: src/composables/useUsdcTransactionInfo.ts:182
 msgid "HTLC Refund"
 msgstr ""
 
-#: src/components/modals/TransactionModal.vue:492
-#: src/components/TransactionListItem.vue:160
+#: src/components/modals/TransactionModal.vue:478
+#: src/composables/useTransactionInfo.ts:161
 #: src/composables/useUsdcTransactionInfo.ts:175
 msgid "HTLC Settlement"
 msgstr ""
@@ -1685,7 +1676,7 @@ msgstr ""
 msgid "Refund"
 msgstr ""
 
-#: src/components/modals/UsdcTransactionModal.vue:565
+#: src/components/modals/UsdcTransactionModal.vue:531
 msgid "Refund failed: "
 msgstr ""
 
@@ -1879,8 +1870,8 @@ msgstr ""
 msgid "Sent {btc} BTC to {name}"
 msgstr ""
 
-#: src/components/BtcTransactionListItem.vue:141
-#: src/components/TransactionListItem.vue:139
+#: src/composables/useBtcTransactionInfo.ts:171
+#: src/composables/useTransactionInfo.ts:140
 #: src/composables/useUsdcTransactionInfo.ts:154
 msgid "Sent {fromAsset} – Received {toAsset}"
 msgstr ""
@@ -2044,14 +2035,11 @@ msgstr ""
 
 #. avoid displaying the proxy address until we know related peer address
 #: src/components/layouts/Sidebar.vue:115
-#: src/components/modals/BtcTransactionModal.vue:497
 #: src/components/modals/BtcTransactionModal.vue:9
-#: src/components/modals/TransactionModal.vue:545
 #: src/components/modals/TransactionModal.vue:7
-#: src/components/modals/UsdcTransactionModal.vue:413
 #: src/components/modals/UsdcTransactionModal.vue:9
-#: src/composables/useBtcTransactionInfo.ts:113
-#: src/composables/useTransactionInfo.ts:83
+#: src/composables/useBtcTransactionInfo.ts:117
+#: src/composables/useTransactionInfo.ts:86
 #: src/composables/useUsdcTransactionInfo.ts:121
 msgid "Swap"
 msgstr ""
@@ -2252,12 +2240,12 @@ msgstr ""
 msgid "This might take up to {min} minutes."
 msgstr ""
 
-#: src/components/BtcTransactionList.vue:240
-#: src/components/BtcTransactionList.vue:262
-#: src/components/TransactionList.vue:252
-#: src/components/TransactionList.vue:274
-#: src/components/UsdcTransactionList.vue:202
-#: src/components/UsdcTransactionList.vue:224
+#: src/components/BtcTransactionList.vue:241
+#: src/components/BtcTransactionList.vue:263
+#: src/components/TransactionList.vue:253
+#: src/components/TransactionList.vue:275
+#: src/components/UsdcTransactionList.vue:203
+#: src/components/UsdcTransactionList.vue:225
 msgid "This month"
 msgstr ""
 
@@ -2349,8 +2337,7 @@ msgstr ""
 msgid "Tx time"
 msgstr ""
 
-#: src/components/modals/TransactionModal.vue:572
-#: src/composables/useTransactionInfo.ts:110
+#: src/composables/useTransactionInfo.ts:113
 msgid "Unclaimed Cashlink"
 msgstr ""
 
@@ -2394,11 +2381,9 @@ msgstr ""
 #: src/components/AddressList.vue:179
 #: src/components/layouts/AccountOverview.vue:158
 #: src/components/layouts/AddressOverview.vue:84
-#: src/components/modals/BtcTransactionModal.vue:501
-#: src/components/modals/TransactionModal.vue:558
 #: src/components/UsdcAddressInfo.vue:12
-#: src/composables/useBtcTransactionInfo.ts:117
-#: src/composables/useTransactionInfo.ts:96
+#: src/composables/useBtcTransactionInfo.ts:121
+#: src/composables/useTransactionInfo.ts:99
 msgid "USD Coin"
 msgstr ""
 


### PR DESCRIPTION
Previously there was unexpected behavior when searching for address labels and "extra data" was not used for the search in BTC or USDC.

![image](https://github.com/nimiq/wallet/assets/14013679/d45b6cd8-91ce-44ae-a460-1006ffae8fa5)
![image](https://github.com/nimiq/wallet/assets/14013679/0903dd6f-1505-4181-8d80-ed85eabaef16)

As you can see, nothing is shown...

Now, you can search for labels or any word in the data and it will be displayed.

![image](https://github.com/nimiq/wallet/assets/14013679/4b4827be-74c6-49d2-b221-3a0f45007ead)

![image](https://github.com/nimiq/wallet/assets/14013679/19e3f7f6-618a-4c1d-acfc-94637b959383)
![image](https://github.com/nimiq/wallet/assets/14013679/d34502f3-fbff-44f3-a248-462efabd0305)
