### PR TITLE
Fix validator icon size when the original icon is not 1:1

### DIFF
--- a/src/components/staking/ValidatorIcon.vue
+++ b/src/components/staking/ValidatorIcon.vue
@@ -32,5 +32,6 @@ img, .identicon {
     width: var(--size);
     height: var(--size);
     display: block;
+    object-fit: contain;
 }
 </style>


### PR DESCRIPTION
Before
<img width="425" alt="image" src="https://github.com/user-attachments/assets/756a4170-3803-48af-8c28-2324f5cf57f5">

After:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/8ba37253-11b8-4ff7-9bb6-a89a8f1ae641">
