### PR TITLE
Disable buttons if active currency is NIM and disable network flag is…

### DIFF
--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -5,7 +5,7 @@
         </button>
         <button class="send nq-button-pill light-blue flex-row"
             @click="send" @mousedown.prevent
-            :disabled="$config.disableNetworkInteraction || sendDisabled"
+            :disabled="sendDisabled"
         >
             <ArrowRightSmallIcon />{{ $t('Send') }}
         </button>
@@ -18,6 +18,7 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
+import { useConfig } from '@/composables/useConfig';
 import { AddressType, useAddressStore } from '../stores/Address';
 import { useAccountStore } from '../stores/Account';
 import { CryptoCurrency } from '../lib/Constants';
@@ -78,8 +79,11 @@ export default defineComponent({
             }
         }
 
-        const sendDisabled = computed(() =>
-            context.root.$route.path !== '/' && nimOrBtcOrStable(
+        const { config } = useConfig();
+
+        const sendDisabled = computed(() => {
+            if (activeCurrency.value === 'nim' && config.disableNetworkInteraction) return true;
+            return context.root.$route.path !== '/' && nimOrBtcOrStable(
                 !activeAddressInfo.value || !activeAddressInfo.value.balance,
                 !btcBalance.value,
                 (stablecoin.value === CryptoCurrency.USDC
@@ -87,8 +91,8 @@ export default defineComponent({
                     : stablecoin.value === CryptoCurrency.USDT
                         ? !accountUsdtBridgedBalance.value
                         : true),
-            ),
-        );
+            );
+        });
 
         return {
             receive,

--- a/src/components/layouts/AccountOverview.vue
+++ b/src/components/layouts/AccountOverview.vue
@@ -62,7 +62,7 @@
                 </div>
 
                 <Tooltip
-                    v-if="!$config.disableNetworkInteraction
+                    v-if="(activeCurrency === 'nim' && !$config.disableNetworkInteraction)
                         && $config.fastspot.enabled
                         && hasBitcoinAddresses && $config.enableBitcoin
                         && (nimAccountBalance > 0 || btcAccountBalance > 0)"
@@ -85,7 +85,7 @@
                 </Tooltip>
 
                 <Tooltip
-                    v-if="!$config.disableNetworkInteraction
+                    v-if="(activeCurrency === 'nim' && !$config.disableNetworkInteraction)
                         && $config.fastspot.enabled
                         && activeAccountInfo && activeAccountInfo.type !== AccountType.LEDGER
                         && hasPolygonAddresses && $config.polygon.enabled
@@ -156,8 +156,7 @@
                 </button>
 
                 <Tooltip
-                    v-if="!$config.disableNetworkInteraction
-                        && $config.fastspot.enabled
+                    v-if="$config.fastspot.enabled
                         && activeAccountInfo && activeAccountInfo.type !== AccountType.LEDGER
                         && hasBitcoinAddresses && $config.enableBitcoin
                         && hasPolygonAddresses && $config.polygon.enabled

--- a/src/components/layouts/AddressOverview.vue
+++ b/src/components/layouts/AddressOverview.vue
@@ -182,8 +182,10 @@
 
                     <button class="send nq-button-pill light-blue flex-row"
                         @click="$router.push(`/send/${activeCurrency}`)" @mousedown.prevent
-                        :disabled="$config.disableNetworkInteraction
-                            || (activeCurrency === 'nim' && (!activeAddressInfo || !activeAddressInfo.balance))
+                        :disabled="
+                            (activeCurrency === 'nim'
+                                && (!activeAddressInfo || !activeAddressInfo.balance
+                                    || $config.disableNetworkInteraction))
                             || (activeCurrency === 'btc' && !btcAccountBalance)
                             || (activeCurrency === 'usdc' && !accountUsdcBalance /* can only send native usdc */)
                             || (activeCurrency === CryptoCurrency.USDT && !accountUsdtBridgedBalance)"

--- a/src/components/layouts/Sidebar.vue
+++ b/src/components/layouts/Sidebar.vue
@@ -52,7 +52,7 @@
                 <template #trigger>
                     <button
                         class="nq-button-s inverse"
-                        :disabled="$config.disableNetworkInteraction || hasActiveSwap"
+                        :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction) || hasActiveSwap"
                         @click="openModal('buy')"
                         @mousedown.prevent="hideTooltips"
                     >{{ $t('Buy') }}</button>
@@ -74,7 +74,8 @@
             >
                 <template #trigger>
                     <button class="nq-button-s inverse"
-                        :disabled="$config.disableNetworkInteraction || !canSellCryptoWithMoonpay"
+                        :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction)
+                            || !canSellCryptoWithMoonpay"
                         @click="openModal('moonpay-sell-info')"
                         @mousedown.prevent="hideTooltips"
                     >{{ $t('Sell') }}</button>
@@ -130,7 +131,7 @@
         >
             <template #trigger>
                 <button
-                    :disabled="$config.disableNetworkInteraction
+                    :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction)
                         || fastspotEnabledCryptoSwapAssets.length <= 1
                         || walletActivatedCurrencies.length <= 1
                         || !hasSwappableBalance
@@ -345,6 +346,7 @@ export default defineComponent({
             openModal,
             canSellCryptoWithMoonpay,
             nimSellOptions,
+            activeCurrency,
         };
     },
     components: {

--- a/src/components/modals/BuyCryptoModal.vue
+++ b/src/components/modals/BuyCryptoModal.vue
@@ -191,7 +191,7 @@
                     v-if="!insufficientLimit || !$config.ten31Pass.enabled || kycUser"
                     :assets="[activeCurrency]"
                     :buttonColor="kycUser ? 'purple' : 'light-blue'"
-                    :disabled="$config.disableNetworkInteraction || !canSign"
+                    :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction) || !canSign"
                     :error="estimateError || swapError"
                     :requireCompleteBtcHistory="false"
                     @click="sign"

--- a/src/components/modals/SellCryptoModal.vue
+++ b/src/components/modals/SellCryptoModal.vue
@@ -172,7 +172,7 @@
                     v-if="!insufficientLimit || !$config.ten31Pass.enabled || kycUser"
                     :assets="[activeCurrency]"
                     :buttonColor="kycUser ? 'purple' : 'light-blue'"
-                    :disabled="$config.disableNetworkInteraction || !canSign"
+                    :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction) || !canSign"
                     :error="estimateError || swapError"
                     requireCompleteBtcHistory
                     @click="sign"

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -202,7 +202,7 @@
             </PageBody>
             <SendModalFooter
                 :assets="[CryptoCurrency.NIM]"
-                :disabled="$config.disableNetworkInteraction || !canSend"
+                :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction) || !canSend"
                 @click="sign"
             ><template #cta>{{ $t('Send {currency}', { currency: 'NIM' }) }}</template></SendModalFooter>
         </div>

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -186,7 +186,7 @@
             v-if="!isLimitReached || !$config.ten31Pass.enabled || kycUser"
             :assets="[assetToCurrency(leftAsset), assetToCurrency(rightAsset)]"
             :buttonColor="kycUser ? 'purple' : 'light-blue'"
-            :disabled="$config.disableNetworkInteraction || !canSign || currentlySigning"
+            :disabled="(activeCurrency === 'nim' && $config.disableNetworkInteraction) || !canSign || currentlySigning"
             :error="disabledAssetError || estimateError || swapError || polygonFeeError"
             requireCompleteBtcHistory
             @click="sign"


### PR DESCRIPTION
In 3db91879462cc457dc4688452da319a3789aa47c we introduced a flag to disable the Wallet interactions.

This flag should be only used for NIM operations and not disable stable or BTC operations 