### PR TITLE
Removed network map width limit

### DIFF
--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -146,7 +146,6 @@ export default defineComponent({
     position: relative;
     overflow: hidden;
     width: 100%;
-    max-width: 1500px;
 }
 
 .map,


### PR DESCRIPTION
For more context please go to #164


|   |  Before  |  After  | 
|---|---|---|
|  Desktop  |  ![image](https://github.com/nimiq/wallet/assets/14013679/36295362-1a4b-4643-967f-7f41ea375a48)  |  ![image](https://github.com/nimiq/wallet/assets/14013679/d279442d-fbf9-473b-b91d-31108fcfed66)  |
|  Wide Desktop  |  ![image](https://github.com/nimiq/wallet/assets/14013679/26ebabad-2f96-4ac9-ae1d-31ab2b0b625b)  |  ![image](https://github.com/nimiq/wallet/assets/14013679/52cab283-6964-458b-9e04-f4a155adafde)  |
|  Mobile  |  ![image](https://github.com/nimiq/wallet/assets/14013679/1d4421aa-e6b7-4dfa-ae01-2a62ae768067)  |  ![image](https://github.com/nimiq/wallet/assets/14013679/8fe9514e-7f88-4dc6-8ab2-e6783b8fa540)  |
|  Tablet  |  ![image](https://github.com/nimiq/wallet/assets/14013679/8aca409c-5e37-4c66-abfe-55cccf70ab03)  |  ![image](https://github.com/nimiq/wallet/assets/14013679/5c8d8db1-372f-49e4-a058-cfaf22c50622)  |

As you can see, the only difference is in ultra-wide screens. I couldn't find any reason for the `max-width: 1500px` to be there.