### PR TITLE
fix(TransactionListItem): don't cut out svg

### DIFF
--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -253,6 +253,7 @@ svg {
             width: 6rem;
             height: 6rem;
             padding: 0.375rem;
+            overflow: initial;
 
             &.bitcoin {
                 color: var(--bitcoin-orange);


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3fcdf98b-3596-4006-99d2-07f5bd47bdfe) | ![image](https://github.com/user-attachments/assets/19203b87-3600-493f-b58b-75188a4a7d30) |

The SVG is being clipped on the right
