### PR TITLE
chore: update vue-router to be able to use `addRoute`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
     "vue-i18n": "^8.15.5",
-    "vue-router": "^3.1.6",
+    "vue-router": "^3.5.0",
     "vue-virtual-scroller": "https://github.com/sisou/vue-virtual-scroller#nimiq/build",
     "webpack-i18n-tools": "https://github.com/nimiq/webpack-i18n-tools"
   },

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -91,7 +91,8 @@ const Modal = defineComponent({
 
             while (router.currentRoute.matched.find((routeRecord) => 'modal' in routeRecord.components
                 || 'persistent-modal' in routeRecord.components
-                || Object.values(routeRecord.components).some((component) => /modal/i.test(component.name || '')))
+                || Object.values(routeRecord.components).some((component) => /modal/i.test(
+                    'name' in component ? component.name as string : '')))
             ) {
                 router.back();
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -125,7 +125,7 @@ hubApi.on(HubApi.RequestType.ONBOARD, async (accounts) => {
     processAndStoreAccounts(accounts);
 
     // Open optional Welcome modal, Bitcoin activation modal or USDC activation modal if appropriate.
-    await new Promise((resolve) => { router.onReady(resolve); });
+    await new Promise<void>((resolve) => { router.onReady(resolve); });
     if (!areOptionalRedirectsAllowed(router.currentRoute)) return;
     const welcomeModalAlreadyShown = window.localStorage.getItem(WELCOME_MODAL_LOCALSTORAGE_KEY);
     const { requestType } = accounts[0];
@@ -390,7 +390,7 @@ export async function syncFromHub() {
     // for Ledgers USDC would not be enabled automatically on logins and the activation reminder on every app start
     // would be annoying for the user.
     const { activeAccountInfo } = useAccountStore();
-    await new Promise((resolve) => { router.onReady(resolve); });
+    await new Promise<void>((resolve) => { router.onReady(resolve); });
     if (
         areOptionalRedirectsAllowed(router.currentRoute)
         && activeAccountInfo.value?.type === AccountType.BIP39 // Legacy accounts and Ledgers are not supported.
@@ -434,7 +434,7 @@ export async function onboard(asRedirect = false) {
     // automatically on login), optionally offer to activate it. After activation, the Bitcoin activation modal leads
     // into the Welcome modal if not shown yet.
     const { activeAccountInfo } = useAccountStore();
-    await new Promise((resolve) => { router.onReady(resolve); });
+    await new Promise<void>((resolve) => { router.onReady(resolve); });
     if (
         areOptionalRedirectsAllowed(router.currentRoute)
         && activeAccountInfo.value

--- a/yarn.lock
+++ b/yarn.lock
@@ -10776,10 +10776,10 @@ vue-resize@^0.4.5:
   resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"
   integrity sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==
 
-vue-router@^3.1.6:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.9.tgz#c016f42030ae2932f14e4748b39a1d9a0e250e66"
-  integrity sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA==
+vue-router@^3.5.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.6.5.tgz#95847d52b9a7e3f1361cb605c8e6441f202afad8"
+  integrity sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==
 
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
   version "4.1.3"


### PR DESCRIPTION
I am working on the wallet playground #252. I want to add some routes, but since it's only for playground mode, I don't want to do it in router.ts, but rather dynamically.

I had to update `vue-router` to be able to add routes to specific children using [addRoute](https://v3.router.vuejs.org/api/#router-addroute). Maybe there is another way, but also it doesn't hurt to update now, as it is something less for the future :).

There are no breaking changes between 3.1 and 3.5: [vuejs/vue-router@dev/CHANGELOG.md#350-2021-01-25](https://github.com/vuejs/vue-router/blob/dev/CHANGELOG.md?rgh-link-date=2025-01-22T11%3A33%3A48Z#350-2021-01-25) except for a few TS issues, which you can find in this PR
