### PR TITLE
Removed `context.root` from every component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,7 @@
 import { defineComponent, ref, watch, computed, onMounted, Ref } from '@vue/composition-api';
 import { LoadingSpinner } from '@nimiq/vue-components';
 import { provideI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Sidebar from './components/layouts/Sidebar.vue';
 import SwapNotification from './components/swap/SwapNotification.vue';
 import UpdateNotification from './components/UpdateNotification.vue';
@@ -118,7 +119,7 @@ export default defineComponent({
             ) {
                 // Go back to root (addresses)
                 router.back();
-                await context.root.$nextTick();
+                await nextTick();
             }
         }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -107,10 +107,10 @@ export default defineComponent({
 
             if (currentXPosition >= sidebarBarrier && (initialXPosition) < sidebarBarrier) {
                 // Go to sidebar
-                await router.push({ name: context.root.$route.name!, query: { sidebar: 'true' } });
+                await router.push({ name: router.currentRoute.name!, query: { sidebar: 'true' } });
             } else if (currentXPosition <= transactionsBarrier && (initialXPosition) > transactionsBarrier) {
                 // Go to transactions
-                if (context.root.$route.name === 'root') {
+                if (router.currentRoute.name === 'root') {
                     await router.push('/transactions');
                 }
             } else if (
@@ -143,7 +143,7 @@ export default defineComponent({
             onSwipeEnded: updateSwipeRestPosition,
             // TODO: clamp movement to smaller area on settings and network view
             clampMovement: computed<[number, number]>(() => {
-                if (context.root.$route.path === '/transactions') {
+                if (router.currentRoute.path === '/transactions') {
                     // Allow swiping back from transactions to address list, but not all the way to sidebar
                     return [-width.value - 192, -192];
                 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@
 <script lang="ts">
 import { defineComponent, ref, watch, computed, onMounted, Ref } from '@vue/composition-api';
 import { LoadingSpinner } from '@nimiq/vue-components';
+import { provideI18n } from '@/lib/useI18n';
 import Sidebar from './components/layouts/Sidebar.vue';
 import SwapNotification from './components/swap/SwapNotification.vue';
 import UpdateNotification from './components/UpdateNotification.vue';
@@ -63,6 +64,7 @@ export default defineComponent({
     name: 'app',
     setup(props, context) {
         provideRouter(router);
+        provideI18n(context.root);
 
         const { config } = useConfig();
         const isMainnet = config.environment === ENV_MAIN;

--- a/src/App.vue
+++ b/src/App.vue
@@ -104,18 +104,18 @@ export default defineComponent({
 
             if (currentXPosition >= sidebarBarrier && (initialXPosition) < sidebarBarrier) {
                 // Go to sidebar
-                await context.root.$router.push({ name: context.root.$route.name!, query: { sidebar: 'true' } });
+                await router.push({ name: context.root.$route.name!, query: { sidebar: 'true' } });
             } else if (currentXPosition <= transactionsBarrier && (initialXPosition) > transactionsBarrier) {
                 // Go to transactions
                 if (context.root.$route.name === 'root') {
-                    await context.root.$router.push('/transactions');
+                    await router.push('/transactions');
                 }
             } else if (
                 (currentXPosition <= sidebarBarrier && currentXPosition >= transactionsBarrier)
                 && (initialXPosition > sidebarBarrier || initialXPosition < transactionsBarrier)
             ) {
                 // Go back to root (addresses)
-                context.root.$router.back();
+                router.back();
                 await context.root.$nextTick();
             }
         }

--- a/src/components/AccountBalance.vue
+++ b/src/components/AccountBalance.vue
@@ -26,6 +26,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, onMounted, onUnmounted, watch } from '@vue/composition-api';
 import { FiatAmount } from '@nimiq/vue-components';
+import { nextTick } from '@/lib/nextTick';
 import PrivacyOffIcon from './icons/PrivacyOffIcon.vue';
 import PrivacyOnIcon from './icons/PrivacyOnIcon.vue';
 import { useAddressStore } from '../stores/Address';
@@ -40,7 +41,7 @@ import { useAccountSettingsStore } from '../stores/AccountSettings';
 import { useStakingStore } from '../stores/Staking';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const { accountBalance } = useAddressStore();
         const { totalAccountStake } = useStakingStore();
         const { accountBalance: btcAccountBalance } = useBtcAddressStore();
@@ -99,7 +100,7 @@ export default defineComponent({
         const fiatAmountFontSize = ref(fiatAmountMaxSize.value);
 
         async function updateFontSize() {
-            await context.root.$nextTick();
+            await nextTick();
             if (!fiatAmount$.value) return;
 
             if (!fiatAmountContainer$.value || !fiatAmount$.value) return;

--- a/src/components/AccountMenu.vue
+++ b/src/components/AccountMenu.vue
@@ -44,7 +44,7 @@ export default defineComponent({
 
         function openMenu() {
             router.push({
-                name: `${context.root.$route.name}-accounts`,
+                name: `${router.currentRoute.name}-accounts`,
                 query: { sidebar: 'true' },
             });
         }
@@ -56,7 +56,7 @@ export default defineComponent({
             && addressState.addressInfos[activeAccountInfo.value.addresses[0]]);
 
         function goToAccount(testForMenuOpening = true) {
-            if (testForMenuOpening && context.root.$route.name === 'root') {
+            if (testForMenuOpening && router.currentRoute.name === 'root') {
                 openMenu();
                 return;
             }

--- a/src/components/AccountMenu.vue
+++ b/src/components/AccountMenu.vue
@@ -28,6 +28,7 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { Identicon, MenuDotsIcon } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 
 import LoginFileIcon from './icons/LoginFileIcon.vue';
 import LedgerIcon from './icons/LedgerIcon.vue';
@@ -37,11 +38,12 @@ import { useAddressStore } from '../stores/Address';
 
 export default defineComponent({
     setup(props, context) {
+        const router = useRouter();
         const { activeAccountInfo } = useAccountStore();
         const { state: addressState } = useAddressStore();
 
         function openMenu() {
-            context.root.$router.push({
+            router.push({
                 name: `${context.root.$route.name}-accounts`,
                 query: { sidebar: 'true' },
             });

--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -46,6 +46,7 @@ import Vue from 'vue';
 import { defineComponent, computed, ref, watch, onMounted, onActivated, onUnmounted } from '@vue/composition-api';
 
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import AddressListItem from './AddressListItem.vue';
 import AddIcon from './icons/AddIcon.vue';
 import { useAddressStore, AddressType, AddressInfo } from '../stores/Address';
@@ -142,7 +143,7 @@ export default defineComponent({
             /* Update the .active-box after the decimals setting is changed */
             router.afterEach((to, from) => {
                 if (from.name === 'settings' && from.query.sidebar && to.name === 'root' && activeAddress.value) {
-                    context.root.$nextTick(() =>
+                    nextTick(() =>
                         activeAddress.value && adjustBackgroundOffsetAndScale(activeAddress.value),
                     );
                 }
@@ -155,7 +156,7 @@ export default defineComponent({
             if (activeAddress.value) adjustBackgroundOffsetAndScale(activeAddress.value);
         });
         onMounted(() => {
-            /* context.root.$nextTick works here except for Opera browser. Using setTimeout instead fix it. */
+            /* nextTick works here except for Opera browser. Using setTimeout instead fix it. */
             /* TODO: find a better way to do it. */
             setTimeout(async () => {
                 if (activeAddress.value) adjustBackgroundOffsetAndScale(activeAddress.value);

--- a/src/components/AddressList.vue
+++ b/src/components/AddressList.vue
@@ -45,6 +45,7 @@
 import Vue from 'vue';
 import { defineComponent, computed, ref, watch, onMounted, onActivated, onUnmounted } from '@vue/composition-api';
 
+import { useI18n } from '@/lib/useI18n';
 import AddressListItem from './AddressListItem.vue';
 import AddIcon from './icons/AddIcon.vue';
 import { useAddressStore, AddressType, AddressInfo } from '../stores/Address';
@@ -95,6 +96,7 @@ export default defineComponent({
         const { height } = useNetworkStore();
         const { amountsHidden } = useSettingsStore();
         const { totalAccountStake } = useStakingStore();
+        const { $t } = useI18n();
 
         function hasLockedBalance(addressInfo: AddressInfo): boolean {
             if (!addressInfo || addressInfo.type !== AddressType.VESTING) return false;
@@ -185,7 +187,7 @@ export default defineComponent({
 
         const btcInfo = computed(() => ({
             address: availableExternalAddresses.value[0] || 'bitcoin',
-            label: context.root.$t('Bitcoin') as string,
+            label: $t('Bitcoin') as string,
             balance: btcAccountBalance.value,
             type: CryptoCurrency.BTC,
         }));
@@ -194,7 +196,7 @@ export default defineComponent({
             if (stablecoin.value === CryptoCurrency.USDC) {
                 return {
                     address: polygonAddressInfo.value?.address || 'usdc',
-                    label: context.root.$t('USD Coin') as string,
+                    label: $t('USD Coin') as string,
                     balance: accountUsdcBalance.value
                         + accountUsdcBridgedBalance.value,
                     type: CryptoCurrency.USDC,
@@ -204,7 +206,7 @@ export default defineComponent({
             if (stablecoin.value === CryptoCurrency.USDT) {
                 return {
                     address: polygonAddressInfo.value?.address || 'usdt',
-                    label: context.root.$t('Tether USD') as string,
+                    label: $t('Tether USD') as string,
                     balance: accountUsdtBridgedBalance.value,
                     type: CryptoCurrency.USDT,
                 };

--- a/src/components/AmountInput.vue
+++ b/src/components/AmountInput.vue
@@ -23,6 +23,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, watch, onMounted } from '@vue/composition-api';
+import { nextTick } from '@/lib/nextTick';
 
 const AmountInput = defineComponent({
     props: {
@@ -83,7 +84,7 @@ const AmountInput = defineComponent({
         }
 
         async function updateWidth() {
-            await context.root.$nextTick(); // Await updated DOM
+            await nextTick(); // Await updated DOM
             if (!widthPlaceholder$.value) return;
 
             const placeholderWidth = widthPlaceholder$.value.offsetWidth;

--- a/src/components/AnnouncementBox.vue
+++ b/src/components/AnnouncementBox.vue
@@ -11,7 +11,7 @@
 import { defineComponent, ref } from '@vue/composition-api';
 import { ArrowRightSmallIcon } from '@nimiq/vue-components';
 import { LocaleMessage } from 'vue-i18n';
-import { RouteName } from '@/router';
+import { RouteName, useRouter } from '@/router';
 import BlueLink from './BlueLink.vue';
 import CrossCloseButton from './CrossCloseButton.vue';
 
@@ -19,6 +19,8 @@ const STORAGE_KEY = 'announcement-box-dismissed';
 
 export default defineComponent({
     setup(props, context) {
+        const router = useRouter();
+
         // text and cta must be functions for translations to work!
         let text: () => LocaleMessage = () => '';
         let cta: () => LocaleMessage = () => '';
@@ -28,7 +30,7 @@ export default defineComponent({
         // text = () => context.root.$t('Buy NIM & BTC with OASIS!');
         text = () => ''; // Disables AnnouncementBox
         cta = () => context.root.$t('Try it now');
-        action = () => context.root.$router.push({ name: RouteName.Buy });
+        action = () => router.push({ name: RouteName.Buy });
         storageKey = 'buy-with-oasis-1';
 
         const wasDismissed = ref(window.localStorage.getItem(STORAGE_KEY) === storageKey);

--- a/src/components/AnnouncementBox.vue
+++ b/src/components/AnnouncementBox.vue
@@ -12,14 +12,16 @@ import { defineComponent, ref } from '@vue/composition-api';
 import { ArrowRightSmallIcon } from '@nimiq/vue-components';
 import { LocaleMessage } from 'vue-i18n';
 import { RouteName, useRouter } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import BlueLink from './BlueLink.vue';
 import CrossCloseButton from './CrossCloseButton.vue';
 
 const STORAGE_KEY = 'announcement-box-dismissed';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const router = useRouter();
+        const { $t } = useI18n();
 
         // text and cta must be functions for translations to work!
         let text: () => LocaleMessage = () => '';
@@ -27,9 +29,9 @@ export default defineComponent({
         let action: string | (() => LocaleMessage) | (() => void) = '';
         let storageKey = ''; // Used to identify if the box has been dismissed yet
 
-        // text = () => context.root.$t('Buy NIM & BTC with OASIS!');
+        // text = () => $t('Buy NIM & BTC with OASIS!');
         text = () => ''; // Disables AnnouncementBox
-        cta = () => context.root.$t('Try it now');
+        cta = () => $t('Try it now');
         action = () => router.push({ name: RouteName.Buy });
         storageKey = 'buy-with-oasis-1';
 

--- a/src/components/BalanceDistribution.vue
+++ b/src/components/BalanceDistribution.vue
@@ -36,6 +36,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { defineComponent, computed, ref, watch } from '@vue/composition-api';
+import { nextTick } from '@/lib/nextTick';
 import { useAddressStore } from '../stores/Address';
 import { useBtcAddressStore } from '../stores/BtcAddress';
 import { usePolygonAddressStore } from '../stores/PolygonAddress';
@@ -97,7 +98,7 @@ export default defineComponent({
             // Update measurements only after the svg has been rendered first, without any arcs, to transition the
             // entry of arcs. Try to measure the actual svg path length if possible because it does not exactly match
             // 2 * PI * r.
-            await Vue.nextTick();
+            await nextTick();
             fullCircleLength.value = svg$.value?.$el?.querySelector('circle')?.getTotalLength()
                 || 2 * Math.PI * RADIUS;
         });

--- a/src/components/BtcAddressInput.vue
+++ b/src/components/BtcAddressInput.vue
@@ -38,6 +38,7 @@ import { defineComponent, ref, watch } from '@vue/composition-api';
 import { LabelInput, ScanQrCodeIcon } from '@nimiq/vue-components';
 import { parseRequestLink, Currency } from '@nimiq/utils';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import { loadBitcoinJS } from '../lib/BitcoinJSLoader';
 import { ENV_MAIN } from '../lib/Constants';
 import { normalizeAddress, validateAddress } from '../lib/BitcoinTransactionUtils';
@@ -132,7 +133,7 @@ const BtcAddressInput = defineComponent({
         }
 
         async function updateInputFontSize() {
-            await context.root.$nextTick();
+            await nextTick();
 
             if (!input$.value) return;
 
@@ -146,7 +147,7 @@ const BtcAddressInput = defineComponent({
             }
 
             inputFontSizeScaleFactor.value = 1;
-            await context.root.$nextTick();
+            await nextTick();
 
             const width = input$.value.$el.children[1].clientWidth;
             const maxWidth = input$.value.$el.children[2].clientWidth - (inputPadding / 2);

--- a/src/components/BtcAddressInput.vue
+++ b/src/components/BtcAddressInput.vue
@@ -37,6 +37,7 @@
 import { defineComponent, ref, watch } from '@vue/composition-api';
 import { LabelInput, ScanQrCodeIcon } from '@nimiq/vue-components';
 import { parseRequestLink, Currency } from '@nimiq/utils';
+import { useI18n } from '@/lib/useI18n';
 import { loadBitcoinJS } from '../lib/BitcoinJSLoader';
 import { ENV_MAIN } from '../lib/Constants';
 import { normalizeAddress, validateAddress } from '../lib/BitcoinTransactionUtils';
@@ -62,6 +63,7 @@ const BtcAddressInput = defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { config } = useConfig();
 
         const input$ = ref<LabelInput>(null);
@@ -97,7 +99,7 @@ const BtcAddressInput = defineComponent({
                         context.emit('domain-address', domain, normalizedAddress);
                         invalid.value = false;
                     } else {
-                        resolverError.value = context.root.$t('Domain does not resolve to a valid address') as string;
+                        resolverError.value = $t('Domain does not resolve to a valid address') as string;
                         invalid.value = true;
                     }
                 } catch (e) {

--- a/src/components/BtcTransactionList.vue
+++ b/src/components/BtcTransactionList.vue
@@ -83,6 +83,7 @@
 import { defineComponent, computed, ref, Ref /* , onMounted, onBeforeUnmount, watch */ } from '@vue/composition-api';
 import { CircleSpinner, AlertTriangleIcon } from '@nimiq/vue-components';
 import BtcTransactionListItem from '@/components/BtcTransactionListItem.vue';
+import { useI18n } from '@/lib/useI18n';
 import { ENV_MAIN } from '../lib/Constants';
 import { useBtcAddressStore } from '../stores/BtcAddress';
 import { Transaction, useBtcTransactionsStore } from '../stores/BtcTransactions';
@@ -137,6 +138,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { state: btcAddresses$, activeAddresses } = useBtcAddressStore();
         const { state: btcTransactions$ } = useBtcTransactionsStore();
         const { isFetchingTxHistory, consensus } = useBtcNetworkStore();
@@ -238,7 +240,7 @@ export default defineComponent({
             let hasThisMonthLabel = false;
 
             if (!txs[n].timestamp) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
                 hasThisMonthLabel = true;
                 while (txs[n] && !txs[n].timestamp) {
@@ -260,7 +262,7 @@ export default defineComponent({
             let txDate: Date;
 
             if (!hasThisMonthLabel && txMonth === currentMonth && txYear === currentYear) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
             }
 

--- a/src/components/BtcTransactionList.vue
+++ b/src/components/BtcTransactionList.vue
@@ -137,8 +137,8 @@ export default defineComponent({
             default: '',
         },
     },
-    setup(props, context) {
-        const { $t } = useI18n();
+    setup(props) {
+        const { $t, locale } = useI18n();
         const { state: btcAddresses$, activeAddresses } = useBtcAddressStore();
         const { state: btcTransactions$ } = useBtcTransactionsStore();
         const { isFetchingTxHistory, consensus } = useBtcNetworkStore();
@@ -284,7 +284,7 @@ export default defineComponent({
                     transactionsWithMonths.push({
                         transactionHash: getLocaleMonthStringFromDate(
                             txDate,
-                            context.root.$i18n.locale,
+                            locale,
                             {
                                 month: 'long',
                                 year: txYear !== currentYear ? 'numeric' : undefined,

--- a/src/components/CountrySelector.vue
+++ b/src/components/CountrySelector.vue
@@ -45,6 +45,7 @@ import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 // @ts-expect-error Could not find a declaration file for module 'v-click-outside'.
 import vClickOutside from 'v-click-outside';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import I18nDisplayNames from '../lib/I18nDisplayNames';
 import CountryFlag from './CountryFlag.vue';
 import { ALL_COUNTRY_CODES } from '../lib/Countries';
@@ -94,7 +95,7 @@ export default defineComponent({
                 selectedIndex.value = 0;
             }
 
-            await context.root.$nextTick();
+            await nextTick();
             if (open && input$.value) input$.value.focus();
         }
 

--- a/src/components/CountrySelector.vue
+++ b/src/components/CountrySelector.vue
@@ -44,6 +44,7 @@
 import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 // @ts-expect-error Could not find a declaration file for module 'v-click-outside'.
 import vClickOutside from 'v-click-outside';
+import { useI18n } from '@/lib/useI18n';
 import I18nDisplayNames from '../lib/I18nDisplayNames';
 import CountryFlag from './CountryFlag.vue';
 import { ALL_COUNTRY_CODES } from '../lib/Countries';
@@ -72,6 +73,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const isOpen = ref(false);
 
         const selectedIndex = ref(0);
@@ -114,7 +116,7 @@ export default defineComponent({
             if (props.includeAllOption) {
                 countries.unshift({
                     code: 'all',
-                    name: context.root.$t('All countries') as string,
+                    name: $t('All countries') as string,
                 });
             }
 

--- a/src/components/DoubleInput.vue
+++ b/src/components/DoubleInput.vue
@@ -28,20 +28,21 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, ref, watch } from '@vue/composition-api';
+import { nextTick } from '@/lib/nextTick';
 import MessageTransition from './MessageTransition.vue';
 
 export default defineComponent({
     props: {
         extended: Boolean,
     },
-    setup(props, context) {
+    setup(props) {
         const secondInput$ = ref<HTMLDivElement>(null);
 
         const labelInputHeight = ref(0);
 
         async function updateLabelInputHeight() {
             if (props.extended && secondInput$.value) {
-                await context.root.$nextTick();
+                await nextTick();
                 const input = secondInput$.value.querySelector('input');
                 if (input) labelInputHeight.value = input.clientHeight;
                 else labelInputHeight.value = 0;

--- a/src/components/LegacyAccountUpgradeButton.vue
+++ b/src/components/LegacyAccountUpgradeButton.vue
@@ -13,12 +13,14 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { createRequestLink, GeneralRequestLinkOptions, NimiqRequestLinkType, Currency } from '@nimiq/utils';
+import { useRouter } from '@/router';
 import { useAccountStore, AccountType } from '../stores/Account';
 import { useAddressStore } from '../stores/Address';
 import { onboard } from '../hub';
 
 export default defineComponent({
     setup(props, context) {
+        const router = useRouter();
         const { accountInfos } = useAccountStore();
         const { activeAddressInfo } = useAddressStore();
 
@@ -33,7 +35,7 @@ export default defineComponent({
             };
 
             const url = createRequestLink(multiAddressAccount.value!.addresses[0], options);
-            context.root.$router.push(`/${url}`);
+            router.push(`/${url}`);
             context.emit('click');
         }
 

--- a/src/components/MessageTransition.vue
+++ b/src/components/MessageTransition.vue
@@ -17,6 +17,7 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import { VNode } from 'vue';
+import { nextTick } from '@/lib/nextTick';
 
 export default defineComponent({
     props: {
@@ -25,7 +26,7 @@ export default defineComponent({
             default: false,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const isReverse = ref(false);
         const messageHeight = ref<number | null>(null);
         const isTransitioning = ref(false);
@@ -50,12 +51,12 @@ export default defineComponent({
         }
 
         async function onEnter(el: HTMLElement) {
-            await context.root.$nextTick();
+            await nextTick();
             messageHeight.value = el.offsetHeight;
         }
 
         async function onAfterLeave() {
-            await context.root.$nextTick();
+            await nextTick();
             messageHeight.value = null;
             isReverse.value = props.reverse;
             isTransitioning.value = false;

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -19,7 +19,7 @@
 import { defineComponent, computed } from '@vue/composition-api';
 import { ArrowRightSmallIcon, ScanQrCodeIcon } from '@nimiq/vue-components';
 import { useConfig } from '@/composables/useConfig';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import { AddressType, useAddressStore } from '../stores/Address';
 import { useAccountStore } from '../stores/Account';
 import { CryptoCurrency } from '../lib/Constants';
@@ -31,6 +31,7 @@ import { useAccountSettingsStore } from '../stores/AccountSettings';
 
 export default defineComponent({
     setup(props, context) {
+        const router = useRouter();
         const { activeAddressInfo, addressInfos } = useAddressStore();
         const { activeCurrency, activeAccountInfo, hasBitcoinAddresses } = useAccountStore();
         const { stablecoin } = useAccountSettingsStore();
@@ -59,9 +60,9 @@ export default defineComponent({
                 && (hasMultipleReceivableAddresses.value || hasBitcoinAddresses.value)
             ) {
                 // redirect to the address selector
-                context.root.$router.push({ name: RouteName.Receive });
+                router.push({ name: RouteName.Receive });
             } else {
-                context.root.$router.push({
+                router.push({
                     name: nimOrBtcOrStable(RouteName.ReceiveNim, RouteName.ReceiveBtc, RouteName.ReceiveUsdc),
                 });
             }
@@ -76,9 +77,9 @@ export default defineComponent({
                 && (hasMultipleSendableAddresses.value || hasBitcoinAddresses.value)
             ) {
                 // redirect to the address selector
-                context.root.$router.push({ name: RouteName.Send });
+                router.push({ name: RouteName.Send });
             } else {
-                context.root.$router.push({
+                router.push({
                     name: nimOrBtcOrStable(RouteName.SendNim, RouteName.SendBtc, RouteName.SendUsdc),
                 });
             }

--- a/src/components/MobileActionBar.vue
+++ b/src/components/MobileActionBar.vue
@@ -30,7 +30,7 @@ import { usePolygonAddressStore } from '../stores/PolygonAddress';
 import { useAccountSettingsStore } from '../stores/AccountSettings';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const router = useRouter();
         const { activeAddressInfo, addressInfos } = useAddressStore();
         const { activeCurrency, activeAccountInfo, hasBitcoinAddresses } = useAccountStore();
@@ -89,7 +89,7 @@ export default defineComponent({
 
         const sendDisabled = computed(() => {
             if (config.disableNetworkInteraction && activeCurrency.value === CryptoCurrency.NIM) return true;
-            return context.root.$route.path !== '/' && nimOrBtcOrStable(
+            return router.currentRoute.path !== '/' && nimOrBtcOrStable(
                 !activeAddressInfo.value || !activeAddressInfo.value.balance,
                 !btcBalance.value,
                 (stablecoin.value === CryptoCurrency.USDC

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script lang="ts">
+import { useI18n } from '@/lib/useI18n';
 import { defineComponent, ref, onMounted, onUnmounted, computed, watch } from '@vue/composition-api';
 
 import CrossCloseButton from './CrossCloseButton.vue';
@@ -30,6 +31,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const containerDiv = ref<HTMLDivElement | null>(null);
         const searchBarInput = ref<HTMLInputElement | null>(null);
         const inputWidth = ref(1000);
@@ -41,10 +43,10 @@ export default defineComponent({
         const placeholderText = computed(() => {
             if (containerWidth.value < 100) return '';
             if (maxWidth.value === '100%' && (containerWidth.value > 400 || inputWidth.value > 350)) {
-                return context.root.$t('Search transactions by contact, address, etc.');
+                return $t('Search transactions by contact, address, etc.');
             }
-            if (containerWidth.value > 210 || inputWidth.value > 150) return context.root.$t('Search transactions');
-            return context.root.$t('Search');
+            if (containerWidth.value > 210 || inputWidth.value > 150) return $t('Search transactions');
+            return $t('Search');
         });
 
         const maxWidth = computed(() => {

--- a/src/components/SendModalFooter.vue
+++ b/src/components/SendModalFooter.vue
@@ -25,6 +25,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import { AlertTriangleIcon, CircleSpinner, PageFooter } from '@nimiq/vue-components';
+import { useI18n } from '@/lib/useI18n';
 import { useBtcNetworkStore } from '../stores/BtcNetwork';
 import { useNetworkStore } from '../stores/Network';
 import { usePolygonNetworkStore } from '../stores/PolygonNetwork';
@@ -48,7 +49,9 @@ export default defineComponent({
             default: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
+        const { $t } = useI18n();
+
         const networkState = computed(() => {
             let message: string | null = null;
 
@@ -60,10 +63,10 @@ export default defineComponent({
                 } = useBtcNetworkStore();
 
                 if (btcConsensus.value !== 'established' || !btcHeight.value) {
-                    message = context.root.$i18n.t('Connecting to Bitcoin network') as string;
+                    message = $t('Connecting to Bitcoin network') as string;
                 } else if (props.requireCompleteBtcHistory && isFetchingBtcHistory.value) {
                     // Current Bitcoin UTXOs and balance are unknown without complete history.
-                    message = context.root.$i18n.t('Syncing with Bitcoin network') as string;
+                    message = $t('Syncing with Bitcoin network') as string;
                 }
             }
 
@@ -71,9 +74,9 @@ export default defineComponent({
                 const { consensus: nimiqConsensus, height: nimiqHeight } = useNetworkStore();
 
                 if (nimiqConsensus.value !== 'established') {
-                    message = context.root.$i18n.t('Connecting to Nimiq network') as string;
+                    message = $t('Connecting to Nimiq network') as string;
                 } else if (!nimiqHeight.value) {
-                    message = context.root.$i18n.t('Waiting for Nimiq network information') as string;
+                    message = $t('Waiting for Nimiq network information') as string;
                 }
             }
 
@@ -81,7 +84,7 @@ export default defineComponent({
                 const { consensus: polygonConsensus } = usePolygonNetworkStore();
 
                 if (polygonConsensus.value !== 'established') {
-                    message = context.root.$i18n.t('Connecting to USDC on Polygon') as string;
+                    message = $t('Connecting to USDC on Polygon') as string;
                 }
             }
 

--- a/src/components/StatusScreen.vue
+++ b/src/components/StatusScreen.vue
@@ -195,7 +195,7 @@ export default defineComponent({
             // only change the _loadingTitle, if we're still in the loading state (and not changing the state right
             // after setting the title) to avoid it being changed on the loading screen when we actually want to set
             // it for the success/error/warning screen.
-            context.root.$nextTick(() => {
+            nextTick(() => {
                 if (props.state !== State.LOADING) return;
                 loadingTitle.value = newTitle;
             });

--- a/src/components/StatusScreen.vue
+++ b/src/components/StatusScreen.vue
@@ -108,6 +108,7 @@
 <script lang="ts">
 import { defineComponent, ref, watch } from '@vue/composition-api';
 import { LoadingSpinner, CheckmarkIcon, FaceNeutralIcon, FaceSadIcon } from '@nimiq/vue-components';
+import { nextTick } from '@/lib/nextTick';
 
 export const SUCCESS_REDIRECT_DELAY = 2000; // 1s of transition + 1s of display
 
@@ -228,7 +229,7 @@ export default defineComponent({
                 clearTimeout(statusUpdateTimeout);
                 // reset transitioning state for new change
                 isTransitioningStatus.value = false;
-                await context.root.$nextTick();
+                await nextTick();
                 await new Promise((resolve) => { requestAnimationFrame(resolve); }); // await style update
                 currentStatus.value = nextStatus.value;
             }

--- a/src/components/TestnetFaucet.vue
+++ b/src/components/TestnetFaucet.vue
@@ -21,6 +21,7 @@ import { defineComponent, ref, Ref } from '@vue/composition-api';
 import { CircleSpinner, CrossIcon } from '@nimiq/vue-components';
 import { LocaleMessage } from 'vue-i18n';
 import Config from 'config';
+import { useI18n } from '@/lib/useI18n';
 
 type FaucetInfoResponse = {
     network: 'test' | 'main',
@@ -58,7 +59,8 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
+        const { $t } = useI18n();
         const canTap = ref(true); // Expect the faucet to be available
         const unavailableMsg: Ref<LocaleMessage> = ref('');
         const errorMsg: Ref<LocaleMessage> = ref('');
@@ -68,22 +70,22 @@ export default defineComponent({
             .then((res) => res.json() as Promise<FaucetInfoResponse>)
             .then((faucet) => {
                 if (faucet.network !== Config.environment) {
-                    unavailableMsg.value = context.root.$t('Faucet unavailable (wrong network)');
+                    unavailableMsg.value = $t('Faucet unavailable (wrong network)');
                     canTap.value = false;
                 }
                 if (faucet.dispensesRemaining < 1) {
-                    unavailableMsg.value = context.root.$t('Faucet is empty');
+                    unavailableMsg.value = $t('Faucet is empty');
                     canTap.value = false;
                 }
                 if (!faucet.availableInRegion) {
-                    unavailableMsg.value = context.root.$t('Faucet is not available from your location');
+                    unavailableMsg.value = $t('Faucet is not available from your location');
                     canTap.value = false;
                 }
 
                 return faucet;
             }).catch((error: Error) => {
                 console.error(error); // eslint-disable-line no-console
-                unavailableMsg.value = `${context.root.$t('Faucet unavailable')} (${error.message})`;
+                unavailableMsg.value = `${$t('Faucet unavailable')} (${error.message})`;
                 canTap.value = false;
                 return null;
             });
@@ -114,33 +116,33 @@ export default defineComponent({
 
                 switch (result.error) {
                     case 'RATE_LIMIT':
-                        errorMsg.value = context.root.$t(
+                        errorMsg.value = $t(
                             'You can receive more free NIM in {waitTime} hours.',
                             { waitTime: Math.ceil(result.wait / 3600) },
                         );
                         break;
                     case 'GEOBLOCKED':
-                        errorMsg.value = context.root.$t(
+                        errorMsg.value = $t(
                             'This service is currently not available in your region.',
                         );
                         break;
                     case 'OUT_OF_FUNDS':
-                        errorMsg.value = context.root.$t('There are currently no free NIM available.');
+                        errorMsg.value = $t('There are currently no free NIM available.');
                         break;
                     case 'TRANSACTION_FAILED':
                         // Set unavailableMsg instead of errorMsg to keep button active for user to try again
-                        unavailableMsg.value = context.root.$t('Faucet error - please try again.');
+                        unavailableMsg.value = $t('Faucet error - please try again.');
                         break;
                     default:
                         // 'INVALID_CAPTCHA', 'VAPTCHA_UNAVAILABLE', 'INVALID_ADDRESS' or unspecified errors should
                         // not occur via this frontend, therefore no need to translate them.
-                        errorMsg.value = `${context.root.$t('Request failed')}: ${result.msg}`;
+                        errorMsg.value = `${$t('Request failed')}: ${result.msg}`;
                 }
 
                 return false;
             }).catch((error: Error) => {
                 console.error(error); // eslint-disable-line no-console
-                errorMsg.value = `${context.root.$t('Request failed')}: ${error.message}`;
+                errorMsg.value = `${$t('Request failed')}: ${error.message}`;
                 return false;
             });
         }

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -145,7 +145,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
-        const { $t } = useI18n();
+        const { $t, locale } = useI18n();
         const { activeAddress, state: addresses$, activeAddressInfo, transactionsForActiveAddress } = useAddressStore();
         const { isFetchingTxHistory, fetchedAddresses } = useNetworkStore();
         const { getLabel: getContactLabel } = useContactsStore();
@@ -269,7 +269,7 @@ export default defineComponent({
                     transactionsWithMonths.push({
                         transactionHash: getLocaleMonthStringFromDate(
                             txDate,
-                            context.root.$i18n.locale,
+                            locale,
                             {
                                 month: 'long',
                                 year: txYear !== currentYear ? 'numeric' : undefined,

--- a/src/components/TransactionList.vue
+++ b/src/components/TransactionList.vue
@@ -78,6 +78,7 @@ import { defineComponent, computed, ref, Ref, watch, onMounted, onUnmounted } fr
 import { CircleSpinner, AlertTriangleIcon } from '@nimiq/vue-components';
 import { AddressBook } from '@nimiq/utils';
 import TransactionListItem from '@/components/TransactionListItem.vue';
+import { useI18n } from '@/lib/useI18n';
 import TestnetFaucet from './TestnetFaucet.vue';
 import CrossCloseButton from './CrossCloseButton.vue';
 import { useAddressStore } from '../stores/Address';
@@ -144,6 +145,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { activeAddress, state: addresses$, activeAddressInfo, transactionsForActiveAddress } = useAddressStore();
         const { isFetchingTxHistory, fetchedAddresses } = useNetworkStore();
         const { getLabel: getContactLabel } = useContactsStore();
@@ -223,7 +225,7 @@ export default defineComponent({
             let hasThisMonthLabel = false;
 
             if (txs[n].state === TransactionState.PENDING) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
                 hasThisMonthLabel = true;
                 while (txs[n] && txs[n].state === TransactionState.PENDING) {
@@ -245,7 +247,7 @@ export default defineComponent({
             let txDate: Date;
 
             if (!hasThisMonthLabel && txMonth === currentMonth && txYear === currentYear) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
             }
 

--- a/src/components/UsdcTransactionList.vue
+++ b/src/components/UsdcTransactionList.vue
@@ -68,6 +68,7 @@
 import { defineComponent, computed, ref, Ref, watch, onMounted, onUnmounted } from '@vue/composition-api';
 import { CircleSpinner, HexagonIcon } from '@nimiq/vue-components';
 import UsdcTransactionListItem from '@/components/UsdcTransactionListItem.vue';
+import { useI18n } from '@/lib/useI18n';
 import { usePolygonAddressStore } from '../stores/PolygonAddress';
 import { useUsdcTransactionsStore, Transaction, TransactionState } from '../stores/UsdcTransactions';
 import { useUsdcContactsStore } from '../stores/UsdcContacts';
@@ -124,6 +125,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { addressInfo } = usePolygonAddressStore();
         const { state: transactions$ } = useUsdcTransactionsStore();
         const { isFetchingUsdcTxHistory } = usePolygonNetworkStore();
@@ -200,7 +202,7 @@ export default defineComponent({
             let hasThisMonthLabel = false;
 
             if (txs[n].state === TransactionState.PENDING) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
                 hasThisMonthLabel = true;
                 while (txs[n] && txs[n].state === TransactionState.PENDING) {
@@ -222,7 +224,7 @@ export default defineComponent({
             let txDate: Date;
 
             if (!hasThisMonthLabel && txMonth === currentMonth && txYear === currentYear) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
             }
 

--- a/src/components/UsdcTransactionList.vue
+++ b/src/components/UsdcTransactionList.vue
@@ -125,7 +125,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
-        const { $t } = useI18n();
+        const { $t, locale } = useI18n();
         const { addressInfo } = usePolygonAddressStore();
         const { state: transactions$ } = useUsdcTransactionsStore();
         const { isFetchingUsdcTxHistory } = usePolygonNetworkStore();
@@ -246,7 +246,7 @@ export default defineComponent({
                     transactionsWithMonths.push({
                         transactionHash: getLocaleMonthStringFromDate(
                             txDate,
-                            context.root.$i18n.locale,
+                            locale,
                             {
                                 month: 'long',
                                 year: txYear !== currentYear ? 'numeric' : undefined,

--- a/src/components/UsdtTransactionList.vue
+++ b/src/components/UsdtTransactionList.vue
@@ -68,6 +68,7 @@
 import { defineComponent, computed, ref, Ref, watch, onMounted, onUnmounted } from '@vue/composition-api';
 import { CircleSpinner, HexagonIcon } from '@nimiq/vue-components';
 import UsdtTransactionListItem from '@/components/UsdtTransactionListItem.vue';
+import { useI18n } from '@/lib/useI18n';
 import { usePolygonAddressStore } from '../stores/PolygonAddress';
 import { useUsdtTransactionsStore, Transaction, TransactionState } from '../stores/UsdtTransactions';
 import { useUsdtContactsStore } from '../stores/UsdtContacts';
@@ -124,6 +125,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { addressInfo } = usePolygonAddressStore();
         const { state: transactions$ } = useUsdtTransactionsStore();
         const { isFetchingUsdtTxHistory } = usePolygonNetworkStore();
@@ -200,7 +202,7 @@ export default defineComponent({
             let hasThisMonthLabel = false;
 
             if (txs[n].state === TransactionState.PENDING) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
                 hasThisMonthLabel = true;
                 while (txs[n] && txs[n].state === TransactionState.PENDING) {
@@ -222,7 +224,7 @@ export default defineComponent({
             let txDate: Date;
 
             if (!hasThisMonthLabel && txMonth === currentMonth && txYear === currentYear) {
-                transactionsWithMonths.push({ transactionHash: context.root.$t('This month'), isLatestMonth });
+                transactionsWithMonths.push({ transactionHash: $t('This month'), isLatestMonth });
                 isLatestMonth = false;
             }
 

--- a/src/components/UsdtTransactionList.vue
+++ b/src/components/UsdtTransactionList.vue
@@ -125,7 +125,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
-        const { $t } = useI18n();
+        const { $t, locale } = useI18n();
         const { addressInfo } = usePolygonAddressStore();
         const { state: transactions$ } = useUsdtTransactionsStore();
         const { isFetchingUsdtTxHistory } = usePolygonNetworkStore();
@@ -246,7 +246,7 @@ export default defineComponent({
                     transactionsWithMonths.push({
                         transactionHash: getLocaleMonthStringFromDate(
                             txDate,
-                            context.root.$i18n.locale,
+                            locale,
                             {
                                 month: 'long',
                                 year: txYear !== currentYear ? 'numeric' : undefined,

--- a/src/components/layouts/AccountOverview.vue
+++ b/src/components/layouts/AccountOverview.vue
@@ -332,7 +332,7 @@
 import { defineComponent, computed, ref, watch, onMounted, onUnmounted, onActivated } from '@vue/composition-api';
 import { SwapAsset } from '@nimiq/fastspot-api';
 import { ArrowRightSmallIcon, AlertTriangleIcon, CircleSpinner, Tooltip } from '@nimiq/vue-components';
-import router, { RouteName } from '@/router';
+import { RouteName, useRouter } from '@/router';
 import AccountBalance from '../AccountBalance.vue';
 import AddressList from '../AddressList.vue';
 import BitcoinIcon from '../icons/BitcoinIcon.vue';
@@ -372,6 +372,7 @@ import { useAccountSettingsStore } from '../../stores/AccountSettings';
 export default defineComponent({
     name: 'account-overview',
     setup(props, context) {
+        const router = useRouter();
         const {
             activeAccountInfo,
             activeAccountId,
@@ -402,7 +403,7 @@ export default defineComponent({
             setActiveCurrency(CryptoCurrency.NIM);
 
             if (isMobile.value) {
-                context.root.$router.push('/transactions');
+                router.push('/transactions');
             }
         }
 
@@ -412,7 +413,7 @@ export default defineComponent({
             setActiveCurrency(CryptoCurrency.BTC);
 
             if (isMobile.value) {
-                context.root.$router.push('/transactions');
+                router.push('/transactions');
             }
         }
 
@@ -420,14 +421,14 @@ export default defineComponent({
             if (!hasPolygonAddresses.value || !stablecoin.value) return;
 
             if (stablecoin.value === CryptoCurrency.USDC && !knowsAboutUsdt.value) {
-                context.root.$router.push({ name: 'usdt-added' });
+                router.push({ name: 'usdt-added' });
                 return;
             }
 
             setActiveCurrency(stablecoin.value);
 
             if (isMobile.value) {
-                context.root.$router.push('/transactions');
+                router.push('/transactions');
             }
         }
 

--- a/src/components/layouts/AccountOverview.vue
+++ b/src/components/layouts/AccountOverview.vue
@@ -333,6 +333,7 @@ import { defineComponent, computed, ref, watch, onMounted, onUnmounted, onActiva
 import { SwapAsset } from '@nimiq/fastspot-api';
 import { ArrowRightSmallIcon, AlertTriangleIcon, CircleSpinner, Tooltip } from '@nimiq/vue-components';
 import { RouteName, useRouter } from '@/router';
+import { nextTick } from '@/lib/nextTick';
 import AccountBalance from '../AccountBalance.vue';
 import AddressList from '../AddressList.vue';
 import BitcoinIcon from '../icons/BitcoinIcon.vue';
@@ -371,7 +372,7 @@ import { useAccountSettingsStore } from '../../stores/AccountSettings';
 
 export default defineComponent({
     name: 'account-overview',
-    setup(props, context) {
+    setup() {
         const router = useRouter();
         const {
             activeAccountInfo,
@@ -491,7 +492,7 @@ export default defineComponent({
         onActivated(forceUpdate); // to update on view change (settings <-> main view)
 
         async function forceUpdate() {
-            await context.root.$nextTick();
+            await nextTick();
             // trick to force vue to update the position on component resize
             forceUpdateRef.value = !forceUpdateRef.value;
             /**
@@ -501,7 +502,7 @@ export default defineComponent({
              * This is workaround to force to re-render the background svg and position it correctly.
              * This does the same as doing a setTimeout(() => forceUpdateRef.value = !forceUpdateRef.value, 0);
              */
-            await context.root.$nextTick();
+            await nextTick();
             forceUpdateRef.value = !forceUpdateRef.value;
         }
 

--- a/src/components/layouts/Groundfloor.vue
+++ b/src/components/layouts/Groundfloor.vue
@@ -26,12 +26,14 @@
 
 <script lang="ts">
 import { defineComponent, ref, watch } from '@vue/composition-api';
+import { useRouter } from '@/router';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const router = useRouter();
         const preventNextTransition = ref(false);
 
-        watch(() => context.root.$route, (to) => {
+        watch(() => router.currentRoute, (to) => {
             preventNextTransition.value = to.name === 'network';
         }, { lazy: true });
 

--- a/src/components/layouts/Network.vue
+++ b/src/components/layouts/Network.vue
@@ -91,6 +91,7 @@ import { InfoCircleIcon, CircleSpinner } from '@nimiq/vue-components';
 import { calculateFee as calculatePolygonFee } from '@/ethers';
 import { estimateFees } from '@/lib/BitcoinTransactionUtils';
 import { getElectrumClient } from '@/electrum';
+import { useI18n } from '@/lib/useI18n';
 import { useSettingsStore } from '../../stores/Settings';
 import { useNetworkStore } from '../../stores/Network';
 import { useAccountSettingsStore } from '../../stores/AccountSettings';
@@ -108,15 +109,16 @@ import router from '../../router';
 const LOCALSTORAGE_KEY = 'network-info-dismissed';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const { $t } = useI18n();
         const { consensus, peerCount } = useNetworkStore();
         const { config } = useConfig();
 
         const consensusStateString = computed(() => ({
-            stalled: context.root.$t('paused'),
-            syncing: context.root.$t('syncing'),
-            connecting: context.root.$t('connecting'),
-            established: context.root.$t('established'),
+            stalled: $t('paused'),
+            syncing: $t('syncing'),
+            connecting: $t('connecting'),
+            established: $t('established'),
         }[consensus.value as 'stalled' | 'syncing' | 'connecting' | 'established']));
 
         const showNetworkInfo = ref(!window.localStorage.getItem(LOCALSTORAGE_KEY));

--- a/src/components/layouts/Settings.vue
+++ b/src/components/layouts/Settings.vue
@@ -295,6 +295,7 @@ import { CircleSpinner } from '@nimiq/vue-components';
 import { ValidationUtils } from '@nimiq/utils';
 import { RouteName } from '@/router';
 
+import { useI18n } from '@/lib/useI18n';
 import MenuIcon from '../icons/MenuIcon.vue';
 import CrossCloseButton from '../CrossCloseButton.vue';
 import CountryFlag from '../CountryFlag.vue';
@@ -313,7 +314,8 @@ import { useKycStore } from '../../stores/Kyc';
 import KycIcon from '../icons/KycIcon.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const { $t } = useI18n();
         const settings = useSettingsStore();
         const { connectedUser: kycUser } = useKycStore();
 
@@ -338,13 +340,13 @@ export default defineComponent({
             try {
                 importedContacts = JSON.parse(data);
             } catch (e) {
-                alert(context.root.$t('Cannot import contacts, wrong file format.')); // eslint-disable-line no-alert
+                alert($t('Cannot import contacts, wrong file format.')); // eslint-disable-line no-alert
                 return;
             }
 
             // Make sure the input is a non-empty array
             if (!Array.isArray(importedContacts) || !importedContacts.length) {
-                alert(context.root.$t('File contains no contacts.')); // eslint-disable-line no-alert
+                alert($t('File contains no contacts.')); // eslint-disable-line no-alert
                 return;
             }
 
@@ -361,7 +363,7 @@ export default defineComponent({
                     if (storedLabel === contact.label) continue;
                     else {
                         // eslint-disable-next-line no-alert, no-restricted-globals
-                        const shouldOverwrite = confirm(context.root.$t(
+                        const shouldOverwrite = confirm($t(
                             'A contact with the address "{address}", but a different name already exists.\n'
                                 + 'Do you want to replace it?',
                             { address },
@@ -372,7 +374,7 @@ export default defineComponent({
 
                 setContact(address, contact.label);
             }
-            alert(context.root.$t('OK! Contacts imported successfully.')); // eslint-disable-line no-alert
+            alert($t('OK! Contacts imported successfully.')); // eslint-disable-line no-alert
         }
 
         function loadFile(event: InputEvent) {

--- a/src/components/layouts/Sidebar.vue
+++ b/src/components/layouts/Sidebar.vue
@@ -234,7 +234,7 @@ export default defineComponent({
             // current route, but with the modal still open on top.
             const modalRoute = router.resolve({ name: routeName }).route;
             const expectedParentRoute = modalRoute.matched.find(({ name }) => !!name && name !== routeName);
-            if (expectedParentRoute && context.root.$route.name !== expectedParentRoute.name) {
+            if (expectedParentRoute && router.currentRoute.name !== expectedParentRoute.name) {
                 // Don't keep the sidebar open for this navigation on mobile because closing it would be a back
                 // navigation on the parent page, leading back to the route we're currently on, instead of closing the
                 // sidebar.

--- a/src/components/layouts/Sidebar.vue
+++ b/src/components/layouts/Sidebar.vue
@@ -192,6 +192,7 @@
 import { defineComponent, ref, computed } from '@vue/composition-api';
 import { SwapAsset } from '@nimiq/fastspot-api';
 import { GearIcon, Tooltip, InfoCircleIcon } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import AnnouncementBox from '../AnnouncementBox.vue';
 import AccountMenu from '../AccountMenu.vue';
 import PriceChart, { TimeRange } from '../PriceChart.vue';
@@ -215,14 +216,15 @@ import { ENV_TEST, ENV_DEV, CryptoCurrency, FIAT_CURRENCIES_OFFERED } from '../.
 export default defineComponent({
     props: {},
     setup(props, context) {
+        const router = useRouter();
         const { config } = useConfig();
         const { isMobile, height: windowHeight } = useWindowSize();
 
         async function navigateTo(path: string) {
             if (isMobile.value) {
-                return context.root.$router.replace(path);
+                return router.replace(path);
             }
-            return context.root.$router.push(path).catch(() => { /* ignore */ });
+            return router.push(path).catch(() => { /* ignore */ });
         }
 
         async function openModal(routeName: string, params: Record<string, string> = {}) {
@@ -230,7 +232,7 @@ export default defineComponent({
             // currently on that route, navigate to it first, such that the modal can be closed later by a simple back
             // navigation leading to that parent route. If we wouldn't do that, a back navigation would lead back to our
             // current route, but with the modal still open on top.
-            const modalRoute = context.root.$router.resolve({ name: routeName }).route;
+            const modalRoute = router.resolve({ name: routeName }).route;
             const expectedParentRoute = modalRoute.matched.find(({ name }) => !!name && name !== routeName);
             if (expectedParentRoute && context.root.$route.name !== expectedParentRoute.name) {
                 // Don't keep the sidebar open for this navigation on mobile because closing it would be a back
@@ -238,7 +240,7 @@ export default defineComponent({
                 // sidebar.
                 await navigateTo(expectedParentRoute.path);
             }
-            return context.root.$router.push({
+            return router.push({
                 name: routeName,
                 query: { sidebar: 'true' }, // on mobile keep sidebar open in background
                 params,

--- a/src/components/modals/AccountMenuModal.vue
+++ b/src/components/modals/AccountMenuModal.vue
@@ -57,7 +57,7 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { AlertTriangleIcon } from '@nimiq/vue-components';
-import { RouteName } from '@/router';
+import { RouteName, useRouter } from '@/router';
 
 import AccountMenuItem from '../AccountMenuItem.vue';
 import Modal from './Modal.vue';
@@ -72,7 +72,8 @@ import { useWindowSize } from '../../composables/useWindowSize';
 import BoxedArrowUpIcon from '../icons/BoxedArrowUpIcon.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const router = useRouter();
         const { accountInfos, activeAccountInfo, activeAccountId, selectAccount } = useAccountStore();
         const { isMobile } = useWindowSize();
 
@@ -89,9 +90,9 @@ export default defineComponent({
             selectAccount(id);
 
             if (isMobile.value) {
-                context.root.$router.replace({ name: RouteName.Root });
+                router.replace({ name: RouteName.Root });
             } else {
-                context.root.$router.push({ name: RouteName.Root }).catch(() => { /* ignore */ });
+                router.push({ name: RouteName.Root }).catch(() => { /* ignore */ });
             }
         }
 

--- a/src/components/modals/AddressSelectorModal.vue
+++ b/src/components/modals/AddressSelectorModal.vue
@@ -25,22 +25,24 @@
 <script lang="ts">
 import { PageBody, PageHeader } from '@nimiq/vue-components';
 import { defineComponent } from '@vue/composition-api';
+import { useRouter } from '@/router';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import AddressList from '../AddressList.vue';
 import { useAccountStore } from '../../stores/Account';
 import { useAccountSettingsStore } from '../../stores/AccountSettings';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const { activeCurrency, hasBitcoinAddresses, hasPolygonAddresses } = useAccountStore();
         const { stablecoin } = useAccountSettingsStore();
 
-        const { name } = context.root.$router.currentRoute;
+        const router = useRouter();
+        const { name } = router.currentRoute;
 
         function addressSelected() {
             disableNextModalTransition();
 
-            context.root.$router.push({
+            router.push({
                 name: `${name}-${activeCurrency.value}`,
                 params: {
                     // It has to be a string since it is a value encapsulated in Location.params

--- a/src/components/modals/BtcActivationModal.vue
+++ b/src/components/modals/BtcActivationModal.vue
@@ -34,7 +34,7 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
 import { PageBody } from '@nimiq/vue-components';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Modal from './Modal.vue';
 import BitcoinIcon from '../icons/BitcoinIcon.vue';
 import { activateBitcoin } from '../../hub';
@@ -47,7 +47,8 @@ export default defineComponent({
     props: {
         redirect: String,
     },
-    setup(props, context) {
+    setup(props) {
+        const router = useRouter();
         const { activeAccountId, setActiveCurrency, hasBitcoinAddresses } = useAccountStore();
 
         const { isMobile } = useWindowSize();
@@ -72,7 +73,7 @@ export default defineComponent({
             if (hasBitcoinAddresses.value && props.redirect) {
                 // The redirect is interpreted as a path and there is no risk of getting redirected to another domain by
                 // a malicious link.
-                await context.root.$router.push(props.redirect);
+                await router.push(props.redirect);
             } else {
                 await modal$.value!.forceClose();
                 if (skipDefaultRedirects) return;
@@ -80,12 +81,12 @@ export default defineComponent({
                 if (isMobile.value && hasBitcoinAddresses.value) {
                     // On mobile, forward to the Bitcoin transactions overview, after Bitcoin got activated and the
                     // redirects by forceClose finished.
-                    await context.root.$router.push('/transactions');
+                    await router.push('/transactions');
                 }
 
                 if (shouldOpenWelcomeModal) {
                     // Open welcome modal with additional BTC and USDC info if not shown yet.
-                    await context.root.$router.push({ name: RouteName.Welcome });
+                    await router.push({ name: RouteName.Welcome });
                 }
             }
         }

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -130,6 +130,7 @@ import {
     InfoCircleSmallIcon,
     QrCodeIcon,
 } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
@@ -319,9 +320,10 @@ export default defineComponent({
             window.removeEventListener('resize', updateAddressFontSizeScaleFactor);
         });
 
+        const router = useRouter();
         function back() {
             disableNextModalTransition();
-            context.root.$router.back();
+            router.back();
         }
 
         return {

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -132,6 +132,7 @@ import {
 } from '@nimiq/vue-components';
 import { useRouter } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
@@ -143,7 +144,7 @@ import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
 import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const { $t, $tc } = useI18n();
         const {
             availableExternalAddresses,
@@ -303,7 +304,7 @@ export default defineComponent({
             }
 
             addressFontSizeScaleFactor.value = 1;
-            await context.root.$nextTick();
+            await nextTick();
 
             const addressWidth = addressWidthFinder$.value.clientWidth;
             const maxWidth = availableAddressCopyable$.value.$el.clientWidth - (addressPadding * 2);

--- a/src/components/modals/BtcReceiveModal.vue
+++ b/src/components/modals/BtcReceiveModal.vue
@@ -131,6 +131,7 @@ import {
     QrCodeIcon,
 } from '@nimiq/vue-components';
 import { useRouter } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useBtcLabelsStore } from '../../stores/BtcLabels';
@@ -143,6 +144,7 @@ import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
     setup(props, context) {
+        const { $t, $tc } = useI18n();
         const {
             availableExternalAddresses,
             copiedExternalAddresses,
@@ -173,16 +175,16 @@ export default defineComponent({
             const difference = now.value - timestamp;
 
             if (difference < 1 * minute) {
-                return context.root.$tc('Created just now');
+                return $tc('Created just now');
             }
             if (difference < 1 * hour) {
-                return context.root.$tc(
+                return $tc(
                     'Created {count} minute ago | Created {count} minutes ago',
                     Math.trunc(difference / minute),
                 );
             }
             if (difference < 1 * day) {
-                return context.root.$tc(
+                return $tc(
                     'Created {count} hour ago | Created {count} hours ago',
                     Math.trunc(difference / hour),
                 );
@@ -190,9 +192,9 @@ export default defineComponent({
             const yesterday = new Date();
             yesterday.setDate(yesterday.getDate() - 1);
             if (timestamp > yesterday.setHours(0, 0, 0, 0)) {
-                return context.root.$t('Created yesterday') as string;
+                return $t('Created yesterday') as string;
             }
-            return context.root.$tc(
+            return $tc(
                 'Created {count} day ago | Created {count} days ago',
                 Math.trunc(difference / day),
             );

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -144,6 +144,7 @@ import {
 } from '@nimiq/vue-components';
 import { parseRequestLink, Currency, CurrencyInfo } from '@nimiq/utils';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import BtcAddressInput from '../BtcAddressInput.vue';
 import BtcLabelInput from '../BtcLabelInput.vue';
@@ -182,6 +183,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const {
             state: addresses$,
             accountUtxos,
@@ -459,7 +461,7 @@ export default defineComponent({
             // Show loading screen
             statusScreenOpened.value = true;
             statusState.value = State.LOADING;
-            statusTitle.value = context.root.$t('Sending Transaction') as string;
+            statusTitle.value = $t('Sending Transaction') as string;
             statusMessage.value = '';
 
             let changeAddress: string;
@@ -505,11 +507,11 @@ export default defineComponent({
                 // Show success screen
                 statusState.value = State.SUCCESS;
                 statusTitle.value = recipientWithLabel.value!.label
-                    ? context.root.$t('Sent {btc} BTC to {name}', {
+                    ? $t('Sent {btc} BTC to {name}', {
                         btc: amount.value / 1e8,
                         name: recipientWithLabel.value!.label,
                     }) as string
-                    : context.root.$t('Sent {btc} BTC', {
+                    : $t('Sent {btc} BTC', {
                         btc: amount.value / 1e8,
                     }) as string;
 
@@ -523,7 +525,7 @@ export default defineComponent({
 
                 // Show error screen
                 statusState.value = State.WARNING;
-                statusTitle.value = context.root.$t('Something went wrong') as string;
+                statusTitle.value = $t('Something went wrong') as string;
                 statusMessage.value = (error as Error).message;
             }
         }

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -145,6 +145,7 @@ import {
 import { parseRequestLink, Currency, CurrencyInfo } from '@nimiq/utils';
 import { useRouter, RouteName } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import BtcAddressInput from '../BtcAddressInput.vue';
 import BtcLabelInput from '../BtcLabelInput.vue';
@@ -182,7 +183,7 @@ export default defineComponent({
             required: false,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const { $t } = useI18n();
         const {
             state: addresses$,
@@ -344,7 +345,7 @@ export default defineComponent({
             }
             // Need to wait here for the next processing tick, as otherwise we would have a
             // race condition between the amount assignment and the fiatAmount watcher.
-            await context.root.$nextTick();
+            await nextTick();
             amount.value = maxSendableAmount.value;
         }
 
@@ -424,7 +425,7 @@ export default defineComponent({
             // TODO: Detect onscreen keyboards instead?
             if (isMobile.value) return;
 
-            await context.root.$nextTick();
+            await nextTick();
             if (!element$.value) return;
             element$.value.focus();
         }

--- a/src/components/modals/BtcSendModal.vue
+++ b/src/components/modals/BtcSendModal.vue
@@ -143,7 +143,7 @@ import {
     InfoCircleSmallIcon,
 } from '@nimiq/vue-components';
 import { parseRequestLink, Currency, CurrencyInfo } from '@nimiq/utils';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import BtcAddressInput from '../BtcAddressInput.vue';
 import BtcLabelInput from '../BtcLabelInput.vue';
@@ -545,10 +545,11 @@ export default defineComponent({
         }
 
         const { btcUnit } = useSettingsStore();
+        const router = useRouter();
 
         function back() {
             disableNextModalTransition();
-            context.root.$router.back();
+            router.back();
         }
 
         return {

--- a/src/components/modals/BtcTransactionModal.vue
+++ b/src/components/modals/BtcTransactionModal.vue
@@ -347,6 +347,7 @@ import { RefundSwapRequest, SignedBtcTransaction } from '@nimiq/hub-api';
 import { SwapAsset, getAssets } from '@nimiq/fastspot-api';
 import { SettlementStatus } from '@nimiq/oasis-api';
 import { RouteName, useRouter } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import Modal from './Modal.vue';
@@ -392,6 +393,7 @@ export default defineComponent({
     },
     setup(props, context) {
         const router = useRouter();
+        const { $t } = useI18n();
         const constants = { FIAT_PRICE_UNAVAILABLE };
         const transaction = computed(() => useBtcTransactionsStore().state.transactions[props.hash]);
 
@@ -465,7 +467,7 @@ export default defineComponent({
         // Data
         const data = computed(() => {
             if (isCancelledSwap.value) {
-                return isIncoming.value ? context.root.$t('HTLC Refund') : context.root.$t('HTLC Creation');
+                return isIncoming.value ? $t('HTLC Refund') : $t('HTLC Creation');
             }
 
             return '';

--- a/src/components/modals/BtcTransactionModal.vue
+++ b/src/components/modals/BtcTransactionModal.vue
@@ -346,7 +346,7 @@ import { TransactionState } from '@nimiq/electrum-client';
 import { RefundSwapRequest, SignedBtcTransaction } from '@nimiq/hub-api';
 import { SwapAsset, getAssets } from '@nimiq/fastspot-api';
 import { SettlementStatus } from '@nimiq/oasis-api';
-import { RouteName } from '@/router';
+import { RouteName, useRouter } from '@/router';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import Modal from './Modal.vue';
@@ -391,6 +391,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const router = useRouter();
         const constants = { FIAT_PRICE_UNAVAILABLE };
         const transaction = computed(() => useBtcTransactionsStore().state.transactions[props.hash]);
 
@@ -571,7 +572,7 @@ export default defineComponent({
             if (!tx) return;
             const plainTx = await sendTransaction(tx as SignedBtcTransaction);
             await context.root.$nextTick();
-            context.root.$router.replace({
+            router.replace({
                 name: RouteName.BtcTransaction,
                 params: { transactionHash: plainTx.transactionHash },
             });

--- a/src/components/modals/BtcTransactionModal.vue
+++ b/src/components/modals/BtcTransactionModal.vue
@@ -348,6 +348,7 @@ import { SwapAsset, getAssets } from '@nimiq/fastspot-api';
 import { SettlementStatus } from '@nimiq/oasis-api';
 import { RouteName, useRouter } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import Modal from './Modal.vue';
@@ -391,7 +392,7 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const router = useRouter();
         const { $t } = useI18n();
         const constants = { FIAT_PRICE_UNAVAILABLE };
@@ -573,7 +574,7 @@ export default defineComponent({
             const tx = await refundSwap(requestPromise);
             if (!tx) return;
             const plainTx = await sendTransaction(tx as SignedBtcTransaction);
-            await context.root.$nextTick();
+            await nextTick();
             router.replace({
                 name: RouteName.BtcTransaction,
                 params: { transactionHash: plainTx.transactionHash },

--- a/src/components/modals/BuyCryptoModal.vue
+++ b/src/components/modals/BuyCryptoModal.vue
@@ -332,6 +332,7 @@ import {
 } from '@nimiq/hub-api';
 import { Bank } from '@nimiq/oasis-bank-list';
 import { getNetworkClient } from '@/network';
+import { useRouter } from '@/router';
 import { SwapState, useSwapsStore } from '@/stores/Swaps';
 import { useNetworkStore } from '@/stores/Network';
 import { useFiatStore } from '@/stores/Fiat';
@@ -390,7 +391,7 @@ enum Pages {
 const ESTIMATE_UPDATE_DEBOUNCE_DURATION = 500; // ms
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const { activeAccountInfo, activeCurrency, hasBitcoinAddresses } = useAccountStore();
         const { activeAddressInfo, activeAddress } = useAddressStore();
         const { exchangeRates } = useFiatStore();
@@ -469,6 +470,8 @@ export default defineComponent({
             && !isBelowOasisMinimum.value,
         );
 
+        const router = useRouter();
+
         onMounted(() => {
             if (!swap.value) {
                 fetchAssets();
@@ -486,7 +489,7 @@ export default defineComponent({
             } else if (page.value === Pages.BANK_CHECK) {
                 goBack();
             } else {
-                context.root.$router.back();
+                router.back();
             }
         }
 

--- a/src/components/modals/HistoryExportModal.vue
+++ b/src/components/modals/HistoryExportModal.vue
@@ -30,6 +30,7 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
 import { PageBody, PageHeader, PageFooter, CircleSpinner } from '@nimiq/vue-components';
+import { useI18n } from '@/lib/useI18n';
 import { ExportFormat, exportTransactions } from '../../lib/export/TransactionExport';
 import { useAccountStore } from '../../stores/Account';
 import Modal from './Modal.vue';
@@ -45,9 +46,10 @@ export default defineComponent({
             default: 'account',
         },
     },
-    setup(props, context) {
+    setup(props) {
+        const { $t } = useI18n();
         const formats = {
-            [ExportFormat.GENERIC]: { label: context.root.$t('Generic') as string },
+            [ExportFormat.GENERIC]: { label: $t('Generic') as string },
             [ExportFormat.BLOCKPIT]: { label: 'Blockpit' },
         };
         const format = ref(ExportFormat.GENERIC);

--- a/src/components/modals/MigrationWelcomeModal.vue
+++ b/src/components/modals/MigrationWelcomeModal.vue
@@ -95,13 +95,15 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
 import { PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import BlueLink from '../BlueLink.vue';
 
 import Modal from './Modal.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const page = ref(1);
+        const router = useRouter();
 
         function reset() {
             page.value = 1;
@@ -109,7 +111,7 @@ export default defineComponent({
 
         function onButtonClick() {
             if (page.value === 3) {
-                context.root.$router.back();
+                router.back();
             } else {
                 page.value += 1;
             }

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -89,7 +89,7 @@ const Modal = defineComponent({
             // For example: choose a sender via AddressSelectorModal -> open qr scanner from SendModal -> after scan in
             // ScanQrModal return to SendModal -> abort the action in SendModal
 
-            while (context.root.$route.matched.find((routeRecord) => 'modal' in routeRecord.components
+            while (router.currentRoute.matched.find((routeRecord) => 'modal' in routeRecord.components
                 || 'persistent-modal' in routeRecord.components
                 || Object.values(routeRecord.components).some((component) => /modal/i.test(component.name || '')))
             ) {
@@ -157,7 +157,7 @@ const Modal = defineComponent({
 
                 if (isMobileNow && !wasMobile && swipingEnabled.value === 1) {
                     showSwipeHandle.value = true;
-                    context.root.$nextTick(attachSwipe);
+                    nextTick(attachSwipe);
                 } else if (!isMobileNow && showSwipeHandle.value) {
                     detachSwipe();
                     showSwipeHandle.value = false;

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -28,6 +28,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, onUnmounted, Ref, ref, watch } from '@vue/composition-api';
 import { SmallPage, CloseButton } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import { useWindowSize } from '../../composables/useWindowSize';
 import { useSwipes } from '../../composables/useSwipes';
 import { useSettingsStore } from '../../stores/Settings';
@@ -66,6 +67,8 @@ const Modal = defineComponent({
         },
     },
     setup(props, context) {
+        const router = useRouter();
+
         function close() {
             if (props.showOverlay) {
                 context.emit('close-overlay');
@@ -89,7 +92,7 @@ const Modal = defineComponent({
                 || 'persistent-modal' in routeRecord.components
                 || Object.values(routeRecord.components).some((component) => /modal/i.test(component.name || '')))
             ) {
-                context.root.$router.back();
+                router.back();
 
                 // eslint-disable-next-line no-await-in-loop
                 await new Promise((resolve) => {

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -29,6 +29,7 @@
 import { computed, defineComponent, onMounted, onUnmounted, Ref, ref, watch } from '@vue/composition-api';
 import { SmallPage, CloseButton } from '@nimiq/vue-components';
 import { useRouter } from '@/router';
+import { nextTick } from '@/lib/nextTick';
 import { useWindowSize } from '../../composables/useWindowSize';
 import { useSwipes } from '../../composables/useSwipes';
 import { useSettingsStore } from '../../stores/Settings';
@@ -136,7 +137,7 @@ const Modal = defineComponent({
             if (currentYPosition >= closeBarrier && initialYPosition < closeBarrier) {
                 // Close modal
                 close();
-                await context.root.$nextTick();
+                await nextTick();
             }
         }
 

--- a/src/components/modals/NetworkInfoModal.vue
+++ b/src/components/modals/NetworkInfoModal.vue
@@ -27,11 +27,12 @@
 <script lang="ts">
 import { defineComponent, ref, onMounted, onUnmounted } from '@vue/composition-api';
 import { PageBody } from '@nimiq/vue-components';
+import { nextTick } from '@/lib/nextTick';
 import Modal from './Modal.vue';
 import BlueLink from '../BlueLink.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         /**
          * This is needed to update the height of the .image element since we're using the `shape-outside` property
          * and that the img inside need to be vertically centered. This cannot be done with css only unfortunately.
@@ -42,7 +43,7 @@ export default defineComponent({
         const height = ref<number>(0);
 
         async function updateHeight() {
-            await context.root.$nextTick();
+            await nextTick();
             if (textDiv$.value && height.value !== textDiv$.value.clientHeight) {
                 height.value = textDiv$.value.clientHeight;
             }

--- a/src/components/modals/PolygonActivationModal.vue
+++ b/src/components/modals/PolygonActivationModal.vue
@@ -53,6 +53,7 @@
 import { defineComponent, ref, computed } from '@vue/composition-api';
 import { PageBody } from '@nimiq/vue-components';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Modal from './Modal.vue';
 import { activatePolygon } from '../../hub';
 import {
@@ -67,12 +68,13 @@ export default defineComponent({
     props: {
         redirect: String,
     },
-    setup(props, context) {
+    setup(props) {
         const { activeAccountId, hasPolygonAddresses } = useAccountStore();
         const { isMobile } = useWindowSize();
         const { config } = useConfig();
         const modal$ = ref<Modal>(null);
         const router = useRouter();
+        const { $t } = useI18n();
 
         const welcomeModalAlreadyShown = window.localStorage.getItem(WELCOME_MODAL_LOCALSTORAGE_KEY);
         // TODO in future, once some time has passed since the USDC release with the new Welcome modal, only show the
@@ -91,9 +93,9 @@ export default defineComponent({
         );
 
         const buttonText = computed(() => {
-            if (shouldOpenWelcomeStakingModal.value) return context.root.$t('Learn about the new Nimiq');
-            if (shouldOpenWelcomeModal.value) return context.root.$t('Check the new intro');
-            return context.root.$t('Got it');
+            if (shouldOpenWelcomeStakingModal.value) return $t('Learn about the new Nimiq');
+            if (shouldOpenWelcomeModal.value) return $t('Check the new intro');
+            return $t('Got it');
         });
 
         async function enablePolygon() {

--- a/src/components/modals/PolygonActivationModal.vue
+++ b/src/components/modals/PolygonActivationModal.vue
@@ -52,7 +52,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed } from '@vue/composition-api';
 import { PageBody } from '@nimiq/vue-components';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Modal from './Modal.vue';
 import { activatePolygon } from '../../hub';
 import {
@@ -72,6 +72,7 @@ export default defineComponent({
         const { isMobile } = useWindowSize();
         const { config } = useConfig();
         const modal$ = ref<Modal>(null);
+        const router = useRouter();
 
         const welcomeModalAlreadyShown = window.localStorage.getItem(WELCOME_MODAL_LOCALSTORAGE_KEY);
         // TODO in future, once some time has passed since the USDC release with the new Welcome modal, only show the
@@ -100,7 +101,7 @@ export default defineComponent({
             if (!hasPolygonAddresses.value) return;
             await close(true);
             if (!props.redirect) {
-                context.root.$router.push({ name: RouteName.StablecoinSelection });
+                router.push({ name: RouteName.StablecoinSelection });
             }
         }
 
@@ -108,7 +109,7 @@ export default defineComponent({
             if (hasPolygonAddresses.value && props.redirect) {
                 // The redirect is interpreted as a path and there is no risk of getting redirected to another domain by
                 // a malicious link.
-                await context.root.$router.push(props.redirect);
+                await router.push(props.redirect);
             } else {
                 await modal$.value!.forceClose();
                 if (skipDefaultRedirects) return;
@@ -116,15 +117,15 @@ export default defineComponent({
                 if (isMobile.value && hasPolygonAddresses.value) {
                     // On mobile, forward to the USDC transactions overview, after USDC got activated and the
                     // redirects by forceClose finished.
-                    await context.root.$router.push('/transactions');
+                    await router.push('/transactions');
                 }
 
                 if (shouldOpenWelcomeStakingModal.value) {
                     // Open welcome staking modal if not shown yet
-                    await context.root.$router.push({ name: RouteName.WelcomeStaking });
+                    await router.push({ name: RouteName.WelcomeStaking });
                 } else if (shouldOpenWelcomeModal.value) {
                     // Open welcome modal with additional BTC and USDC info if not shown yet
-                    await context.root.$router.push({ name: RouteName.Welcome });
+                    await router.push({ name: RouteName.Welcome });
                 }
             }
         }

--- a/src/components/modals/ReceiveModal.vue
+++ b/src/components/modals/ReceiveModal.vue
@@ -49,6 +49,7 @@ import {
     AddressDisplay,
     QrCodeIcon,
 } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import { useAddressStore, AddressType } from '../../stores/Address';
 import PaymentLinkOverlay from './overlays/PaymentLinkOverlay.vue';
@@ -56,7 +57,8 @@ import QrCodeOverlay from './overlays/QrCodeOverlay.vue';
 
 export default defineComponent({
     name: 'receive-modal',
-    setup(props, context) {
+    setup() {
+        const router = useRouter();
         const addressQrCodeOverlayOpened = ref(false);
         const receiveLinkOverlayOpened = ref(false);
 
@@ -69,7 +71,7 @@ export default defineComponent({
 
         function back() {
             disableNextModalTransition();
-            context.root.$router.back();
+            router.back();
         }
 
         return {

--- a/src/components/modals/SellCryptoModal.vue
+++ b/src/components/modals/SellCryptoModal.vue
@@ -293,6 +293,7 @@ import {
 } from '@nimiq/hub-api';
 import { Bank } from '@nimiq/oasis-bank-list';
 import { useRouter } from '@/router';
+import { nextTick } from '@/lib/nextTick';
 import { getNetworkClient } from '../../network';
 import { SwapState, useSwapsStore } from '../../stores/Swaps';
 import { useNetworkStore } from '../../stores/Network';
@@ -358,7 +359,7 @@ enum Pages {
 const ESTIMATE_UPDATE_DEBOUNCE_DURATION = 500; // ms
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const router = useRouter();
         const { activeAccountInfo, activeCurrency, hasBitcoinAddresses } = useAccountStore();
         const { activeAddressInfo, activeAddress } = useAddressStore();
@@ -482,7 +483,7 @@ export default defineComponent({
         async function onBankDetailsEntered(newBankAccount: BankAccount) {
             setBankAccount(newBankAccount);
             page.value = Pages.SETUP_BUY;
-            await context.root.$nextTick();
+            await nextTick();
             if (cryptoAmountInput$.value) cryptoAmountInput$.value.focus();
         }
 

--- a/src/components/modals/SellCryptoModal.vue
+++ b/src/components/modals/SellCryptoModal.vue
@@ -292,6 +292,7 @@ import {
     SetupSwapResult,
 } from '@nimiq/hub-api';
 import { Bank } from '@nimiq/oasis-bank-list';
+import { useRouter } from '@/router';
 import { getNetworkClient } from '../../network';
 import { SwapState, useSwapsStore } from '../../stores/Swaps';
 import { useNetworkStore } from '../../stores/Network';
@@ -358,6 +359,7 @@ const ESTIMATE_UPDATE_DEBOUNCE_DURATION = 500; // ms
 
 export default defineComponent({
     setup(props, context) {
+        const router = useRouter();
         const { activeAccountInfo, activeCurrency, hasBitcoinAddresses } = useAccountStore();
         const { activeAddressInfo, activeAddress } = useAddressStore();
         const { exchangeRates } = useFiatStore();
@@ -468,7 +470,7 @@ export default defineComponent({
             } else if (page.value === Pages.BANK_CHECK) {
                 goBack();
             } else {
-                context.root.$router.back();
+                router.back();
             }
         }
 

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -266,6 +266,7 @@ import {
 } from '@nimiq/vue-components';
 import { parseRequestLink, AddressBook, Utf8Tools, Currency, CurrencyInfo, ValidationUtils } from '@nimiq/utils';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import ContactShortcuts from '../ContactShortcuts.vue';
 import ContactBook from '../ContactBook.vue';
@@ -317,6 +318,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         enum Pages {
             RECIPIENT_INPUT,
             AMOUNT_INPUT,
@@ -374,7 +376,7 @@ export default defineComponent({
                         };
                         page.value = Pages.AMOUNT_INPUT;
                     } else {
-                        resolverError.value = context.root.$t('Domain does not resolve to a valid address') as string;
+                        resolverError.value = $t('Domain does not resolve to a valid address') as string;
                     }
                 } catch (e) {
                     console.debug(e); // eslint-disable-line no-console
@@ -634,7 +636,7 @@ export default defineComponent({
             } catch (e) {
                 statusType.value = 'go-crypto';
                 statusState.value = State.WARNING;
-                statusTitle.value = context.root.$t('Something went wrong') as string;
+                statusTitle.value = $t('Something went wrong') as string;
                 statusMessage.value = e instanceof Error ? e.message : String(e);
             } finally {
                 clearTimeout(goCryptoMonitoringTimeout); // end if requested, or clear to avoid parallel monitoring
@@ -765,7 +767,7 @@ export default defineComponent({
             // Show loading screen
             statusType.value = 'signing';
             statusState.value = State.LOADING;
-            statusTitle.value = context.root.$t('Sending Transaction') as string;
+            statusTitle.value = $t('Sending Transaction') as string;
             statusMessage.value = '';
 
             try {
@@ -800,11 +802,11 @@ export default defineComponent({
                 statusType.value = 'signing';
                 statusState.value = State.SUCCESS;
                 statusTitle.value = recipientWithLabel.value!.label
-                    ? context.root.$t('Sent {nim} NIM to {name}', {
+                    ? $t('Sent {nim} NIM to {name}', {
                         nim: amount.value / 1e5,
                         name: recipientWithLabel.value!.label,
                     }) as string
-                    : context.root.$t('Sent {nim} NIM', {
+                    : $t('Sent {nim} NIM', {
                         nim: amount.value / 1e5,
                     }) as string;
 
@@ -819,7 +821,7 @@ export default defineComponent({
                 // Show error screen
                 statusType.value = 'signing';
                 statusState.value = State.WARNING;
-                statusTitle.value = context.root.$t('Something went wrong') as string;
+                statusTitle.value = $t('Something went wrong') as string;
                 statusMessage.value = `${error.message} - ${error.data}`;
             }
         }

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -267,6 +267,7 @@ import {
 import { parseRequestLink, AddressBook, Utf8Tools, Currency, CurrencyInfo, ValidationUtils } from '@nimiq/utils';
 import { useRouter, RouteName } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import ContactShortcuts from '../ContactShortcuts.vue';
 import ContactBook from '../ContactBook.vue';
@@ -317,7 +318,7 @@ export default defineComponent({
             required: false,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const { $t } = useI18n();
         enum Pages {
             RECIPIENT_INPUT,
@@ -524,7 +525,7 @@ export default defineComponent({
             }
             // Need to wait here for the next processing tick, as otherwise we would have a
             // race condition between the amount assignment and the fiatAmount watcher.
-            await context.root.$nextTick();
+            await nextTick();
             amount.value = maxSendableAmount.value;
         }
 
@@ -730,7 +731,7 @@ export default defineComponent({
             // TODO: Detect onscreen keyboards instead?
             if (isMobile.value) return;
 
-            await context.root.$nextTick();
+            await nextTick();
             if (!element$.value) return;
             element$.value.focus();
         }

--- a/src/components/modals/SendModal.vue
+++ b/src/components/modals/SendModal.vue
@@ -265,7 +265,7 @@ import {
     InfoCircleSmallIcon,
 } from '@nimiq/vue-components';
 import { parseRequestLink, AddressBook, Utf8Tools, Currency, CurrencyInfo, ValidationUtils } from '@nimiq/utils';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Modal, { disableNextModalTransition } from './Modal.vue';
 import ContactShortcuts from '../ContactShortcuts.vue';
 import ContactBook from '../ContactBook.vue';
@@ -858,9 +858,10 @@ export default defineComponent({
             }
         }
 
+        const router = useRouter();
         function back() {
             disableNextModalTransition();
-            context.root.$router.back();
+            router.back();
         }
 
         let successCloseTimeout = 0;

--- a/src/components/modals/SimplexModal.vue
+++ b/src/components/modals/SimplexModal.vue
@@ -54,6 +54,7 @@
 <script lang="ts">
 import { defineComponent, ref, onMounted, onActivated, onUnmounted, computed } from '@vue/composition-api';
 import { Tooltip, InfoCircleSmallIcon, PageHeader, PageBody, Identicon } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import Modal from './Modal.vue';
 import ResizingCopyable from '../ResizingCopyable.vue';
 import { useSettingsStore } from '../../stores/Settings';
@@ -145,6 +146,8 @@ export default defineComponent({
             });
         }
 
+        const router = useRouter();
+
         async function loadScripts(): Promise<any> {
             // Check if script already exists
             if (document.querySelector('script#simplex-form-script')) {
@@ -156,7 +159,7 @@ export default defineComponent({
 
                 window.Simplex.subscribe('onlineFlowFinished', () => {
                     // Close modal
-                    context.root.$router.push('/');
+                    router.push('/');
                 });
             };
 
@@ -271,7 +274,7 @@ export default defineComponent({
 
             try {
                 // Try setting the language in the URL (Simplex SDK takes it from there)
-                await context.root.$router.replace({ name: 'simplex', query: { lang: language } });
+                await router.replace({ name: 'simplex', query: { lang: language } });
             } catch (error) {
                 // ignore
             }

--- a/src/components/modals/StablecoinReceiveModal.vue
+++ b/src/components/modals/StablecoinReceiveModal.vue
@@ -45,6 +45,7 @@
 import { computed, defineComponent, ref } from '@vue/composition-api';
 import { PageHeader, PageBody, QrCode } from '@nimiq/vue-components';
 import { CryptoCurrency } from '@nimiq/utils';
+import { useRouter } from '@/router';
 import { usePolygonAddressStore } from '../../stores/PolygonAddress';
 import { useUsdcTransactionsStore } from '../../stores/UsdcTransactions';
 import { useUsdtTransactionsStore } from '../../stores/UsdtTransactions';
@@ -57,11 +58,13 @@ import { useAccountSettingsStore } from '../../stores/AccountSettings';
 
 export default defineComponent({
     name: 'stablecoin-receive-modal',
-    setup(props, context) {
+    setup() {
         enum Pages {
             WARNING,
             RECEIVE,
         }
+
+        const router = useRouter();
 
         const { state: addresses$, addressInfo } = usePolygonAddressStore();
         const { stablecoin } = useAccountSettingsStore();
@@ -90,7 +93,7 @@ export default defineComponent({
         function back() {
             if (page.value === initialPage) {
                 disableNextModalTransition();
-                context.root.$router.back();
+                router.back();
             } else if (page.value === Pages.RECEIVE) {
                 page.value = Pages.WARNING;
                 hasSeenAddress.value = false;

--- a/src/components/modals/StablecoinSelectionModal.vue
+++ b/src/components/modals/StablecoinSelectionModal.vue
@@ -36,6 +36,7 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
 import { PageBody, PageHeader, PageFooter, CaretRightSmallIcon } from '@nimiq/vue-components';
+import { useRouter } from '@/router';
 import Modal from './Modal.vue';
 import { CryptoCurrency } from '../../lib/Constants';
 import StablecoinSelector from '../StablecoinSelector.vue';
@@ -45,7 +46,7 @@ import { useWindowSize } from '../../composables/useWindowSize';
 
 export default defineComponent({
     name: 'stablecoin-selection-modal',
-    setup(props, context) {
+    setup() {
         const modal$ = ref<Modal>(null);
 
         const selection = ref<Stablecoin>(CryptoCurrency.USDC);
@@ -54,12 +55,14 @@ export default defineComponent({
 
         const { isMobile } = useWindowSize();
 
+        const router = useRouter();
+
         async function choose() {
             useAccountSettingsStore().setStablecoin(selection.value);
             useAccountStore().setActiveCurrency(selection.value);
             await modal$.value?.forceClose();
             if (isMobile.value) {
-                context.root.$router.push('/transactions');
+                router.push('/transactions');
             }
         }
 

--- a/src/components/modals/StablecoinSendModal.vue
+++ b/src/components/modals/StablecoinSendModal.vue
@@ -252,6 +252,7 @@ import {
 import { computed, defineComponent, onBeforeUnmount, ref, Ref, watch } from '@vue/composition-api';
 import { useRouter, RouteName } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import { useConfig } from '../../composables/useConfig';
 import { useWindowSize } from '../../composables/useWindowSize';
 import { sendPolygonTransaction } from '../../hub';
@@ -299,7 +300,7 @@ export default defineComponent({
             required: false,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const { $t } = useI18n();
         enum Pages {
             WARNING,
@@ -502,7 +503,7 @@ export default defineComponent({
             }
             // Need to wait here for the next processing tick, as otherwise we would have a
             // race condition between the amount assignment and the fiatAmount watcher.
-            await context.root.$nextTick();
+            await nextTick();
             amount.value = maxSendableAmount.value;
         }
 
@@ -588,7 +589,7 @@ export default defineComponent({
             // TODO: Detect onscreen keyboards instead?
             if (isMobile.value) return;
 
-            await context.root.$nextTick();
+            await nextTick();
             if (!elementRef.value) return;
             elementRef.value.focus();
         }

--- a/src/components/modals/StablecoinSendModal.vue
+++ b/src/components/modals/StablecoinSendModal.vue
@@ -250,7 +250,7 @@ import {
     CircleSpinner,
 } from '@nimiq/vue-components';
 import { computed, defineComponent, onBeforeUnmount, ref, Ref, watch } from '@vue/composition-api';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import { useConfig } from '../../composables/useConfig';
 import { useWindowSize } from '../../composables/useWindowSize';
 import { sendPolygonTransaction } from '../../hub';
@@ -712,10 +712,11 @@ export default defineComponent({
             statusScreenOpened.value = false;
         }
 
+        const router = useRouter();
         function back() {
             if (page.value === initialPage) {
                 disableNextModalTransition();
-                context.root.$router.back();
+                router.back();
             } else if (page.value === Pages.RECIPIENT_INPUT) {
                 page.value = Pages.WARNING;
             } else if (page.value === Pages.AMOUNT_INPUT) {

--- a/src/components/modals/StablecoinSendModal.vue
+++ b/src/components/modals/StablecoinSendModal.vue
@@ -251,6 +251,7 @@ import {
 } from '@nimiq/vue-components';
 import { computed, defineComponent, onBeforeUnmount, ref, Ref, watch } from '@vue/composition-api';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import { useConfig } from '../../composables/useConfig';
 import { useWindowSize } from '../../composables/useWindowSize';
 import { sendPolygonTransaction } from '../../hub';
@@ -299,6 +300,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         enum Pages {
             WARNING,
             RECIPIENT_INPUT,
@@ -368,7 +370,7 @@ export default defineComponent({
                         const normalizedAddress = ethers.utils.getAddress(resolvedAddress); // normalize with checksum
                         onAddressEntered(normalizedAddress, domain);
                     } else {
-                        resolverError.value = context.root.$t('Domain does not resolve to a valid address') as string;
+                        resolverError.value = $t('Domain does not resolve to a valid address') as string;
                     }
                 } catch (error) {
                     console.debug(error); // eslint-disable-line no-console
@@ -625,7 +627,7 @@ export default defineComponent({
             // Show loading screen
             statusScreenOpened.value = true;
             statusState.value = State.LOADING;
-            statusTitle.value = context.root.$t('Sending Transaction') as string;
+            statusTitle.value = $t('Sending Transaction') as string;
             statusMessage.value = '';
 
             try {
@@ -655,12 +657,12 @@ export default defineComponent({
                 // Show success screen
                 statusState.value = State.SUCCESS;
                 statusTitle.value = recipientWithLabel.value!.label
-                    ? context.root.$t('Sent {coin} {ticker} to {name}', {
+                    ? $t('Sent {coin} {ticker} to {name}', {
                         coin: amount.value / 1e6,
                         name: recipientWithLabel.value!.label,
                         ticker: stablecoin.value!.toUpperCase(),
                     }) as string
-                    : context.root.$t('Sent {coin} {ticker}', {
+                    : $t('Sent {coin} {ticker}', {
                         coin: amount.value / 1e6,
                         ticker: stablecoin.value!.toUpperCase(),
                     }) as string;
@@ -675,7 +677,7 @@ export default defineComponent({
 
                 // Show error screen
                 statusState.value = State.WARNING;
-                statusTitle.value = context.root.$t('Something went wrong') as string;
+                statusTitle.value = $t('Something went wrong') as string;
                 statusMessage.value = error.message.split(' req={')[0]; // eslint-disable-line prefer-destructuring
             }
         }
@@ -752,7 +754,7 @@ export default defineComponent({
                     feeUpdateTimeout = window.setTimeout(startFeeUpdates, 20e3);
                 }
             } catch (e: unknown) {
-                feeError.value = context.root.$t('Failed to fetch {ticker} fees. Retrying... (Error: {message})', {
+                feeError.value = $t('Failed to fetch {ticker} fees. Retrying... (Error: {message})', {
                     message: e instanceof Error ? e.message : String(e),
                     ticker: stablecoin.value!.toUpperCase(),
                 }) as string;

--- a/src/components/modals/TransactionModal.vue
+++ b/src/components/modals/TransactionModal.vue
@@ -368,6 +368,7 @@ import { SwapAsset, getAssets } from '@nimiq/fastspot-api';
 import { SettlementStatus } from '@nimiq/oasis-api';
 import { useRouter, RouteName } from '@/router';
 import Config from 'config';
+import { useI18n } from '@/lib/useI18n';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import Modal from './Modal.vue';
@@ -419,6 +420,7 @@ export default defineComponent({
     },
     setup(props, context) {
         const router = useRouter();
+        const { $t } = useI18n();
 
         const constants = {
             FIAT_PRICE_UNAVAILABLE,
@@ -536,11 +538,11 @@ export default defineComponent({
 
             if ('hashRoot' in transaction.value.data
                 || (relatedTx.value && 'hashRoot' in relatedTx.value.data)) {
-                return context.root.$t('HTLC Creation');
+                return $t('HTLC Creation');
             }
             if ('hashRoot' in transaction.value.proof
                 || (relatedTx.value && 'hashRoot' in relatedTx.value.proof)) {
-                return context.root.$t('HTLC Settlement');
+                return $t('HTLC Settlement');
             }
             if ('creator' in transaction.value.proof) {
                 // Detect Nimiq Pay transactions
@@ -551,13 +553,13 @@ export default defineComponent({
                     return '';
                 }
 
-                return context.root.$t('HTLC Refund');
+                return $t('HTLC Refund');
             }
             if ((relatedTx.value && 'creator' in relatedTx.value.proof)
                 // if we have an incoming tx from a HTLC proxy but none of the above conditions met, the tx and related
                 // tx are regular transactions and we regard the tx from the proxy as refund
                 || (relatedTx.value && isSwapProxy.value && isIncoming.value)) {
-                return context.root.$t('HTLC Refund');
+                return $t('HTLC Refund');
             }
 
             const stakingData = getStakingTransactionMeaning(transaction.value, false);

--- a/src/components/modals/TransactionModal.vue
+++ b/src/components/modals/TransactionModal.vue
@@ -366,7 +366,7 @@ import { BrowserDetection } from '@nimiq/utils';
 import { RefundSwapRequest, SignedTransaction } from '@nimiq/hub-api';
 import { SwapAsset, getAssets } from '@nimiq/fastspot-api';
 import { SettlementStatus } from '@nimiq/oasis-api';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Config from 'config';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
@@ -418,6 +418,8 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const router = useRouter();
+
         const constants = {
             FIAT_PRICE_UNAVAILABLE,
             CASHLINK_ADDRESS,
@@ -686,7 +688,7 @@ export default defineComponent({
             if (!tx) return;
             const plainTx = await sendTransaction(tx as SignedTransaction);
             await context.root.$nextTick();
-            context.root.$router.replace({
+            router.replace({
                 name: RouteName.Transaction,
                 params: { transactionHash: plainTx.transactionHash },
             });

--- a/src/components/modals/TransactionModal.vue
+++ b/src/components/modals/TransactionModal.vue
@@ -369,6 +369,7 @@ import { SettlementStatus } from '@nimiq/oasis-api';
 import { useRouter, RouteName } from '@/router';
 import Config from 'config';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Amount from '../Amount.vue';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import Modal from './Modal.vue';
@@ -418,7 +419,7 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const router = useRouter();
         const { $t } = useI18n();
 
@@ -689,7 +690,7 @@ export default defineComponent({
             const tx = await refundSwap(requestPromise);
             if (!tx) return;
             const plainTx = await sendTransaction(tx as SignedTransaction);
-            await context.root.$nextTick();
+            await nextTick();
             router.replace({
                 name: RouteName.Transaction,
                 params: { transactionHash: plainTx.transactionHash },

--- a/src/components/modals/UsdcTransactionModal.vue
+++ b/src/components/modals/UsdcTransactionModal.vue
@@ -306,6 +306,7 @@ import { useUsdcContactsStore } from '@/stores/UsdcContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
 import { useRouter, RouteName } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -346,7 +347,7 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const router = useRouter();
         const { $t } = useI18n();
 
@@ -567,7 +568,7 @@ export default defineComponent({
                     (tx as SignedPolygonTransaction).signature,
                     relayUrl!,
                 );
-                await context.root.$nextTick();
+                await nextTick();
                 router.replace({
                     name: RouteName.Transaction,
                     params: { transactionHash: plainTx.transactionHash },

--- a/src/components/modals/UsdcTransactionModal.vue
+++ b/src/components/modals/UsdcTransactionModal.vue
@@ -304,7 +304,7 @@ import { useAccountStore } from '@/stores/Account';
 import { useUsdcTransactionsStore, TransactionState } from '@/stores/UsdcTransactions';
 import { useUsdcContactsStore } from '@/stores/UsdcContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -346,6 +346,8 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const router = useRouter();
+
         const constants = { FIAT_PRICE_UNAVAILABLE };
 
         const transaction = computed(() => useUsdcTransactionsStore().state.transactions[props.hash]);
@@ -564,7 +566,7 @@ export default defineComponent({
                     relayUrl!,
                 );
                 await context.root.$nextTick();
-                context.root.$router.replace({
+                router.replace({
                     name: RouteName.Transaction,
                     params: { transactionHash: plainTx.transactionHash },
                 });

--- a/src/components/modals/UsdcTransactionModal.vue
+++ b/src/components/modals/UsdcTransactionModal.vue
@@ -305,6 +305,7 @@ import { useUsdcTransactionsStore, TransactionState } from '@/stores/UsdcTransac
 import { useUsdcContactsStore } from '@/stores/UsdcContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -347,6 +348,7 @@ export default defineComponent({
     },
     setup(props, context) {
         const router = useRouter();
+        const { $t } = useI18n();
 
         const constants = { FIAT_PRICE_UNAVAILABLE };
 
@@ -403,11 +405,11 @@ export default defineComponent({
         // Data
         const data = computed(() => {
             if (isCancelledSwap.value) {
-                return isIncoming.value ? context.root.$t('HTLC Refund') : context.root.$t('HTLC Creation');
+                return isIncoming.value ? $t('HTLC Refund') : $t('HTLC Creation');
             }
 
             if (transaction.value.event?.name === 'Swap') {
-                return context.root.$t('Converted {amount1} USDC.e to {amount2} USDC', {
+                return $t('Converted {amount1} USDC.e to {amount2} USDC', {
                     amount1: (transaction.value.event.amountIn / 1e6).toFixed(2),
                     amount2: (transaction.value.event.amountOut / 1e6).toFixed(2),
                 }) as string;
@@ -572,7 +574,7 @@ export default defineComponent({
                 });
             } catch (e) {
                 const errorMessage = e instanceof Error ? e.message : String(e);
-                alert(context.root.$t('Refund failed: ') + errorMessage); // eslint-disable-line no-alert
+                alert($t('Refund failed: ') + errorMessage); // eslint-disable-line no-alert
             }
         }
 

--- a/src/components/modals/UsdtAddedModal.vue
+++ b/src/components/modals/UsdtAddedModal.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
 import { PageBody, PageHeader, PageFooter } from '@nimiq/vue-components';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Modal from './Modal.vue';
 import { CryptoCurrency } from '../../lib/Constants';
 import { useAccountSettingsStore } from '../../stores/AccountSettings';
@@ -38,7 +38,8 @@ import { useWindowSize } from '../../composables/useWindowSize';
 
 export default defineComponent({
     name: 'usdt-added-modal',
-    setup(props, context) {
+    setup() {
+        const router = useRouter();
         const modal$ = ref<Modal>(null);
 
         useAccountSettingsStore().setKnowsAboutUsdt(true);
@@ -50,7 +51,7 @@ export default defineComponent({
             useAccountStore().setActiveCurrency(CryptoCurrency.USDC);
             await modal$.value?.forceClose();
             if (isMobile.value) {
-                context.root.$router.push('/transactions');
+                router.push('/transactions');
             }
         }
 

--- a/src/components/modals/UsdtTransactionModal.vue
+++ b/src/components/modals/UsdtTransactionModal.vue
@@ -285,7 +285,7 @@ import { useAccountStore } from '@/stores/Account';
 import { useUsdtTransactionsStore, TransactionState } from '@/stores/UsdtTransactions';
 import { useUsdtContactsStore } from '@/stores/UsdtContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -327,6 +327,7 @@ export default defineComponent({
     },
     setup(props, context) {
         const constants = { FIAT_PRICE_UNAVAILABLE };
+        const router = useRouter();
 
         const transaction = computed(() => useUsdtTransactionsStore().state.transactions[props.hash]);
 
@@ -533,7 +534,7 @@ export default defineComponent({
                     relayUrl!,
                 );
                 await context.root.$nextTick();
-                context.root.$router.replace({
+                router.replace({
                     name: RouteName.UsdtTransaction,
                     params: { transactionHash: plainTx.transactionHash },
                 });

--- a/src/components/modals/UsdtTransactionModal.vue
+++ b/src/components/modals/UsdtTransactionModal.vue
@@ -287,6 +287,7 @@ import { useUsdtContactsStore } from '@/stores/UsdtContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
 import { useRouter, RouteName } from '@/router';
 import { useI18n } from '@/lib/useI18n';
+import { nextTick } from '@/lib/nextTick';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -326,7 +327,7 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props, context) {
+    setup(props) {
         const constants = { FIAT_PRICE_UNAVAILABLE };
         const router = useRouter();
         const { $t } = useI18n();
@@ -535,7 +536,7 @@ export default defineComponent({
                     (tx as SignedPolygonTransaction).signature,
                     relayUrl!,
                 );
-                await context.root.$nextTick();
+                await nextTick();
                 router.replace({
                     name: RouteName.UsdtTransaction,
                     params: { transactionHash: plainTx.transactionHash },

--- a/src/components/modals/UsdtTransactionModal.vue
+++ b/src/components/modals/UsdtTransactionModal.vue
@@ -286,6 +286,7 @@ import { useUsdtTransactionsStore, TransactionState } from '@/stores/UsdtTransac
 import { useUsdtContactsStore } from '@/stores/UsdtContacts';
 import { usePolygonNetworkStore } from '@/stores/PolygonNetwork';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import Amount from '../Amount.vue';
 import BlueLink from '../BlueLink.vue';
 import Modal from './Modal.vue';
@@ -328,6 +329,7 @@ export default defineComponent({
     setup(props, context) {
         const constants = { FIAT_PRICE_UNAVAILABLE };
         const router = useRouter();
+        const { $t } = useI18n();
 
         const transaction = computed(() => useUsdtTransactionsStore().state.transactions[props.hash]);
 
@@ -382,7 +384,7 @@ export default defineComponent({
         // Data
         const data = computed(() => {
             if (isCancelledSwap.value) {
-                return isIncoming.value ? context.root.$t('HTLC Refund') : context.root.$t('HTLC Creation');
+                return isIncoming.value ? $t('HTLC Refund') : $t('HTLC Creation');
             }
 
             return '';
@@ -540,7 +542,7 @@ export default defineComponent({
                 });
             } catch (e) {
                 const errorMessage = e instanceof Error ? e.message : String(e);
-                alert(context.root.$t('Refund failed: ') + errorMessage); // eslint-disable-line no-alert
+                alert($t('Refund failed: ') + errorMessage); // eslint-disable-line no-alert
             }
         }
 

--- a/src/components/modals/WelcomeModal.vue
+++ b/src/components/modals/WelcomeModal.vue
@@ -373,6 +373,7 @@
 <script lang="ts">
 import { computed, defineComponent, onUnmounted, ref, watch } from '@vue/composition-api';
 import { PageHeader, PageBody, PageFooter, Tooltip } from '@nimiq/vue-components';
+import { nextTick } from '@/lib/nextTick';
 import Modal from './Modal.vue';
 import AmountMenu from '../AmountMenu.vue';
 import { Languages } from '../../i18n/i18n-setup';
@@ -389,7 +390,7 @@ import UsdcIcon from '../icons/UsdcIcon.vue';
 import { useFiatStore } from '../../stores/Fiat';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const { state: settings$, setLanguage } = useSettingsStore();
         const { activeAddress } = useAddressStore();
         const { isMobile } = useWindowSize();
@@ -523,7 +524,7 @@ export default defineComponent({
                 setTimeout(() => {
                     highlightedCurrencyIndex.value = 0; // Show NIM section highlighted first
                     page.value = 5;
-                    // context.root.$nextTick().then(() => {
+                    // nextTick().then(() => {
                     //     isPageBodyFadedOut.value = false;
                     // });
                     setTimeout(() => {
@@ -561,7 +562,7 @@ export default defineComponent({
                 setTimeout(() => {
                     highlightedCurrencyIndex.value = 0; // Show NIM highlighted first
                     page.value = 1;
-                    context.root.$nextTick().then(() => {
+                    nextTick().then(() => {
                         isPageBodyFadedOut.value = false;
                     });
                 }, 1000);

--- a/src/components/modals/overlays/BuyCryptoBankCheckOverlay.vue
+++ b/src/components/modals/overlays/BuyCryptoBankCheckOverlay.vue
@@ -32,17 +32,18 @@
 import { computed, defineComponent, onMounted, ref } from '@vue/composition-api';
 import { PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
 import { RouteName } from '@/router';
+import { nextTick } from '@/lib/nextTick';
 import BankCheckInput from '../../BankCheckInput.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const bankCheckInput$ = ref<BankCheckInput>(null);
         const bankName = ref('');
 
         const writing = computed(() => bankName.value.length !== 0);
 
         onMounted(async () => {
-            await context.root.$nextTick();
+            await nextTick();
             if (bankCheckInput$.value) bankCheckInput$.value.focus();
         });
 

--- a/src/components/modals/overlays/SellCryptoBankCheckOverlay.vue
+++ b/src/components/modals/overlays/SellCryptoBankCheckOverlay.vue
@@ -79,6 +79,7 @@ import { PageHeader, PageBody, PageFooter, LabelInput } from '@nimiq/vue-compone
 import { Bank } from '@nimiq/oasis-bank-list';
 import IBAN from 'iban';
 import { BankAccount, useBankStore } from '@/stores/Bank';
+import { nextTick } from '@/lib/nextTick';
 import BankCheckInput from '../../BankCheckInput.vue';
 import MessageTransition from '../../MessageTransition.vue';
 import DoubleInput from '../../DoubleInput.vue';
@@ -115,7 +116,7 @@ export default defineComponent({
         );
 
         watch(currentStep, async () => {
-            await context.root.$nextTick();
+            await nextTick();
             if (currentStep.value === Step.BANK_CHECK) {
                 if (bankCheckInput$.value) bankCheckInput$.value.focus();
             } else if (currentStep.value === Step.IBAN_CHECK) {

--- a/src/components/staking/AmountSlider.vue
+++ b/src/components/staking/AmountSlider.vue
@@ -64,6 +64,7 @@
 import { Ref, defineComponent, ref, computed, onMounted, onBeforeUnmount } from '@vue/composition-api';
 import { CryptoCurrency } from '@nimiq/utils';
 
+import { nextTick } from '@/lib/nextTick';
 import { useAddressStore } from '../../stores/Address';
 
 import VerticalLineIcon from '../icons/Staking/VerticalLineIcon.vue';
@@ -255,7 +256,7 @@ export default defineComponent({
             if (!firstRender) {
                 window.clearTimeout(timeoutID);
                 animate.value = true;
-                await context.root.$nextTick();
+                await nextTick();
             }
 
             const amount = Math.max(0, Math.min(availableAmount.value, valueNim));

--- a/src/components/staking/StakingButton.vue
+++ b/src/components/staking/StakingButton.vue
@@ -35,7 +35,7 @@
 <script lang="ts">
 import { computed, defineComponent, ref, watch } from '@vue/composition-api';
 import { Tooltip } from '@nimiq/vue-components';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import { useAddressStore } from '../../stores/Address';
 import { useStakingStore } from '../../stores/Staking';
 import { useConfig } from '../../composables/useConfig';
@@ -44,7 +44,8 @@ import { MIN_STAKE } from '../../lib/Constants';
 import HeroIcon from '../icons/Staking/HeroIcon.vue';
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const router = useRouter();
         const { config } = useConfig();
         const { activeAddressInfo } = useAddressStore();
         const { totalAccountStake, totalActiveStake } = useStakingStore();
@@ -71,7 +72,7 @@ export default defineComponent({
             if (canStake.value) {
                 e.stopPropagation();
                 e.preventDefault();
-                context.root.$router.push({ name: RouteName.Staking });
+                router.push({ name: RouteName.Staking });
             }
         }
 

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -85,6 +85,7 @@
 import { computed, defineComponent, ref } from '@vue/composition-api';
 import { InfoCircleSmallIcon, Amount, PageHeader, PageBody, Tooltip } from '@nimiq/vue-components';
 
+import { useI18n } from '@/lib/useI18n';
 import { CryptoCurrency, MIN_STAKE } from '../../lib/Constants';
 import { calculateDisplayedDecimals } from '../../lib/NumberFormatting';
 import { getNetworkClient } from '../../network';
@@ -107,6 +108,7 @@ import { reportToSentry } from '../../lib/Sentry';
 
 export default defineComponent({
     setup(props, context) {
+        const { $t } = useI18n();
         const { activeAddress } = useAddressStore();
         const { activeStake, activeValidator } = useStakingStore();
 
@@ -136,7 +138,7 @@ export default defineComponent({
                     context.emit('statusChange', {
                         type: StatusChangeType.STAKING,
                         state: State.LOADING,
-                        title: context.root.$t('Sending Staking Transaction') as string,
+                        title: $t('Sending Staking Transaction') as string,
                     });
 
                     if (!activeStake.value
@@ -174,7 +176,7 @@ export default defineComponent({
 
                         context.emit('statusChange', {
                             state: State.SUCCESS,
-                            title: context.root.$t(
+                            title: $t(
                                 'Successfully staked {amount} NIM with {validator}',
                                 {
                                     amount: Math.abs(stakeDelta.value / 1e5),
@@ -218,7 +220,7 @@ export default defineComponent({
 
                         context.emit('statusChange', {
                             state: State.SUCCESS,
-                            title: context.root.$t(
+                            title: $t(
                                 'Successfully added {amount} NIM to your stake with {validator}',
                                 {
                                     amount: Math.abs(stakeDelta.value / 1e5),
@@ -231,7 +233,7 @@ export default defineComponent({
                     context.emit('statusChange', {
                         type: StatusChangeType.DEACTIVATING,
                         state: State.LOADING,
-                        title: context.root.$t('Sending Staking Transaction') as string,
+                        title: $t('Sending Staking Transaction') as string,
                     });
 
                     const transaction = TransactionBuilder.newSetActiveStake(
@@ -267,7 +269,7 @@ export default defineComponent({
 
                     context.emit('statusChange', {
                         state: State.SUCCESS,
-                        title: context.root.$t(
+                        title: $t(
                             'Successfully deactivated {amount} NIM from your stake with {validator}',
                             {
                                 amount: Math.abs((activeStake.value!.inactiveBalance - stakeDelta.value) / 1e5),
@@ -292,7 +294,7 @@ export default defineComponent({
                 // Show error screen
                 context.emit('statusChange', {
                     state: State.WARNING,
-                    title: context.root.$t('Something went wrong') as string,
+                    title: $t('Something went wrong') as string,
                     message: `${error.message} - ${error.data}`,
                 });
             }

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -278,7 +278,7 @@ export default defineComponent({
 
                     // if (Math.abs(stakeDelta.value) === activeStake.value!.activeBalance) {
                     //     // Close staking modal
-                    //     context.root.$router.back();
+                    //     router.back();
                     // }
                 }
 

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -177,6 +177,7 @@ import {
     ArrowRightSmallIcon,
 } from '@nimiq/vue-components';
 
+import { useI18n } from '@/lib/useI18n';
 import { useStakingStore } from '../../stores/Staking';
 import { useAddressStore } from '../../stores/Address';
 import { MIN_STAKE } from '../../lib/Constants';
@@ -200,6 +201,7 @@ import { reportToSentry } from '../../lib/Sentry';
 
 export default defineComponent({
     setup(props, context) {
+        const { $t } = useI18n();
         const { activeAddress, activeAddressInfo } = useAddressStore();
         const { activeStake: stake, activeValidator: validator, restakingRewards } = useStakingStore();
         const { height, consensus } = useNetworkStore();
@@ -262,7 +264,7 @@ export default defineComponent({
                 context.emit('statusChange', {
                     type: StatusChangeType.VALIDATOR,
                     state: State.LOADING,
-                    title: context.root.$t('Deactivating Stake') as string,
+                    title: $t('Deactivating Stake') as string,
                 });
 
                 try {
@@ -303,7 +305,7 @@ export default defineComponent({
 
                     context.emit('statusChange', {
                         state: State.SUCCESS,
-                        title: context.root.$t('Successfully deactivated {amount} NIM', {
+                        title: $t('Successfully deactivated {amount} NIM', {
                             amount: deactivatedAmount / 1e5,
                         }),
                     });
@@ -319,7 +321,7 @@ export default defineComponent({
 
                     context.emit('statusChange', {
                         state: State.WARNING,
-                        title: context.root.$t('Something went wrong') as string,
+                        title: $t('Something went wrong') as string,
                         message: `${error.message} - ${error.data}`,
                     });
                 }
@@ -332,7 +334,7 @@ export default defineComponent({
             context.emit('statusChange', {
                 type: StatusChangeType.UNSTAKING,
                 state: State.LOADING,
-                title: context.root.$t('Sending Unstaking Transaction') as string,
+                title: $t('Sending Unstaking Transaction') as string,
             });
 
             try {
@@ -388,7 +390,7 @@ export default defineComponent({
 
                 context.emit('statusChange', {
                     state: State.SUCCESS,
-                    title: context.root.$t('Successfully unstaked {amount} NIM', { amount: unstakedAmount / 1e5 }),
+                    title: $t('Successfully unstaked {amount} NIM', { amount: unstakedAmount / 1e5 }),
                 });
 
                 // // Close staking modal
@@ -402,7 +404,7 @@ export default defineComponent({
 
                 context.emit('statusChange', {
                     state: State.WARNING,
-                    title: context.root.$t('Something went wrong') as string,
+                    title: $t('Something went wrong') as string,
                     message: `${error.message} - ${error.data}`,
                 });
             }

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -309,7 +309,7 @@ export default defineComponent({
                     });
 
                     // // Close staking modal
-                    // context.root.$router.back();
+                    // router.back();
                     context.emit('statusChange', {
                         type: StatusChangeType.NONE,
                         timeout: SUCCESS_REDIRECT_DELAY,
@@ -392,7 +392,7 @@ export default defineComponent({
                 });
 
                 // // Close staking modal
-                // context.root.$router.back();
+                // router.back();
                 context.emit('statusChange', {
                     type: StatusChangeType.NONE,
                     timeout: SUCCESS_REDIRECT_DELAY,

--- a/src/components/staking/StakingModal.vue
+++ b/src/components/staking/StakingModal.vue
@@ -60,6 +60,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch, onBeforeUnmount } from '@vue/composition-api';
+import { useI18n } from '@/lib/useI18n';
 import { useStakingStore, Validator } from '../../stores/Staking';
 import { useAddressStore } from '../../stores/Address';
 import Modal from '../modals/Modal.vue';
@@ -102,7 +103,8 @@ type StatusChangeParams = {
 };
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
+        const { $t } = useI18n();
         const { activeAddressInfo } = useAddressStore();
         const { activeValidator, activeStake, totalAccountStake } = useStakingStore();
         const page = ref(activeValidator.value
@@ -150,7 +152,7 @@ export default defineComponent({
             }
 
             if (statusChangeObj.state === State.ERROR || statusChangeObj.state === State.WARNING) {
-                statusMainAction.value = context.root.$t('Close') as string;
+                statusMainAction.value = $t('Close') as string;
             }
         }
 

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -61,6 +61,7 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
 import { PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
+import { useI18n } from '@/lib/useI18n';
 import { Validator, useStakingStore } from '../../stores/Staking';
 import ValidatorIcon from './ValidatorIcon.vue';
 import ShortAddress from '../ShortAddress.vue';
@@ -87,6 +88,7 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
         const { activeAddress } = useAddressStore();
         const { activeStake, setStake, activeValidator } = useStakingStore();
 
@@ -110,7 +112,7 @@ export default defineComponent({
                     context.emit('statusChange', {
                         type: StatusChangeType.VALIDATOR,
                         state: State.LOADING,
-                        title: context.root.$t('Changing validator') as string,
+                        title: $t('Changing validator') as string,
                     });
 
                     const { Address, TransactionBuilder } = await import('@nimiq/core');
@@ -156,7 +158,7 @@ export default defineComponent({
 
                     context.emit('statusChange', {
                         state: State.SUCCESS,
-                        title: context.root.$t(
+                        title: $t(
                             'Successfully changed validator to {validator}',
                             { validator: validatorLabelOrAddress },
                         ),
@@ -172,7 +174,7 @@ export default defineComponent({
 
                 context.emit('statusChange', {
                     state: State.WARNING,
-                    title: context.root.$t('Something went wrong') as string,
+                    title: $t('Something went wrong') as string,
                     message: `${error.message} - ${error.data}`,
                 });
             }

--- a/src/components/staking/ValidatorFilter.vue
+++ b/src/components/staking/ValidatorFilter.vue
@@ -34,6 +34,7 @@
 <script lang="ts">
 import { defineComponent, watch, ref } from '@vue/composition-api';
 import { SliderToggle } from '@nimiq/vue-components';
+import { nextTick } from '@/lib/nextTick';
 import { FilterState } from '../../lib/StakingUtils';
 import FatSearchIcon from '../icons/Staking/FatSearchIcon.vue';
 import XCloseIcon from '../icons/Staking/XCloseIcon.vue';
@@ -48,7 +49,7 @@ export default defineComponent({
             context.emit('changed', state.value);
 
             if (state.value === FilterState.SEARCH) {
-                context.root.$nextTick(() => $search.value?.focus());
+                nextTick(() => $search.value?.focus());
             }
         });
 

--- a/src/components/swap/SwapAnimation.vue
+++ b/src/components/swap/SwapAnimation.vue
@@ -358,6 +358,7 @@ import {
     CloseButton,
 } from '@nimiq/vue-components';
 import { SwapAsset } from '@nimiq/fastspot-api';
+import { useI18n } from '@/lib/useI18n';
 import GroundedArrowDownIcon from '../icons/GroundedArrowDownIcon.vue';
 import GroundedArrowUpIcon from '../icons/GroundedArrowUpIcon.vue';
 import OverflowingCup from '../icons/OverflowingCup.vue';
@@ -455,6 +456,8 @@ export default defineComponent({
         },
     },
     setup(props, context) {
+        const { $t } = useI18n();
+
         // NIM Identicon
         const identicon$ = ref<Identicon>(null);
         const identiconUrl = ref('');
@@ -644,7 +647,7 @@ export default defineComponent({
                     && props.toAsset === SwapAsset.USDT_MATIC
                 ))
             ) {
-                return context.root.$t('Restart payout process') as string;
+                return $t('Restart payout process') as string;
             }
 
             return false;

--- a/src/components/swap/SwapBalanceBar.vue
+++ b/src/components/swap/SwapBalanceBar.vue
@@ -127,6 +127,7 @@
 import { defineComponent, computed, onMounted, onUnmounted, ref, watch } from '@vue/composition-api';
 import { Identicon, Amount } from '@nimiq/vue-components';
 import { SwapAsset } from '@nimiq/fastspot-api';
+import { nextTick } from '@/lib/nextTick';
 import { useBtcAddressStore } from '../../stores/BtcAddress';
 import { useFiatStore } from '../../stores/Fiat';
 import { useAddressStore } from '../../stores/Address';
@@ -557,7 +558,7 @@ export default defineComponent({
         }
 
         watch(() => [props.leftAsset, props.rightAsset], async () => {
-            await context.root.$nextTick();
+            await nextTick();
             const { offsetLeft } = separator$.value!;
             equiPointPositionX.value = (offsetLeft / root.value!.offsetWidth) * 100;
         });

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -296,7 +296,7 @@ import type { BigNumber } from 'ethers';
 import type { RelayRequest } from '@opengsn/common/dist/EIP712/RelayRequest';
 import type { ForwardRequest } from '@opengsn/common/dist/EIP712/ForwardRequest';
 import { CurrencyInfo } from '@nimiq/utils';
-import { RouteName } from '@/router';
+import { RouteName, useRouter } from '@/router';
 
 import Modal from '../modals/Modal.vue';
 import Amount from '../Amount.vue';
@@ -378,7 +378,6 @@ export default defineComponent({
             },
         },
     },
-    // @ts-expect-error Cannot derive types of props and context
     setup(props, context) {
         const { config } = useConfig();
 
@@ -1388,13 +1387,15 @@ export default defineComponent({
 
         const feeSmallerThanSmUnit = computed(() => roundedUpFeeFiat.value <= fiatSmUnit.value);
 
+        const router = useRouter();
+
         function onClose() {
             if (addressListOverlayOpened.value === true) {
                 addressListOverlayOpened.value = false;
             } else if (kycOverlayOpened.value === true) {
                 kycOverlayOpened.value = false;
             } else {
-                context.root.$router.back();
+                router.back();
             }
         }
 
@@ -2194,7 +2195,7 @@ export default defineComponent({
                 rightAsset.value = leftAsset.value;
             }
             leftAsset.value = asset;
-            context.root.$router.replace({
+            router.replace({
                 name: RouteName.Swap,
                 params: { pair: `${leftAsset.value}-${rightAsset.value}` },
             });
@@ -2205,7 +2206,7 @@ export default defineComponent({
                 leftAsset.value = rightAsset.value;
             }
             rightAsset.value = asset;
-            context.root.$router.replace({
+            router.replace({
                 name: RouteName.Swap,
                 params: { pair: `${leftAsset.value}-${rightAsset.value}` },
             });

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -298,6 +298,7 @@ import type { ForwardRequest } from '@opengsn/common/dist/EIP712/ForwardRequest'
 import { CurrencyInfo } from '@nimiq/utils';
 import { RouteName, useRouter } from '@/router';
 
+import { useI18n } from '@/lib/useI18n';
 import Modal from '../modals/Modal.vue';
 import Amount from '../Amount.vue';
 import AmountInput from '../AmountInput.vue';
@@ -380,6 +381,8 @@ export default defineComponent({
     },
     setup(props, context) {
         const { config } = useConfig();
+
+        const { $t } = useI18n();
 
         const estimate = ref<Estimate>(null);
         const estimateError = ref<string>(null);
@@ -998,7 +1001,7 @@ export default defineComponent({
                     stopPolygonFeeUpdates();
                     return false;
                 }
-                polygonFeeError.value = context.root.$t(
+                polygonFeeError.value = $t(
                     'Failed to fetch Polygon fees. Retrying... (Error: {message})',
                     { message: e instanceof Error ? e.message : String(e) },
                 ) as string;
@@ -1085,13 +1088,13 @@ export default defineComponent({
                 // Check against minimums
                 if (!newEstimate.from.amount || (newEstimate.to.amount - newEstimate.to.fee) <= 0) {
                     // If one of the two amounts is 0 or less, that means the fees are higher than the swap amount
-                    estimateError.value = context.root.$t('The fees determine the minimum amount.') as string;
+                    estimateError.value = $t('The fees determine the minimum amount.') as string;
                 } else if (
                     newEstimate.to.asset === SwapAsset.BTC
                     // Check that output is higher than the BTC dust limit
                     && newEstimate.to.amount - newEstimate.to.fee <= BTC_DUST_LIMIT
                 ) {
-                    estimateError.value = context.root.$t('Resulting BTC amount is too small.') as string;
+                    estimateError.value = $t('Resulting BTC amount is too small.') as string;
                 } else {
                     estimateError.value = null;
                 }
@@ -2024,7 +2027,7 @@ export default defineComponent({
                             : 0;
             } catch (error) {
                 reportToSentry(error);
-                swapError.value = context.root.$t('Invalid swap state, swap aborted!') as string;
+                swapError.value = $t('Invalid swap state, swap aborted!') as string;
                 cancelSwap({ id: swapId } as PreSwap);
                 currentlySigning.value = false;
                 updateEstimate();

--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -379,6 +379,7 @@ export default defineComponent({
             },
         },
     },
+    // @ts-expect-error Parameters 'props', 'context' implicitly have an 'any' type.
     setup(props, context) {
         const { config } = useConfig();
 

--- a/src/components/swap/SwapNotification.vue
+++ b/src/components/swap/SwapNotification.vue
@@ -67,6 +67,7 @@ import { SwapHandler, Swap as GenericSwap, SwapAsset, Client, Transaction } from
 import type { ForwardRequest } from '@opengsn/common/dist/EIP712/ForwardRequest';
 import { Event as PolygonEvent, EventType as PolygonEventType } from '@nimiq/libswap/dist/src/Erc20AssetAdapter';
 import { useRouter, RouteName } from '@/router';
+import { useI18n } from '@/lib/useI18n';
 import MaximizeIcon from '../icons/MaximizeIcon.vue';
 import { useSwapsStore, SwapState, ActiveSwap, SwapEurData, SwapErrorAction } from '../../stores/Swaps';
 import { useNetworkStore } from '../../stores/Network';
@@ -113,6 +114,7 @@ export default defineComponent({
         const swapIsErrored = computed(() => !!activeSwap.value && activeSwap.value.error);
 
         const router = useRouter();
+        const { $t } = useI18n();
 
         function onUnload(event: BeforeUnloadEvent) {
             // Firefox respects the event cancellation to prompt the user
@@ -223,8 +225,8 @@ export default defineComponent({
             if (currentError.value) return currentError.value;
 
             const consensusErrorMsg = (chain: 'Nimiq' | 'Bitcoin' | 'Polygon') => `
-                ${context.root.$t('No connection to {chain} network.', { chain })}
-                ${context.root.$t('If this error persists, check your internet connection or '
+                ${$t('No connection to {chain} network.', { chain })}
+                ${$t('If this error persists, check your internet connection or '
                     + 'reload the page to reconnect.')}
             `;
 

--- a/src/components/swap/SwapNotification.vue
+++ b/src/components/swap/SwapNotification.vue
@@ -66,7 +66,7 @@ import {
 import { SwapHandler, Swap as GenericSwap, SwapAsset, Client, Transaction } from '@nimiq/libswap';
 import type { ForwardRequest } from '@opengsn/common/dist/EIP712/ForwardRequest';
 import { Event as PolygonEvent, EventType as PolygonEventType } from '@nimiq/libswap/dist/src/Erc20AssetAdapter';
-import { RouteName } from '@/router';
+import { useRouter, RouteName } from '@/router';
 import MaximizeIcon from '../icons/MaximizeIcon.vue';
 import { useSwapsStore, SwapState, ActiveSwap, SwapEurData, SwapErrorAction } from '../../stores/Swaps';
 import { useNetworkStore } from '../../stores/Network';
@@ -111,6 +111,8 @@ export default defineComponent({
         const swapIsComplete = computed(() => !!activeSwap.value && activeSwap.value.state === SwapState.COMPLETE);
         const swapIsExpired = computed(() => !!activeSwap.value && activeSwap.value.state === SwapState.EXPIRED);
         const swapIsErrored = computed(() => !!activeSwap.value && activeSwap.value.error);
+
+        const router = useRouter();
 
         function onUnload(event: BeforeUnloadEvent) {
             // Firefox respects the event cancellation to prompt the user
@@ -419,7 +421,7 @@ export default defineComponent({
                         });
 
                         // Open Swap modal to show payment instructions to user if not already open
-                        if (context.root.$route.name !== 'buy-crypto') context.root.$router.push('buy-crypto');
+                        if (context.root.$route.name !== 'buy-crypto') router.push('buy-crypto');
 
                         // Wait for OASIS HTLC to be funded out-of-band
                         const fundingTx = await swapHandler.awaitOutgoing((htlc) => {
@@ -947,11 +949,11 @@ export default defineComponent({
             const toAsset = activeSwap.value.to.asset as SwapAsset;
 
             if (cryptoCurrencies.includes(fromAsset) && cryptoCurrencies.includes(toAsset)) {
-                context.root.$router.push({ name: RouteName.Swap });
+                router.push({ name: RouteName.Swap });
             } else if (fiatCurrencies.includes(fromAsset)) {
-                context.root.$router.push({ name: RouteName.BuyCrypto });
+                router.push({ name: RouteName.BuyCrypto });
             } else if (fiatCurrencies.includes(toAsset)) {
-                context.root.$router.push({ name: RouteName.SellCrypto });
+                router.push({ name: RouteName.SellCrypto });
             } else {
                 throw new Error('Unhandled swap type, cannot open correct swap modal');
             }

--- a/src/components/swap/SwapNotification.vue
+++ b/src/components/swap/SwapNotification.vue
@@ -97,7 +97,7 @@ enum SwapError {
 }
 
 export default defineComponent({
-    setup(props, context) {
+    setup() {
         const {
             activeSwap,
             setActiveSwap,
@@ -423,7 +423,7 @@ export default defineComponent({
                         });
 
                         // Open Swap modal to show payment instructions to user if not already open
-                        if (context.root.$route.name !== 'buy-crypto') router.push('buy-crypto');
+                        if (router.currentRoute.name !== 'buy-crypto') router.push('buy-crypto');
 
                         // Wait for OASIS HTLC to be funded out-of-band
                         const fundingTx = await swapHandler.awaitOutgoing((htlc) => {
@@ -920,7 +920,7 @@ export default defineComponent({
                     }
                     setTimeout(() => {
                         // Hide notification after a timeout, if not in a swap modal
-                        if (['swap', 'buy-crypto', 'sell-crypto'].includes(context.root.$route.name!)) return;
+                        if (['swap', 'buy-crypto', 'sell-crypto'].includes(router.currentRoute.name!)) return;
                         setActiveSwap(null);
                     }, 4 * 1000); // 4 seconds
                 }

--- a/src/lib/nextTick.ts
+++ b/src/lib/nextTick.ts
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+// This is just syntactic sugar for Vue.nextTick which does not make much sense,
+// but it is used so the migration to Vue 3 is easier.
+export const { nextTick } = Vue;

--- a/src/lib/useI18n.ts
+++ b/src/lib/useI18n.ts
@@ -1,0 +1,17 @@
+import { inject, provide } from '@vue/composition-api';
+import type { Vue } from 'vue/types/vue';
+
+const translateSymbol = Symbol('$t');
+const translateWithVariableSymbol = Symbol('$tc');
+
+export function provideI18n({ $t, $tc }: Vue) {
+    provide(translateSymbol, $t);
+    provide(translateWithVariableSymbol, $tc);
+}
+
+export function useI18n(): Pick<Vue, '$t' | '$tc'> {
+    const $t = inject(translateSymbol) as Vue['$t'];
+    const $tc = inject(translateWithVariableSymbol) as Vue['$tc'];
+    if (!$tc) throw new Error('$tc was not provided.');
+    return { $t, $tc };
+}

--- a/src/lib/useI18n.ts
+++ b/src/lib/useI18n.ts
@@ -1,17 +1,14 @@
 import { inject, provide } from '@vue/composition-api';
 import type { Vue } from 'vue/types/vue';
 
-const translateSymbol = Symbol('$t');
-const translateWithVariableSymbol = Symbol('$tc');
+const i18nSymbol = Symbol('i18n');
 
-export function provideI18n({ $t, $tc }: Vue) {
-    provide(translateSymbol, $t);
-    provide(translateWithVariableSymbol, $tc);
+export function provideI18n({ $i18n }: Vue) {
+    provide(i18nSymbol, $i18n);
 }
 
-export function useI18n(): Pick<Vue, '$t' | '$tc'> {
-    const $t = inject(translateSymbol) as Vue['$t'];
-    const $tc = inject(translateWithVariableSymbol) as Vue['$tc'];
-    if (!$tc) throw new Error('$tc was not provided.');
-    return { $t, $tc };
+export function useI18n(): { locale: Vue['$i18n']['locale'], $t: Vue['$t'], $tc: Vue['$tc'] } {
+    const i18n = inject(i18nSymbol) as Vue['$i18n'];
+    if (!i18n) throw new Error('$tc was not provided.');
+    return { locale: i18n.locale, $t: i18n.t.bind(i18n), $tc: i18n.tc.bind(i18n) };
 }


### PR DESCRIPTION
As we have said, 2025 is going to be the focus for moving away from Vue 2 to Vue 3. This task is tremendous, but we can always do small bits.

I have removed `context.root` calls and move it away from context to different places, so once we move to vue 3, we just need to change the import.

Here are the key changes

<details><summary>useRouter & useRoute</summary>
<p>


### Before my PR

```ts
defineComponent({
	setup(props, context) {
		context.root.$router.push();
		context.root.$route.name;
	}
})

```

### After my PR


```ts
import { useRouter } from "@/router";

defineComponent({
	setup() {
		const router = useRouter()
		router.push();
		router.currentRoute.name;
	}
})

```

#### How does `useRouter` work under-the-hood?

In `app.vue` we provide the `context.root.router` to the app.
Then inside `useRouter` we just use inject it.

### After Vue 3

```ts
import { useRouter } from "@/router";

const router = useRouter()
router.push();
router.currentRoute.name;
```

</p>
</details> 


<details><summary>useI18n</summary>
<p>


### Before my PR

```ts
defineComponent({
	setup(props, context) {
		context.root.$i18n.t('Translate me');	
		context.root.$t('Translate me');
		context.root.locale;
		context.root.$tc('transalte with variable');
	}
})

```

### After my PR


```ts
import { useI18n } from "@/lib/i18n";

defineComponent({
	setup(props, context) {
		const { $t, $tc, locale } = useI18n(); 
		$t('Translate me');	
		$tc('Translate me');
	}
})

```

#### How does `useI18n` work under-the-hood?

In `app.vue` we provide the `context.root.$i18n` to the app.
Then inside `useI18n` we just use inject it.

```ts
import { useI18n } from "@/lib/i18n";

const { $t, $tc, locale } = useI18n(); 
$t('Translate me');	
$tc('Translate me');
```

</p>
</details> 


<details><summary>Next Tick</summary>
<p>


### Before my PR


```ts
defineComponent({
	setup(props, context) {
		context.root.$nextTick();
	}
})
```

### My PR


```ts
import { nextTick } from "@/lib/nextTick"; // My PR

defineComponent({
	setup(props, context) {
		nextTick();
	}
})
```

### Vue 3!

Once we move to vue 3 will become (if we decide to not use [auto-imports](https://github.com/unplugin/unplugin-auto-import) 😉)

```ts
import { nextTick } from "vue"; 

nextTick();
```

</p>
</details> 

## Missing `context` definitions

We still need to use `context` to define `refs` and `emit`, which I am not aware that we do a similar approach to ease the transition to vue 3. If you have an idea, please let me know.
