### PR TITLE
Allow 0 values in the fee 

### DIFF
--- a/src/components/swap/SwapModal.vue
+++ b/src/components/swap/SwapModal.vue
@@ -1362,9 +1362,9 @@ export default defineComponent({
         );
 
         const feeIsLoading = computed(() => {
-            if (swapHasBtc.value && !btcFeeFiat.value) return true;
-            if (swapHasUsdc.value && !usdcFeeFiat.value) return true;
-            if (swapHasUsdt.value && !usdtFeeFiat.value) return true;
+            if (swapHasBtc.value && btcFeeFiat.value === undefined) return true;
+            if (swapHasUsdc.value && usdcFeeFiat.value === undefined) return true;
+            if (swapHasUsdt.value && usdtFeeFiat.value === undefined) return true;
             return false;
         });
 


### PR DESCRIPTION
While working on #252, we came across a small bug that if the fee is 0, the swap cannot be continued.

I understand that the swap will always have a value greater than 0, but maybe for the playground we don't want to show the fees. So I am opening therefore this PR