### PR TITLE
Fix introduce retries if usdc tx fetching exceeds limits

### DIFF
--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -37,7 +37,7 @@ export default {
     },
 
     polygon: {
-        enabled: true,
+        enabled: false,
         networkId: 80002,
         rpcEndpoint: 'wss://polygon-amoy.g.alchemy.com/v2/#ALCHEMY_API_KEY#',
         rpcMaxBlockRange: 1_296_000, // 30 days - Range not limited, only limited by number of logs returned

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -37,7 +37,7 @@ export default {
     },
 
     polygon: {
-        enabled: false,
+        enabled: true,
         networkId: 80002,
         rpcEndpoint: 'wss://polygon-amoy.g.alchemy.com/v2/#ALCHEMY_API_KEY#',
         rpcMaxBlockRange: 1_296_000, // 30 days - Range not limited, only limited by number of logs returned

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -40,7 +40,7 @@ export default {
         enabled: false,
         networkId: 80002,
         rpcEndpoint: 'wss://polygon-amoy.g.alchemy.com/v2/#ALCHEMY_API_KEY#',
-        rpcMaxBlockRange: 1_296_000, // 30 days - Range not limited, only limited by number of logs returned
+        rpcMaxBlockRange: 648_000, // 15 days - Maximum supported range by Alchemy?
         // eslint-disable-next-line max-len
         // rpcEndpoint: 'wss://shy-sparkling-wind.matic-testnet.discover.quiknode.pro/4461ca78cea96dd6a168a58d8fc30a021cabf01d/',
         usdc_bridged: {

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -50,7 +50,7 @@ export default {
         enabled: true,
         networkId: 137,
         rpcEndpoint: 'wss://polygon-mainnet.g.alchemy.com/v2/#ALCHEMY_API_KEY#',
-        rpcMaxBlockRange: 1_296_000, // 30 days - Range not limited, only limited by number of logs returned
+        rpcMaxBlockRange: 648_000, // 15 days - Maximum supported range by Alchemy?
         usdc_bridged: {
             tokenContract: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
             transferContract: '0x98E69a6927747339d5E543586FC0262112eBe4BD',

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -38,7 +38,7 @@ export default {
         enabled: false,
         networkId: 80002,
         rpcEndpoint: 'wss://polygon-amoy.g.alchemy.com/v2/#ALCHEMY_API_KEY#',
-        rpcMaxBlockRange: 1_296_000, // 30 days - Range not limited, only limited by number of logs returned
+        rpcMaxBlockRange: 648_000, // 15 days - Maximum supported range by Alchemy?
         usdc_bridged: {
             tokenContract: '',
             transferContract: '', // v3

--- a/src/ethers.ts
+++ b/src/ethers.ts
@@ -302,12 +302,12 @@ export async function safeQueryFilter(
             } catch (err: any) {
                 if (currentEnd - currentStart <= 1) {
                     // eslint-disable-next-line
-                    console.error('QueryFilter failed with the smallest window, giving up.', currentStart, currentEnd);
+                    console.error('ITEST QueryFilter failed with the smallest window, giving up.', currentStart, currentEnd);
                     throw err;
                 }
 
                 const mid = Math.floor((currentStart + currentEnd) / 2);
-                console.warn('QueryFilter failed, retrying with smaller range', currentStart, currentEnd);
+                console.warn('ITEST QueryFilter failed, retrying with smaller range', currentStart, currentEnd);
                 currentEnd = mid;
             }
         }

--- a/src/ethers.ts
+++ b/src/ethers.ts
@@ -295,20 +295,22 @@ export async function safeQueryFilter(
         // Reduce the window size until it no longer crosses the provider’s limits.
         while (true) {
             try {
+                console.warn('ITEST Trying to fetch ', currentStart, currentEnd);
                 // eslint-disable-next-line no-await-in-loop
                 const eventsChunk = await contract.queryFilter(event, currentStart, currentEnd);
                 allEvents.push(...eventsChunk);
                 break;
-            } catch (err: any) {
-                if (currentEnd - currentStart <= 1) {
-                    // eslint-disable-next-line
-                    console.error('ITEST QueryFilter failed with the smallest window, giving up.', currentStart, currentEnd);
-                    throw err;
+            } catch (err: unknown) {
+                if (err instanceof Error) { //TODO
+                    console.warn('ITEST ', err);
+                    if (currentEnd - currentStart < 1) {
+                        // eslint-disable-next-line
+                        console.error('ITEST QueryFilter failed with the smallest window, giving up.', currentStart, currentEnd);
+                        throw err;
+                    }
+                    console.warn('ITEST QueryFilter failed, retrying with smaller range');
+                    currentEnd = Math.floor((currentEnd - currentStart) / 2) + currentStart; // Splits range in half
                 }
-
-                const mid = Math.floor((currentStart + currentEnd) / 2);
-                console.warn('ITEST QueryFilter failed, retrying with smaller range', currentStart, currentEnd);
-                currentEnd = mid;
             }
         }
 

--- a/src/ethers.ts
+++ b/src/ethers.ts
@@ -296,25 +296,25 @@ export async function safeQueryFilter(
         // Reduce the window size until it no longer crosses the provider’s limits.
         while (true) {
             try {
-                console.warn('ITEST Trying to fetch ', currentStart, currentEnd);
+                console.warn('Trying to fetch ', currentStart, currentEnd);
                 // eslint-disable-next-line no-await-in-loop
                 const eventsChunk = await contract.queryFilter(event, currentStart, currentEnd);
                 allEvents.push(...eventsChunk);
                 break;
             } catch (err: any) {
-                console.warn('ITEST Query filter failed', err);
+                console.warn('Query filter failed', err);
 
                 // Fail if minimum window is reached
                 if (currentEnd - currentStart <= 8) {
                     // eslint-disable-next-line
-                    console.error('ITEST Query filter failed with the smallest window, giving up.', currentStart, currentEnd);
+                    console.error('Query filter failed with the smallest window, giving up.', currentStart, currentEnd);
                     throw err;
                 } else if (currentEnd - currentStart > MAX_RANGE) {
                     currentEnd = currentStart + MAX_RANGE;
-                    console.warn('ITEST Query filter failed retrying with rage of 2000.', currentStart, currentEnd);
+                    console.warn('Query filter failed retrying with rage of 2000.', currentStart, currentEnd);
                 } else {
                     currentEnd = Math.floor((currentEnd - currentStart) / 2) + currentStart;
-                    console.warn('ITEST Query filter failed retrying with halved range.', currentStart, currentEnd);
+                    console.warn('Query filter failed retrying with halved range.', currentStart, currentEnd);
                 }
             }
         }

--- a/src/ethers.ts
+++ b/src/ethers.ts
@@ -297,30 +297,30 @@ export async function safeQueryFilter(
     // Subsequent tries halve the range until success or minimum range reached.
     while (currentStart <= toBlock) {
         // Attempt to fetch logs in the current range.
-        // Reduce the window size until it no longer crosses breaches alchemy's limits.
+        // Reduce the window size until it no longer exceeds alchemy's limits.
         while (true) {
             try {
-                console.warn('Trying to fetch ', currentStart, currentEnd);
+                console.warn('Trying to fetch from Alchemy:', currentStart, currentEnd);
                 // eslint-disable-next-line no-await-in-loop
                 const eventsChunk = await contract.queryFilter(event, currentStart, currentEnd);
                 allEvents.push(...eventsChunk);
                 break;
             } catch (err: any) {
-                const currentRage = currentEnd - currentStart;
+                const currentRange = currentEnd - currentStart;
 
                 // Fail if minimum range is reached.
-                if (currentRage <= 8) {
+                if (currentRange <= 8) {
                     // eslint-disable-next-line
                     console.error('Query filter failed with the smallest window, giving up.', err, currentStart, currentEnd);
                     throw err;
                 }
                 // Try the recommended max range first, otherwise halves the range.
-                if (currentRage > MAX_RECOMMENDED_RANGE) {
+                if (currentRange > MAX_RECOMMENDED_RANGE) {
                     currentEnd = currentStart + MAX_RECOMMENDED_RANGE;
-                    console.warn('Query filter failed retrying with rage of 2000.', err, currentStart, currentEnd);
+                    console.warn('Query filter failed. Retrying with range of 2000.', err, currentStart, currentEnd);
                 } else {
-                    currentEnd = Math.floor(currentRage / 2) + currentStart;
-                    console.warn('Query filter failed retrying with halved range.', err, currentStart, currentEnd);
+                    currentEnd = currentStart + Math.floor(currentRange / 2);
+                    console.warn('Query filter failed. Retrying with halved range.', err, currentStart, currentEnd);
                 }
             }
         }
@@ -971,8 +971,8 @@ export async function launchPolygon() {
                 console.debug(`Querying native logs from ${startHeight} to ${endHeight} = ${endHeight - startHeight}`);
 
                 let [logsIn, logsOut/* , metaTxs */] = await Promise.all([ // eslint-disable-line no-await-in-loop
-                    safeQueryFilter(client.usdcBridgedToken, filterIncoming, startHeight, endHeight),
-                    safeQueryFilter(client.usdcBridgedToken, filterOutgoing, startHeight, endHeight),
+                    safeQueryFilter(client.usdcToken, filterIncoming, startHeight, endHeight),
+                    safeQueryFilter(client.usdcToken, filterOutgoing, startHeight, endHeight),
                 ]);
 
                 // Ignore address poisoning transactions
@@ -1232,8 +1232,8 @@ export async function launchPolygon() {
                 console.debug(`Querying bridged logs from ${startHeight} to ${endHeight} = ${endHeight - startHeight}`);
 
                 let [logsIn, logsOut/* , metaTxs */] = await Promise.all([ // eslint-disable-line no-await-in-loop
-                    safeQueryFilter(client.usdcBridgedToken, filterIncoming, startHeight, endHeight),
-                    safeQueryFilter(client.usdcBridgedToken, filterOutgoing, startHeight, endHeight),
+                    safeQueryFilter(client.usdtBridgedToken, filterIncoming, startHeight, endHeight),
+                    safeQueryFilter(client.usdtBridgedToken, filterOutgoing, startHeight, endHeight),
                 ]);
 
                 // Ignore address poisoning transactions

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -217,8 +217,8 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:154
-#: src/components/layouts/AccountOverview.vue:268
+#: src/components/layouts/AccountOverview.vue:159
+#: src/components/layouts/AccountOverview.vue:273
 msgid "Activate"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:276
+#: src/components/layouts/AccountOverview.vue:281
 #: src/components/LegacyAccountNotice.vue:37
 msgid "All new features are exclusive to new accounts. Upgrade now, it only takes seconds."
 msgstr ""
@@ -435,7 +435,7 @@ msgid "BIC works, too."
 msgstr ""
 
 #: src/components/AddressList.vue:191
-#: src/components/layouts/AccountOverview.vue:135
+#: src/components/layouts/AccountOverview.vue:140
 #: src/components/layouts/AddressOverview.vue:125
 #: src/components/layouts/Settings.vue:119
 #: src/components/LegacyAccountNotice.vue:21
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Choose an Address"
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:224
+#: src/components/layouts/AccountOverview.vue:229
 msgid "Choose Stablecoin"
 msgstr ""
 
@@ -1124,23 +1124,23 @@ msgstr ""
 msgid "Failed to fetch transactions"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:134
+#: src/components/TestnetFaucet.vue:138
 msgid "Faucet error - please try again."
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:77
+#: src/components/TestnetFaucet.vue:81
 msgid "Faucet is empty"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:81
+#: src/components/TestnetFaucet.vue:85
 msgid "Faucet is not available from your location"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:88
+#: src/components/TestnetFaucet.vue:92
 msgid "Faucet unavailable"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:73
+#: src/components/TestnetFaucet.vue:77
 msgid "Faucet unavailable (wrong network)"
 msgstr ""
 
@@ -2060,8 +2060,8 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:139
-#: src/components/TestnetFaucet.vue:145
+#: src/components/TestnetFaucet.vue:143
+#: src/components/TestnetFaucet.vue:149
 msgid "Request failed"
 msgstr ""
 
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Swap"
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:189
+#: src/components/layouts/AccountOverview.vue:194
 msgid "Swap BTC {arrowIcon} {ticker}"
 msgstr ""
 
@@ -2566,11 +2566,11 @@ msgstr ""
 msgid "Swap more per 30 days."
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:118
+#: src/components/layouts/AccountOverview.vue:123
 msgid "Swap NIM {arrowIcon} {ticker}"
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:82
+#: src/components/layouts/AccountOverview.vue:87
 msgid "Swap NIM {arrowIcon} BTC"
 msgstr ""
 
@@ -2641,7 +2641,7 @@ msgid "TEN31 Verification"
 msgstr ""
 
 #: src/components/AddressList.vue:210
-#: src/components/layouts/AccountOverview.vue:216
+#: src/components/layouts/AccountOverview.vue:221
 #: src/components/layouts/AddressOverview.vue:131
 #: src/components/swap/SwapBalanceBar.vue:29
 #: src/components/swap/SwapBalanceBar.vue:55
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "The validator is solely responsible for the information provided above. It is not to be viewed as an endorsement or recommendation by Nimiq."
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:130
+#: src/components/TestnetFaucet.vue:134
 msgid "There are currently no free NIM available."
 msgstr ""
 
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "This pool usually produces blocks."
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:125
+#: src/components/TestnetFaucet.vue:129
 msgid "This service is currently not available in your region."
 msgstr ""
 
@@ -2900,8 +2900,8 @@ msgstr ""
 msgid "To change your validator, un-stake all NIM and restart the process. Click here to {unstakeLink}."
 msgstr ""
 
-#: src/components/layouts/AccountOverview.vue:123
-#: src/components/layouts/AccountOverview.vue:194
+#: src/components/layouts/AccountOverview.vue:128
+#: src/components/layouts/AccountOverview.vue:199
 #: src/components/swap/SwapModal.vue:37
 msgid "To swap with USDC/USDT, choose a stablecoin."
 msgstr ""
@@ -3027,7 +3027,7 @@ msgid "Update validator"
 msgstr ""
 
 #: src/components/AddressList.vue:200
-#: src/components/layouts/AccountOverview.vue:213
+#: src/components/layouts/AccountOverview.vue:218
 #: src/components/layouts/AddressOverview.vue:128
 #: src/components/swap/SwapBalanceBar.vue:24
 #: src/components/swap/SwapBalanceBar.vue:50
@@ -3162,7 +3162,7 @@ msgstr ""
 msgid "You can receive from Polygon {ticker} addresses only!"
 msgstr ""
 
-#: src/components/TestnetFaucet.vue:119
+#: src/components/TestnetFaucet.vue:123
 msgid "You can receive more free NIM in {waitTime} hours."
 msgstr ""
 

--- a/src/lib/usdc/OpenGSN.ts
+++ b/src/lib/usdc/OpenGSN.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import type { BigNumber, Contract } from 'ethers';
-import { getPolygonBlockNumber, PolygonClient } from '../../ethers';
+import { getPolygonBlockNumber, PolygonClient, safeQueryFilter } from '../../ethers';
 import { OPENGSN_RELAY_HUB_CONTRACT_ABI } from './ContractABIs';
 import { useConfig } from '../../composables/useConfig';
 import { ENV_MAIN } from '../Constants';
@@ -119,7 +119,8 @@ async function* relayServerRegisterGen(
         const { fromBlock, toBlock } = blocks.value;
 
         // eslint-disable-next-line no-await-in-loop
-        events = await relayHub.queryFilter(
+        events = await safeQueryFilter(
+            relayHub,
             relayHub.filters.RelayServerRegistered(),
             fromBlock,
             toBlock,
@@ -151,7 +152,7 @@ async function* relayServerRegisterGen(
                 return false;
             }
 
-            return <RelayRegistration> {
+            return <RelayRegistration>{
                 relayManagerAddress,
                 baseRelayFee,
                 pctRelayFee,
@@ -264,7 +265,7 @@ async function* relayServerRegisterGen(
                 const filterFromBlock = Math.max(filterToBlock - STEP_BLOCKS, earliestBlock);
 
                 // eslint-disable-next-line no-await-in-loop
-                const logs = await relayHub.queryFilter(filter, filterFromBlock, filterToBlock);
+                const logs = await safeQueryFilter(relayHub, filter, filterFromBlock, filterToBlock);
                 if (logs.length) break;
 
                 startBlock = filterFromBlock;


### PR DESCRIPTION
Introduces a mechanism to retry the request with a smaller block interval if there is an error.

This is an example of the error message we get where no more tx are fetched afterwards.
`Query timeout exceeded. Consider reducing your block range. Based on your parameters and the response size limit, this block range should work: [0x42b950f, 0x435784f]`

Alchemy restricts log responses to 10k if the block range is >2000. So the safe query filter is tried with the provided block range, and if it fails, it attempts with a 2000 block range. If that still fails, it halves the range. https://www.alchemy.com/docs/deep-dive-into-eth_getlogs