### PR TITLE
fix: point validators API base URLs to workers

### DIFF
--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -26,7 +26,7 @@ export default {
         prestakingStartBlock: 3_023_730,
         prestakingEndBlock: 3_028_050,
         transitionBlock: 3_032_010,
-        validatorsApiBase: 'https://validators-api-testnet.nuxt.dev',
+        validatorsApiBase: 'https://validators-api-test.je-cf9.workers.dev',
         validatorsPath: '/api/v1/validators',
         stakeEventsEndpoint: 'https://v2.test.nimiqwatch.com/api/v2/staker/ADDRESS/events/restake-grouped',
         genesis: {

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -36,7 +36,7 @@ export default {
         prestakingStartBlock: 3_392_200, // 2024-10-06T02:53:18Z
         prestakingEndBlock: 3_456_000, // ~2024-11-19T16:00:00Z
         transitionBlock: 3_456_000,
-        validatorsApiBase: 'https://validators-api-mainnet.nuxt.dev',
+        validatorsApiBase: 'https://validators-api-main.je-cf9.workers.dev',
         validatorsPath: '/api/v1/validators',
         stakeEventsEndpoint: 'https://v2.nimiqwatch.com/api/v2/staker/ADDRESS/events/restake-grouped',
         genesis: {

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -24,7 +24,7 @@ export default {
         prestakingStartBlock: 3_023_730,
         prestakingEndBlock: 3_028_050,
         transitionBlock: 3_032_010,
-        validatorsApiBase: 'https://validators-api-testnet.nuxt.dev',
+        validatorsApiBase: 'https://validators-api-test.je-cf9.workers.dev',
         validatorsPath: '/api/v1/validators',
         stakeEventsEndpoint: 'https://v2.test.nimiqwatch.com/api/v2/staker/ADDRESS/events/restake-grouped',
         genesis: {


### PR DESCRIPTION
## Summary
- The wallet was still using deprecated `.nuxt.dev` validator API domains.
- Switched staking API base URLs to Cloudflare Workers endpoints for mainnet and testnet.

## Why
- The legacy domains no longer reliably serve API traffic after migration.

## Notes
- Updated config files:
  - `src/config/config.mainnet.ts`
  - `src/config/config.testnet.ts`
  - `src/config/config.local.ts`
