### PR TITLE
[WIP] feat: improve validator fetch logic

### DIFF
--- a/src/components/icons/Staking/FatSearchIcon.vue
+++ b/src/components/icons/Staking/FatSearchIcon.vue
@@ -1,6 +1,6 @@
 <template functional>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 19">
-        <circle cx="8.25" cy="8.25" r="4.5" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.0"/>
-        <line x1="16.25" y1="16.25" x2="11.75" y2="11.75" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.0"/>
+        <circle cx="8.25" cy="8.25" r="4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.0"/>
+        <line x1="16.25" y1="16.25" x2="11.75" y2="11.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.0"/>
     </svg>
 </template>

--- a/src/components/staking/ValidatorFilter.vue
+++ b/src/components/staking/ValidatorFilter.vue
@@ -112,6 +112,7 @@ export default defineComponent({
             border: 0;
             background: transparent;
             box-shadow: none;
+            color: rgb(31, 35, 72);
 
             svg {
                 width: 2.375rem;
@@ -122,7 +123,6 @@ export default defineComponent({
                 }
 
                 line, circle {
-                    stroke: rgb(31, 35, 72);
                     stroke-width: 2.0;
                 }
             }

--- a/src/components/staking/ValidatorIcon.vue
+++ b/src/components/staking/ValidatorIcon.vue
@@ -1,11 +1,12 @@
 <template>
-    <img class="validator-icon" v-if="'logo' in validator" :src="validator.logo" :alt="validator.name" />
+    <img class="validator-icon" v-if="src" :src="src" :alt="validator.name" loading="lazy" />
     <Identicon class="validator-icon" v-else :address="validator.address"/>
 </template>
 
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
 import { Identicon } from '@nimiq/vue-components';
+import { useConfig } from '@/composables/useConfig';
 import { Validator } from '../../stores/Staking';
 
 export default defineComponent({
@@ -14,6 +15,14 @@ export default defineComponent({
             type: Object as () => Validator,
             required: true,
         },
+    },
+    setup(props) {
+        const { config } = useConfig();
+
+        return {
+            src: 'logoPath' in props.validator
+                ? `${config.staking.validatorsEndpoint}}/${props.validator.logoPath}` : undefined,
+        };
     },
     components: {
         Identicon,

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -24,7 +24,7 @@ export default {
         prestakingStartBlock: 3_023_730,
         prestakingEndBlock: 3_028_050,
         transitionBlock: 3_032_010,
-        validatorsEndpoint: 'https://validators-api-testnet.nuxt.dev/api/v1/validators?only-known=false',
+        validatorsEndpoint: 'https://validators-api-testnet.nuxt.dev',
         genesis: {
             height: 3032010,
             date: new Date('2024-11-13T20:00:00Z'),

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -34,7 +34,7 @@ export default {
         prestakingStartBlock: 3_392_200, // 2024-10-06T02:53:18Z
         prestakingEndBlock: 3_456_000, // ~2024-11-19T16:00:00Z
         transitionBlock: 3_456_000,
-        validatorsEndpoint: 'https://validators-api-mainnet.nuxt.dev/api/v1/validators?only-known=false',
+        validatorsEndpoint: 'https://validators-api-mainnet.nuxt.dev',
         genesis: {
             height: 3456000,
             date: new Date('2024-11-19T16:00:00Z'),

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -22,7 +22,7 @@ export default {
         prestakingStartBlock: 3_023_730,
         prestakingEndBlock: 3_028_050,
         transitionBlock: 3_032_010,
-        validatorsEndpoint: 'https://validators-api-testnet.nuxt.dev/api/v1/validators?with-scores=true',
+        validatorsEndpoint: 'https://validators-api-testnet.nuxt.dev',
         genesis: {
             height: 3032010,
             date: new Date('2024-11-13T20:00:00Z'),

--- a/src/network.ts
+++ b/src/network.ts
@@ -242,7 +242,8 @@ export async function launchNetwork() {
             payoutType: 'none' | 'direct' | 'restake',
             payoutSchedule: string,
             isMaintainedByNimiq: boolean,
-            icon?: string,
+            logo?: string,
+            logoPath?: string,
             hasDefaultIcon: boolean,
             accentColor: string,
             website: string | null,
@@ -256,8 +257,9 @@ export async function launchNetwork() {
         };
 
         const { config } = useConfig();
+        const url = `${config.staking.validatorsEndpoint}/api/v1/validators?only-known=false`;
         const apiValidators = await retry<ApiValidator[]>(
-            () => fetch(config.staking.validatorsEndpoint).then((res) => res.json()).catch(() => []), 1000, 3,
+            () => fetch(url).then((res) => res.json()).catch(() => []), 1000, 3,
         );
         // TODO: Make it work even in the case this request fails
         const validatorData: Record<string, ApiValidator> = {};

--- a/src/stores/Staking.ts
+++ b/src/stores/Staking.ts
@@ -34,6 +34,7 @@ export type RegisteredValidator = RawValidator & {
     payoutSchedule: string,
     isMaintainedByNimiq: boolean,
     logo?: string,
+    logoPath?: string,
     hasDefaultIcon: boolean,
     accentColor: string,
     website: string | null,
@@ -167,7 +168,7 @@ export const useStakingStore = createStore({
             };
         },
         setStakes(stakes: Stake[]) {
-            const newStakes: {[address: string]: Stake} = {};
+            const newStakes: { [address: string]: Stake } = {};
 
             for (const stake of stakes) {
                 newStakes[stake.address] = stake;
@@ -197,7 +198,7 @@ export const useStakingStore = createStore({
             };
         },
         setValidators(validators: Validator[]) {
-            const newValidators: {[address: string]: Validator} = {};
+            const newValidators: { [address: string]: Validator } = {};
 
             for (const validator of validators) {
                 newValidators[validator.address] = validator;


### PR DESCRIPTION
We load the validators api in two occasions:
1. When we run `launchNetwork`
2. In new epochs

---

The webclient when we subscribe to blocks, some of them will be on already ended epochs, so the wallet will update the epoch number two times.
