### PR TITLE
New SearchBar Behavior

### DIFF
--- a/src/components/CashlinkButton.vue
+++ b/src/components/CashlinkButton.vue
@@ -1,0 +1,98 @@
+<template>
+    <button @click="$emit('toggle-unclaimed-cashlink-list')" @mousedown.prevent>
+        <div class="cashlink-button" :class="showUnclaimedCashlinkList ? 'active' : ''">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 12 18" fill="none">
+                <path
+                    d="M10.5 4.125C10.5 2.375 8.97692 1 7.03846 1H4.96154C3.02308
+                    1 1.5 2.375 1.5 4.125V7.875C1.5 9.625 3.02308 11 4.96154 11H5.65385"
+                    stroke-width="2" stroke-linecap="round" />
+                <path
+                    d="M1.5 13.875C1.5 15.625 3.02308 17 4.96154 17L7.03846
+                    17C8.97692 17 10.5 15.625 10.5 13.875L10.5 10.125C10.5 8.375 8.97692 7 7.03846 7L6.34615 7"
+                    stroke-width="2" stroke-linecap="round" />
+            </svg>
+        </div>
+        <div class="notification-dot">
+            <span class="text">{{ unclaimedCashlinkCount }}</span>
+        </div>
+    </button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+    setup() {
+        return {
+        };
+    },
+    props: {
+        unclaimedCashlinkCount: {
+            type: Number,
+        },
+        showUnclaimedCashlinkList: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    components: {
+    },
+});
+</script>
+
+<style lang="scss" scoped>
+button {
+    position: relative;
+    background: transparent;
+    border-width: 0;
+    cursor: pointer;
+}
+
+.cashlink-button {
+    width: 4rem;
+    height: 4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2rem;
+    background: var(--nimiq-blue-bg);
+
+    transition: background var(--attr-duration) var(--nimiq-ease);
+
+    svg {
+        stroke: white;
+    }
+}
+
+.active {
+    background: transparent;
+    border: 1.5px solid rgba(31, 35, 72, 0.16);
+
+    svg {
+        stroke: var(--nimiq-blue);
+    }
+}
+
+.notification-dot {
+    position: absolute;
+    bottom: -1rem;
+    right: 0;
+    padding: 2.5px 5px;
+    font-size: 11px;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2rem;
+    border: 0.375rem solid var(--bg-primary);
+    transition: border-color 400ms var(--nimiq-ease);
+    color: white;
+    font-family: Muli;
+    background: var(--light-blue-gradient, radial-gradient(100% 100% at 100% 100.00%, #265DD7 0%, #0582CA 100%));
+
+    .text {
+        font-size: 11px;
+        font-weight: 600;
+        line-height: 100%;
+    }
+}</style>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -18,16 +18,18 @@
             @focus="handleFocus"
             @blur="handleBlur"
         />
-        <CrossCloseButton
-            class="cross-close-button"
-            v-if="isInputActive"
-            @click="handleClose"
-        />
+        <transition name="fade">
+            <CrossCloseButton
+                class="cross-close-button"
+                v-if="isInputActive"
+                @click="handleClose"
+            />
+        </transition>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onMounted, onUnmounted, computed, watch } from '@vue/composition-api';
+import { defineComponent, ref, onMounted, onUnmounted, computed } from '@vue/composition-api';
 
 import CrossCloseButton from './CrossCloseButton.vue';
 
@@ -235,6 +237,10 @@ input {
     z-index: 1;
     right: 1.75rem;
     cursor: pointer;
+}
+
+.fade-enter-active, .fade-leave-active {
+    transition-duration: var(--attr-duration);
 }
 
 @media (min-width: 700px) and (max-width: 900px) {

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -10,11 +10,11 @@
         >
             <template v-if="showUnclaimedCashlinkList" v-slot:before>
                 <div class="unclaimed-cashlink-list">
+                    <div class="month-label nq-blue opacity-40"><label>{{ $t('Pending Cashlinks') }}</label></div>
                     <CrossCloseButton
                         class="top-right nq-blue opacity-50"
                         @click="$emit('close-unclaimed-cashlink-list')"
                     />
-                    <div class="month-label nq-blue opacity-40"><label>{{ $t('Pending Cashlinks') }}</label></div>
                     <TransactionListItem
                         v-for="tx in unclaimedCashlinkTxs"
                         :transaction="tx"

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -10,8 +10,11 @@
         >
             <template v-if="showUnclaimedCashlinkList" v-slot:before>
                 <div class="unclaimed-cashlink-list">
-                    <CrossCloseButton class="top-right nq-orange" @click="$emit('close-unclaimed-cashlink-list')"/>
-                    <div class="month-label nq-orange"><label>{{ $t('Pending Cashlinks') }}</label></div>
+                    <CrossCloseButton
+                        class="top-right nq-blue opacity-50"
+                        @click="$emit('close-unclaimed-cashlink-list')"
+                    />
+                    <div class="month-label nq-blue opacity-40"><label>{{ $t('Pending Cashlinks') }}</label></div>
                     <TransactionListItem
                         v-for="tx in unclaimedCashlinkTxs"
                         :transaction="tx"
@@ -472,7 +475,7 @@ export default defineComponent({
     padding: 2rem;
     position: relative;
     margin: 4rem -2rem 0;
-    box-shadow: inset 0 0 0 0.1875rem rgba(252, 135, 2, 0.4);
+    box-shadow: inset 0 0 0 0.1875rem rgba(31, 35, 72, 0.16);
 
     .cross-close-button {
         top: 1.5rem;
@@ -689,5 +692,13 @@ export default defineComponent({
             margin-top: 2.5rem;
         }
     }
+}
+
+.opacity-50 {
+    opacity: 0.5;
+}
+
+.opacity-40 {
+    opacity: 0.4;
 }
 </style>

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -6,14 +6,16 @@
         >
             <div class="actions-mobile flex-row">
                 <button class="reset icon-button" @click="$router.back()"><ArrowLeftIcon/></button>
-                <SearchBar v-model="searchString"/>
+                <div class="flex-row justify-between w-full">
+                    <SearchBar v-model="searchString"/>
 
-                <CashlinkButton
-                    v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
-                    :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
-                    :unclaimedCashlinkCount="unclaimedCashlinkCount"
-                    @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
-                />
+                    <CashlinkButton
+                        v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
+                        :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
+                        :unclaimedCashlinkCount="unclaimedCashlinkCount"
+                        @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
+                    />
+                </div>
                 <button
                     class="reset icon-button"
                     @click="$event.currentTarget.focus() /* Required for MacOS Safari & Firefox */"
@@ -120,7 +122,7 @@
             <div class="actions flex-row">
                 <SearchBar v-model="searchString"/>
 
-                <div class="flex-row">
+                <div class="flex-row ml-auto">
                     <CashlinkButton
                         v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
                         :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
@@ -602,6 +604,7 @@ export default defineComponent({
 
 .actions,
 .actions-mobile {
+    position: relative;
     justify-content: space-between;
     margin-bottom: 0.75rem;
     align-items: center;
@@ -716,10 +719,6 @@ export default defineComponent({
     .nq-icon {
         transform: rotateZ(90deg);
     }
-}
-
-.search-bar {
-    margin-right: 3rem;
 }
 
 .unclaimed-cashlinks {
@@ -979,5 +978,14 @@ export default defineComponent({
             left: 40%;
         }
     }
+}
+.justify-between {
+    justify-content: space-between;
+}
+.w-full {
+    width: 100%;
+}
+.ml-auto {
+    margin-left: auto;
 }
 </style>

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -7,18 +7,13 @@
             <div class="actions-mobile flex-row">
                 <button class="reset icon-button" @click="$router.back()"><ArrowLeftIcon/></button>
                 <SearchBar v-model="searchString"/>
-                <button
+
+                <CashlinkButton
                     v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
-                    class="nq-button-s orange unclaimed-cashlinks"
-                    :class="{'active': showUnclaimedCashlinkList}"
-                    @click="showUnclaimedCashlinkList = !showUnclaimedCashlinkList"
-                    @mousedown.prevent
-                >
-                    {{ $tc(
-                        '{count} pending Cashlink | {count} pending Cashlinks',
-                        unclaimedCashlinkCount,
-                    ) }}
-                </button>
+                    :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
+                    :unclaimedCashlinkCount="unclaimedCashlinkCount"
+                    @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
+                />
                 <button
                     class="reset icon-button"
                     @click="$event.currentTarget.focus() /* Required for MacOS Safari & Firefox */"
@@ -124,19 +119,12 @@
             </div>
             <div class="actions flex-row">
                 <SearchBar v-model="searchString"/>
-
-                <button
+                <CashlinkButton
                     v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
-                    class="nq-button-s orange unclaimed-cashlinks"
-                    :class="{'active': showUnclaimedCashlinkList}"
-                    @click="showUnclaimedCashlinkList = !showUnclaimedCashlinkList"
-                    @mousedown.prevent
-                >
-                    {{ $tc(
-                        '{count} pending Cashlink | {count} pending Cashlinks',
-                        unclaimedCashlinkCount,
-                    ) }}
-                </button>
+                    :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
+                    :unclaimedCashlinkCount="unclaimedCashlinkCount"
+                    @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
+                />
 
                 <button class="send nq-button-pill light-blue flex-row"
                     @click="$router.push(`/send/${activeCurrency}`)" @mousedown.prevent
@@ -233,6 +221,7 @@ import UsdcTransactionList from '../UsdcTransactionList.vue';
 import MobileActionBar from '../MobileActionBar.vue';
 import RenameIcon from '../icons/AccountMenu/RenameIcon.vue';
 import RefreshIcon from '../icons/RefreshIcon.vue';
+import CashlinkButton from '../CashlinkButton.vue';
 
 import { useAccountStore } from '../../stores/Account';
 import { useAddressStore } from '../../stores/Address';
@@ -331,6 +320,10 @@ export default defineComponent({
             setPromoBoxVisible(false);
         }
 
+        function toggleUnclaimedCashlinkList() {
+            showUnclaimedCashlinkList.value = !showUnclaimedCashlinkList.value;
+        }
+
         return {
             activeCurrency,
             searchString,
@@ -352,6 +345,7 @@ export default defineComponent({
             onTransactionListScroll,
             address$,
             addressMasked,
+            toggleUnclaimedCashlinkList,
         };
     },
     components: {
@@ -375,6 +369,7 @@ export default defineComponent({
         HighFiveIcon,
         BoxedArrowUpIcon,
         UsdcIcon,
+        CashlinkButton,
     },
 });
 </script>

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -119,26 +119,29 @@
             </div>
             <div class="actions flex-row">
                 <SearchBar v-model="searchString"/>
-                <CashlinkButton
-                    v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
-                    :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
-                    :unclaimedCashlinkCount="unclaimedCashlinkCount"
-                    @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
-                />
 
-                <button class="send nq-button-pill light-blue flex-row"
-                    @click="$router.push(`/send/${activeCurrency}`)" @mousedown.prevent
-                    :disabled="(activeCurrency === 'nim' && (!activeAddressInfo || !activeAddressInfo.balance))
-                        || (activeCurrency === 'btc' && !btcAccountBalance)
-                        || (activeCurrency === 'usdc' && (!usdcAddressInfo || !usdcAddressInfo.balance))"
-                >
-                    <ArrowRightSmallIcon />{{ $t('Send') }}
-                </button>
-                <button class="receive nq-button-s flex-row"
-                    @click="$router.push(`/receive/${activeCurrency}`)" @mousedown.prevent
-                >
-                    <ArrowRightSmallIcon />{{ $t('Receive') }}
-                </button>
+                <div class="flex-row">
+                    <CashlinkButton
+                        v-if="activeCurrency === 'nim' && unclaimedCashlinkCount"
+                        :showUnclaimedCashlinkList="showUnclaimedCashlinkList"
+                        :unclaimedCashlinkCount="unclaimedCashlinkCount"
+                        @toggle-unclaimed-cashlink-list="toggleUnclaimedCashlinkList"
+                    />
+
+                    <button class="send nq-button-pill light-blue flex-row"
+                        @click="$router.push(`/send/${activeCurrency}`)" @mousedown.prevent
+                        :disabled="(activeCurrency === 'nim' && (!activeAddressInfo || !activeAddressInfo.balance))
+                            || (activeCurrency === 'btc' && !btcAccountBalance)
+                            || (activeCurrency === 'usdc' && (!usdcAddressInfo || !usdcAddressInfo.balance))"
+                    >
+                        <ArrowRightSmallIcon />{{ $t('Send') }}
+                    </button>
+                    <button class="receive nq-button-s flex-row"
+                        @click="$router.push(`/receive/${activeCurrency}`)" @mousedown.prevent
+                    >
+                        <ArrowRightSmallIcon />{{ $t('Receive') }}
+                    </button>
+                </div>
             </div>
             <div class="scroll-mask top"></div>
             <TransactionList

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -274,7 +274,7 @@ msgstr ""
 msgid "All new features are exclusive to new accounts. Upgrade now, it only takes seconds."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:175
+#: src/components/layouts/AddressOverview.vue:178
 msgid "All swaps are part of your transaction history and feature a small swap icon."
 msgstr ""
 
@@ -465,8 +465,8 @@ msgstr ""
 msgid "Buy more here in the wallet."
 msgstr ""
 
-#: src/components/TransactionList.vue:65
-#: src/components/TransactionList.vue:75
+#: src/components/TransactionList.vue:68
+#: src/components/TransactionList.vue:78
 msgid "Buy NIM"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Click on ‘Troubleshooting’ to learn more."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:177
+#: src/components/layouts/AddressOverview.vue:180
 #: src/components/swap/SwapAnimation.vue:105
 msgid "Close"
 msgstr ""
@@ -629,7 +629,7 @@ msgid "Confirm account"
 msgstr ""
 
 #: src/components/BtcTransactionList.vue:54
-#: src/components/TransactionList.vue:57
+#: src/components/TransactionList.vue:60
 #: src/components/UsdcTransactionList.vue:45
 msgid "Congrats"
 msgstr ""
@@ -983,7 +983,7 @@ msgid "fees"
 msgstr ""
 
 #: src/components/BtcTransactionList.vue:38
-#: src/components/TransactionList.vue:48
+#: src/components/TransactionList.vue:51
 #: src/components/UsdcTransactionList.vue:36
 msgid "Fetching"
 msgstr ""
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Invalid swap state, swap aborted!"
 msgstr ""
 
-#: src/components/TransactionList.vue:59
+#: src/components/TransactionList.vue:62
 msgid "Invite a friend with a {cashlink} or buy more here in the wallet."
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Learn more here"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:162
+#: src/components/layouts/AddressOverview.vue:165
 msgid "Let's get started! Create your Nimiq account:"
 msgstr ""
 
@@ -1422,7 +1422,7 @@ msgid "No request received."
 msgstr ""
 
 #: src/components/BtcTransactionList.vue:77
-#: src/components/TransactionList.vue:80
+#: src/components/TransactionList.vue:83
 #: src/components/UsdcTransactionList.vue:62
 msgid "No transactions found"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: src/components/TransactionList.vue:14
+#: src/components/TransactionList.vue:17
 msgid "Pending Cashlinks"
 msgstr ""
 
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Read all about it in this {blog_post} or click below for the new wallet intro."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:140
+#: src/components/layouts/AddressOverview.vue:142
 #: src/components/MobileActionBar.vue:4
 msgid "Receive"
 msgstr ""
@@ -1743,15 +1743,15 @@ msgid ""
 msgstr ""
 
 #: src/components/CountrySelector.vue:22
-#: src/components/SearchBar.vue:18
+#: src/components/SearchBar.vue:98
 msgid "Search"
 msgstr ""
 
-#: src/components/SearchBar.vue:17
+#: src/components/SearchBar.vue:97
 msgid "Search transactions"
 msgstr ""
 
-#: src/components/SearchBar.vue:15
+#: src/components/SearchBar.vue:95
 msgid "Search transactions by contact, address, etc."
 msgstr ""
 
@@ -1811,7 +1811,7 @@ msgstr ""
 msgid "Selling now available"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:135
+#: src/components/layouts/AddressOverview.vue:137
 #: src/components/MobileActionBar.vue:10
 msgid "Send"
 msgstr ""
@@ -1973,7 +1973,7 @@ msgstr ""
 msgid "Show values as {currency}"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:163
+#: src/components/layouts/AddressOverview.vue:166
 msgid "Signup"
 msgstr ""
 
@@ -2496,7 +2496,7 @@ msgid "You need a SEPA account that supports instant transactions."
 msgstr ""
 
 #: src/components/BtcTransactionList.vue:55
-#: src/components/TransactionList.vue:58
+#: src/components/TransactionList.vue:61
 #: src/components/UsdcTransactionList.vue:46
 msgid "You now own crypto!"
 msgstr ""
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Your payout is on its way"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:171
+#: src/components/layouts/AddressOverview.vue:174
 msgid "Your swap was successful!"
 msgstr ""
 
@@ -2575,7 +2575,7 @@ msgid "Your transaction must be SEPA Instant"
 msgstr ""
 
 #: src/components/BtcTransactionList.vue:65
-#: src/components/TransactionList.vue:72
+#: src/components/TransactionList.vue:75
 #: src/components/UsdcTransactionList.vue:55
 msgid "Your transactions will appear here"
 msgstr ""

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -274,7 +274,7 @@ msgstr ""
 msgid "All new features are exclusive to new accounts. Upgrade now, it only takes seconds."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:178
+#: src/components/layouts/AddressOverview.vue:180
 msgid "All swaps are part of your transaction history and feature a small swap icon."
 msgstr ""
 
@@ -389,7 +389,7 @@ msgstr ""
 
 #: src/components/AddressList.vue:172
 #: src/components/layouts/AccountOverview.vue:105
-#: src/components/layouts/AddressOverview.vue:78
+#: src/components/layouts/AddressOverview.vue:80
 #: src/components/layouts/Settings.vue:119
 #: src/components/LegacyAccountNotice.vue:21
 #: src/components/modals/BtcTransactionModal.vue:116
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Click on ‘Troubleshooting’ to learn more."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:180
+#: src/components/layouts/AddressOverview.vue:182
 #: src/components/swap/SwapAnimation.vue:105
 msgid "Close"
 msgstr ""
@@ -925,8 +925,8 @@ msgstr ""
 msgid "Expired HTLC"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:39
-#: src/components/layouts/AddressOverview.vue:70
+#: src/components/layouts/AddressOverview.vue:41
+#: src/components/layouts/AddressOverview.vue:72
 #: src/components/modals/AccountMenuModal.vue:30
 msgid "Export History"
 msgstr ""
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Learn more here"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:165
+#: src/components/layouts/AddressOverview.vue:167
 msgid "Let's get started! Create your Nimiq account:"
 msgstr ""
 
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Read all about it in this {blog_post} or click below for the new wallet intro."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:142
+#: src/components/layouts/AddressOverview.vue:144
 #: src/components/MobileActionBar.vue:4
 msgid "Receive"
 msgstr ""
@@ -1684,8 +1684,8 @@ msgstr ""
 msgid "Release Notes"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:27
-#: src/components/layouts/AddressOverview.vue:58
+#: src/components/layouts/AddressOverview.vue:29
+#: src/components/layouts/AddressOverview.vue:60
 #: src/components/modals/AccountMenuModal.vue:16
 msgid "Rename"
 msgstr ""
@@ -1699,8 +1699,8 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:33
-#: src/components/layouts/AddressOverview.vue:64
+#: src/components/layouts/AddressOverview.vue:35
+#: src/components/layouts/AddressOverview.vue:66
 msgid "Rescan"
 msgstr ""
 
@@ -1743,15 +1743,15 @@ msgid ""
 msgstr ""
 
 #: src/components/CountrySelector.vue:22
-#: src/components/SearchBar.vue:98
+#: src/components/SearchBar.vue:155
 msgid "Search"
 msgstr ""
 
-#: src/components/SearchBar.vue:97
+#: src/components/SearchBar.vue:154
 msgid "Search transactions"
 msgstr ""
 
-#: src/components/SearchBar.vue:95
+#: src/components/SearchBar.vue:152
 msgid "Search transactions by contact, address, etc."
 msgstr ""
 
@@ -1811,7 +1811,7 @@ msgstr ""
 msgid "Selling now available"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:137
+#: src/components/layouts/AddressOverview.vue:139
 #: src/components/MobileActionBar.vue:10
 msgid "Send"
 msgstr ""
@@ -1973,7 +1973,7 @@ msgstr ""
 msgid "Show values as {currency}"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:166
+#: src/components/layouts/AddressOverview.vue:168
 msgid "Signup"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Your payout is on its way"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:174
+#: src/components/layouts/AddressOverview.vue:176
 msgid "Your swap was successful!"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -41,11 +41,6 @@ msgstr ""
 msgid "{count} Peer | {count} Peers"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:135
-#: src/components/layouts/AddressOverview.vue:17
-msgid "{count} pending Cashlink | {count} pending Cashlinks"
-msgstr ""
-
 #: src/components/modals/overlays/QrCodeOverlay.vue:3
 msgid "{currency} Address"
 msgstr ""
@@ -279,7 +274,7 @@ msgstr ""
 msgid "All new features are exclusive to new accounts. Upgrade now, it only takes seconds."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:187
+#: src/components/layouts/AddressOverview.vue:175
 msgid "All swaps are part of your transaction history and feature a small swap icon."
 msgstr ""
 
@@ -394,7 +389,7 @@ msgstr ""
 
 #: src/components/AddressList.vue:172
 #: src/components/layouts/AccountOverview.vue:105
-#: src/components/layouts/AddressOverview.vue:83
+#: src/components/layouts/AddressOverview.vue:78
 #: src/components/layouts/Settings.vue:119
 #: src/components/LegacyAccountNotice.vue:21
 #: src/components/modals/BtcTransactionModal.vue:116
@@ -601,7 +596,7 @@ msgstr ""
 msgid "Click on ‘Troubleshooting’ to learn more."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:189
+#: src/components/layouts/AddressOverview.vue:177
 #: src/components/swap/SwapAnimation.vue:105
 msgid "Close"
 msgstr ""
@@ -930,8 +925,8 @@ msgstr ""
 msgid "Expired HTLC"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:44
-#: src/components/layouts/AddressOverview.vue:75
+#: src/components/layouts/AddressOverview.vue:39
+#: src/components/layouts/AddressOverview.vue:70
 #: src/components/modals/AccountMenuModal.vue:30
 msgid "Export History"
 msgstr ""
@@ -1255,7 +1250,7 @@ msgstr ""
 msgid "Learn more here"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:174
+#: src/components/layouts/AddressOverview.vue:162
 msgid "Let's get started! Create your Nimiq account:"
 msgstr ""
 
@@ -1599,7 +1594,7 @@ msgstr ""
 msgid "Read all about it in this {blog_post} or click below for the new wallet intro."
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:152
+#: src/components/layouts/AddressOverview.vue:140
 #: src/components/MobileActionBar.vue:4
 msgid "Receive"
 msgstr ""
@@ -1689,8 +1684,8 @@ msgstr ""
 msgid "Release Notes"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:32
-#: src/components/layouts/AddressOverview.vue:63
+#: src/components/layouts/AddressOverview.vue:27
+#: src/components/layouts/AddressOverview.vue:58
 #: src/components/modals/AccountMenuModal.vue:16
 msgid "Rename"
 msgstr ""
@@ -1704,8 +1699,8 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:38
-#: src/components/layouts/AddressOverview.vue:69
+#: src/components/layouts/AddressOverview.vue:33
+#: src/components/layouts/AddressOverview.vue:64
 msgid "Rescan"
 msgstr ""
 
@@ -1816,7 +1811,7 @@ msgstr ""
 msgid "Selling now available"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:147
+#: src/components/layouts/AddressOverview.vue:135
 #: src/components/MobileActionBar.vue:10
 msgid "Send"
 msgstr ""
@@ -1978,7 +1973,7 @@ msgstr ""
 msgid "Show values as {currency}"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:175
+#: src/components/layouts/AddressOverview.vue:163
 msgid "Signup"
 msgstr ""
 
@@ -2571,7 +2566,7 @@ msgstr ""
 msgid "Your payout is on its way"
 msgstr ""
 
-#: src/components/layouts/AddressOverview.vue:183
+#: src/components/layouts/AddressOverview.vue:171
 msgid "Your swap was successful!"
 msgstr ""
 


### PR DESCRIPTION
The previous SearchBar showed some strange behavior when the viewport was small but not small enough to trigger the mobile view, resulting in the SearchBar being too small.

![image](https://github.com/nimiq/wallet/assets/14013679/19788b51-982a-45d3-b4f2-85aece64e894)

A few changes have been made to improve this:
- Changed the Cashlink Button design
- Min width for SearchBar + new extended behavior

## Cashlink Button

The new cashlink button consist in a circle with a dot notification for the amount of pending cashlinks.

![image](https://github.com/nimiq/wallet/assets/14013679/154cbeb2-8abb-4db4-b15c-6f37dd5ea987)
![image](https://github.com/nimiq/wallet/assets/14013679/88d6d40d-261b-49fb-8680-2f13171ae374)


## New SearchBar Behavior

The search bar is collapsed and displays `Search transactions` when it's not being used (i.e., not focused or no text entered).

![image](https://github.com/nimiq/wallet/assets/14013679/8f64ab26-a5ac-42a2-b818-a45bcddd9c32)

When is being used, it will take all the remaining space and the placeholder will change to `Search transactions by contact, address, etc.` if there's enough space.

![image](https://github.com/nimiq/wallet/assets/14013679/aedd4bf1-8f36-49a0-a0ec-719f05685da2)

An `X` button has been added for clearing the input and collapsing the bar. Its behavior is as follows:

- The bar won't be auto-collapses if active, only if cleared/closed.
- Clearing while focussed will not close it, clearing while not focussed will close/collapse it.

You can also watch a video preview [here](https://www.loom.com/share/fdf29903dfbf46cf90a5518678996fe8?sid=9d38a8ff-e1ad-488f-8bf4-085ab3ab1846)

If there's not enough space for the bar to be clearly visible, it will extend, taking up the send and receive button space
<img width="443" alt="image" src="https://github.com/nimiq/wallet/assets/14013679/7b63fd89-6872-4309-af69-3da5bd609386">
<img width="443" alt="image" src="https://github.com/nimiq/wallet/assets/14013679/648270b6-409a-4727-80d4-34b398382356">

Lastly, before the search bar didn't have a minimun width (can be seen in the first screenshot). Now it will look like a button and take the full width when clicked on it
<img width="340" alt="image" src="https://github.com/nimiq/wallet/assets/14013679/f34e95fc-99f3-4ed3-b7b0-4057739646d9">
<img width="340" alt="image" src="https://github.com/nimiq/wallet/assets/14013679/393cf809-c707-4380-8d3a-a7de012df80a">
