### PR TITLE
Incorporate the watchtower for unstaking and switching validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@nimiq/core": "^2.20.0",
     "@nimiq/electrum-client": "https://github.com/nimiq/electrum-client#build",
     "@nimiq/fastspot-api": "^1.10.3",
-    "@nimiq/hub-api": "^1.13.0",
+    "@nimiq/hub-api": "^1.15.0",
     "@nimiq/iqons": "^1.5.2",
     "@nimiq/libswap": "^1.5.2",
     "@nimiq/oasis-api": "^1.1.1",

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -147,7 +147,6 @@ export default defineComponent({
                         const txs = await sendStaking({
                             transaction: transaction.serialize(),
                             recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                            // @ts-expect-error Not typed yet in Hub
                             validatorImageUrl: 'logo' in activeValidator.value!
                                 && !activeValidator.value.hasDefaultLogo
                                 ? activeValidator.value.logo
@@ -190,7 +189,6 @@ export default defineComponent({
                         const txs = await sendStaking({
                             transaction: transaction.serialize(),
                             recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                            // @ts-expect-error Not typed yet in Hub
                             validatorAddress: activeValidator.value!.address,
                             validatorImageUrl: ('logo' in activeValidator.value!
                                 && !activeValidator.value.hasDefaultLogo)
@@ -344,12 +342,10 @@ export default defineComponent({
                     // Send the retire and remove transactions to the watchtower
                     try {
                         await startUnstaking({
-                            staker_address: activeAddress.value!,
-                            transactions: {
-                                inactive_stake_tx_hash: signedTransactions[0].hash,
-                                retire_tx: signedTransactions[1].serializedTx,
-                                unstake_tx: signedTransactions[2].serializedTx,
-                            },
+                            stakerAddress: activeAddress.value!,
+                            inactiveStakeTxHash: signedTransactions[0].hash,
+                            retireTx: signedTransactions[1].serializedTx,
+                            unstakeTx: signedTransactions[2].serializedTx,
                         });
                     } catch (watchtowerError: any) {
                         // Log watchtower error but don't fail the unstaking operation

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -291,8 +291,9 @@ export default defineComponent({
                     // Sign all 3 transactions at once using the SignTransaction API
                     const signedTransactions = await signUnstakingTransactions({
                         sender: activeAddress.value!,
-                        senderLabel: activeAddress.value!,
-                        recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
+                        // FROM = validator (rendered on the dashed "current" card in the keyguard).
+                        senderLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
+                        // TO = user wallet — let the keyguard fall back to keyLabel.
                         transactions: [
                             deactivationTx.serialize(),
                             retireTx.serialize(),

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -81,8 +81,10 @@ import { InfoCircleSmallIcon, Amount, PageHeader, PageBody, Tooltip } from '@nim
 import { useI18n } from '@/lib/useI18n';
 import { CryptoCurrency, MIN_STAKE } from '../../lib/Constants';
 import { calculateDisplayedDecimals } from '../../lib/NumberFormatting';
-import { getNetworkClient } from '../../network';
-import { sendStaking } from '../../hub';
+import { getNetworkClient, sendTransaction as sendTx, waitForTransactionConfirmation } from '../../network';
+import { usePolicy } from '../../composables/usePolicy';
+import { sendStaking, signUnstakingTransactions } from '../../hub';
+import { startUnstaking } from '../../lib/AlbatrossWatchtower';
 
 import { useAddressStore } from '../../stores/Address';
 import { useStakingStore } from '../../stores/Staking';
@@ -227,35 +229,134 @@ export default defineComponent({
                         title: $t('Sending Staking Transaction') as string,
                     });
 
-                    const transaction = TransactionBuilder.newSetActiveStake(
+                    const unstakeAmount = Math.abs(stakeDelta.value);
+
+                    // Load policy to calculate correct validity heights for retire/unstake transactions
+                    const policy = await usePolicy();
+
+                    // Use current height as the basis for validity height calculations
+                    // This ensures our calculated heights are <= what the watchtower will calculate
+                    // (since the actual block will be currentHeight or later)
+                    const currentHeight = useNetworkStore().state.height;
+
+                    // Calculate when the retire transaction can be broadcast (after inactivation period)
+                    // This matches the watchtower's logic: election_block_after + blocks_per_epoch
+                    const nextElectionBlock = policy.electionBlockAfter(currentHeight);
+                    const retireValidityStartHeight = nextElectionBlock + policy.blocksPerEpoch();
+
+                    // Unstake must be valid 1 block after retire
+                    const unstakeValidityStartHeight = retireValidityStartHeight + 1;
+
+                    // eslint-disable-next-line no-console
+                    console.debug('Unstaking transaction validity heights:', {
+                        currentHeight,
+                        nextElectionBlock,
+                        retireValidityStartHeight,
+                        unstakeValidityStartHeight,
+                        blocksPerEpoch: policy.blocksPerEpoch(),
+                        genesisBlockNumber: policy.genesisBlockNumber,
+                    });
+
+                    // Build all 3 transactions for the unstaking watchtower flow:
+                    // 1. Deactivation: Move active stake to inactive
+                    const deactivationTx = TransactionBuilder.newSetActiveStake(
                         Address.fromUserFriendlyAddress(activeAddress.value!),
                         BigInt(activeStake.value!.activeBalance + stakeDelta.value),
                         BigInt(0),
-                        useNetworkStore().state.height,
+                        currentHeight,
                         await client.getNetworkId(),
                     );
-                    const txs = await sendStaking({
-                        transaction: transaction.serialize(),
+
+                    // 2. Retire: Move inactive stake to retired (will be broadcast after epoch boundary)
+                    // Must specify the TOTAL inactive balance after deactivation
+                    const totalInactiveAfterDeactivation = (activeStake.value!.inactiveBalance || 0) + unstakeAmount;
+                    const retireTx = TransactionBuilder.newRetireStake(
+                        Address.fromUserFriendlyAddress(activeAddress.value!),
+                        BigInt(totalInactiveAfterDeactivation),
+                        BigInt(0),
+                        retireValidityStartHeight,
+                        await client.getNetworkId(),
+                    );
+
+                    // 3. Remove: Remove retired stake and send funds back (will be broadcast after retire)
+                    // Must remove TOTAL retired balance (existing retired + newly retired)
+                    const totalRetiredAfterRetire = (activeStake.value!.retiredBalance || 0)
+                        + totalInactiveAfterDeactivation;
+                    const removeTx = TransactionBuilder.newRemoveStake(
+                        Address.fromUserFriendlyAddress(activeAddress.value!),
+                        BigInt(totalRetiredAfterRetire),
+                        BigInt(0),
+                        unstakeValidityStartHeight,
+                        await client.getNetworkId(),
+                    );
+
+                    // Sign all 3 transactions at once using the SignTransaction API
+                    const signedTransactions = await signUnstakingTransactions({
+                        sender: activeAddress.value!,
+                        senderLabel: activeAddress.value!,
                         recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                        // @ts-expect-error Not typed yet in Hub
+                        transactions: [
+                            deactivationTx.serialize(),
+                            retireTx.serialize(),
+                            removeTx.serialize(),
+                        ],
                         validatorAddress: activeValidator.value!.address,
                         validatorImageUrl: 'logo' in activeValidator.value! && !activeValidator.value.hasDefaultLogo
                             ? activeValidator.value.logo
                             : undefined,
-                        amount: Math.abs(stakeDelta.value),
                     }).catch((error) => {
-                        throw new Error(error.data);
+                        throw new Error(error?.data || error?.message || error);
                     });
 
-                    if (!txs) {
+                    if (!signedTransactions) {
                         context.emit('statusChange', {
                             type: StakingOperationType.NONE,
                         });
                         return;
                     }
 
-                    if (txs.some((tx) => tx.executionResult === false)) {
-                        throw new Error('The transaction did not succeed');
+                    // Validate that we received 3 signed transactions
+                    if (!Array.isArray(signedTransactions) || signedTransactions.length !== 3) {
+                        const got = Array.isArray(signedTransactions) ? signedTransactions.length : 'non-array';
+                        throw new Error(`Expected 3 signed transactions, got ${got}`);
+                    }
+
+                    // Broadcast the deactivation transaction immediately
+                    const deactivationResult = await sendTx(signedTransactions[0]);
+
+                    if (!deactivationResult || deactivationResult.executionResult === false) {
+                        throw new Error('Deactivation transaction failed');
+                    }
+
+                    // Wait for the deactivation transaction to be confirmed before sending to watchtower
+                    // The watchtower requires the transaction to be confirmed on-chain
+                    try {
+                        await waitForTransactionConfirmation(signedTransactions[0].hash, {
+                            requireConfirmed: true,
+                        });
+                    } catch (confirmationError: any) {
+                        // Log confirmation timeout but continue - watchtower is optional
+                        reportToSentry(confirmationError);
+                        // eslint-disable-next-line no-console
+                        console.warn('Transaction confirmation timeout:', confirmationError);
+                    }
+
+                    // Send the retire and remove transactions to the watchtower
+                    try {
+                        await startUnstaking({
+                            staker_address: activeAddress.value!,
+                            transactions: {
+                                inactive_stake_tx_hash: signedTransactions[0].hash,
+                                retire_tx: signedTransactions[1].serializedTx,
+                                unstake_tx: signedTransactions[2].serializedTx,
+                            },
+                        });
+                    } catch (watchtowerError: any) {
+                        // Log watchtower error but don't fail the unstaking operation
+                        // The deactivation was successful, watchtower is just for automation
+                        reportToSentry(watchtowerError);
+                        // eslint-disable-next-line no-console
+                        console.warn('Watchtower registration failed:', watchtowerError);
                     }
 
                     context.emit('statusChange', {
@@ -263,16 +364,11 @@ export default defineComponent({
                         title: $t(
                             'Successfully deactivated {amount} NIM from your stake with {validator}',
                             {
-                                amount: Math.abs((activeStake.value!.inactiveBalance - stakeDelta.value) / 1e5),
+                                amount: Math.abs(unstakeAmount / 1e5),
                                 validator: validatorLabelOrAddress,
                             },
                         ),
                     });
-
-                    // if (Math.abs(stakeDelta.value) === activeStake.value!.activeBalance) {
-                    //     // Close staking modal
-                    //     router.back();
-                    // }
                 }
 
                 window.setTimeout(() => {

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -287,7 +287,7 @@ export default defineComponent({
                         sender: activeAddress.value!,
                         // FROM = validator (rendered on the dashed "current" card in the keyguard).
                         senderLabel: validatorLabelOrAddress,
-                        // TO = user wallet — let the Hub fall back to the signer label.
+                        // TO = user wallet — the Hub sets the signer label.
                         transactions: [
                             deactivationTx.serialize(),
                             retireTx.serialize(),

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -293,7 +293,7 @@ export default defineComponent({
                         sender: activeAddress.value!,
                         // FROM = validator (rendered on the dashed "current" card in the keyguard).
                         senderLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                        // TO = user wallet — let the keyguard fall back to keyLabel.
+                        // TO = user wallet — let the Hub fall back to the signer label.
                         transactions: [
                             deactivationTx.serialize(),
                             retireTx.serialize(),

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -147,6 +147,7 @@ export default defineComponent({
                         const txs = await sendStaking({
                             transaction: transaction.serialize(),
                             recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
+                            validatorAddress: activeValidator.value!.address,
                             validatorImageUrl: 'logo' in activeValidator.value!
                                 && !activeValidator.value.hasDefaultLogo
                                 ? activeValidator.value.logo

--- a/src/components/staking/StakingGraphPage.vue
+++ b/src/components/staking/StakingGraphPage.vue
@@ -94,7 +94,7 @@ import ValidatorInfoBar from './tooltips/ValidatorInfoBar.vue';
 
 import { SUCCESS_REDIRECT_DELAY, State } from '../StatusScreen.vue';
 import AmountSlider from './AmountSlider.vue';
-import { StakingOperationType } from '../../lib/StakingUtils';
+import { StakingOperationType, toValidatorRef, validatorLabel } from '../../lib/StakingUtils';
 import MessageTransition from '../MessageTransition.vue';
 import StakingGraph from './StakingGraph.vue';
 import { reportToSentry } from '../../lib/Sentry';
@@ -119,12 +119,11 @@ export default defineComponent({
         async function performStaking() {
             if (isStakeBelowMinimum.value) return;
 
-            const validatorLabelOrAddress = 'name' in activeValidator.value!
-                ? activeValidator.value.name
-                : activeValidator.value!.address;
-
             const { Address, TransactionBuilder } = await import('@nimiq/core');
             const client = await getNetworkClient();
+
+            const validatorRef = toValidatorRef(activeValidator.value!);
+            const validatorLabelOrAddress = validatorLabel(validatorRef);
 
             try {
                 if (stakeDelta.value > 0) {
@@ -138,7 +137,7 @@ export default defineComponent({
                         || (!activeStake.value.activeBalance && !activeStake.value.inactiveBalance)) {
                         const transaction = TransactionBuilder.newCreateStaker(
                             Address.fromUserFriendlyAddress(activeAddress.value!),
-                            Address.fromUserFriendlyAddress(activeValidator.value!.address),
+                            Address.fromUserFriendlyAddress(validatorRef.address),
                             BigInt(stakeDelta.value),
                             BigInt(0),
                             useNetworkStore().state.height,
@@ -146,12 +145,9 @@ export default defineComponent({
                         );
                         const txs = await sendStaking({
                             transaction: transaction.serialize(),
-                            recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                            validatorAddress: activeValidator.value!.address,
-                            validatorImageUrl: 'logo' in activeValidator.value!
-                                && !activeValidator.value.hasDefaultLogo
-                                ? activeValidator.value.logo
-                                : undefined,
+                            recipientLabel: validatorLabelOrAddress,
+                            validatorAddress: validatorRef.address,
+                            validatorImageUrl: validatorRef.logo,
                         }).catch((error) => {
                             throw new Error(error.data);
                         });
@@ -189,12 +185,9 @@ export default defineComponent({
                         );
                         const txs = await sendStaking({
                             transaction: transaction.serialize(),
-                            recipientLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                            validatorAddress: activeValidator.value!.address,
-                            validatorImageUrl: ('logo' in activeValidator.value!
-                                && !activeValidator.value.hasDefaultLogo)
-                                ? activeValidator.value.logo
-                                : undefined,
+                            recipientLabel: validatorLabelOrAddress,
+                            validatorAddress: validatorRef.address,
+                            validatorImageUrl: validatorRef.logo,
                         }).catch((error) => {
                             throw new Error(error.data);
                         });
@@ -293,17 +286,15 @@ export default defineComponent({
                     const signedTransactions = await signUnstakingTransactions({
                         sender: activeAddress.value!,
                         // FROM = validator (rendered on the dashed "current" card in the keyguard).
-                        senderLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
+                        senderLabel: validatorLabelOrAddress,
                         // TO = user wallet — let the Hub fall back to the signer label.
                         transactions: [
                             deactivationTx.serialize(),
                             retireTx.serialize(),
                             removeTx.serialize(),
                         ],
-                        validatorAddress: activeValidator.value!.address,
-                        validatorImageUrl: 'logo' in activeValidator.value! && !activeValidator.value.hasDefaultLogo
-                            ? activeValidator.value.logo
-                            : undefined,
+                        validatorAddress: validatorRef.address,
+                        validatorImageUrl: validatorRef.logo,
                     }).catch((error) => {
                         throw new Error(error?.data || error?.message || error);
                     });

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -197,6 +197,7 @@ export default defineComponent({
             activeValidator: validator,
             activeSwitchOperation,
             canManuallyActivateSwitch,
+            isSwitchingValidator,
             validators,
             restakingRewards,
             monthlyRewards,
@@ -296,6 +297,8 @@ export default defineComponent({
 
         const showDeactivateAll = computed(() => {
             if (!stake.value) return false;
+            // A second deactivate would orphan the watchtower's pending update-staker.
+            if (isSwitchingValidator.value) return false;
             if (stake.value?.activeBalance) return true;
 
             if (

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -318,7 +318,6 @@ export default defineComponent({
                     const txs = await sendStaking({
                         transaction: transaction.serialize(),
                         recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                        // @ts-expect-error Not typed yet in Hub
                         validatorAddress: validator.value!.address,
                         validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
                             ? validator.value.logo
@@ -404,7 +403,6 @@ export default defineComponent({
                 const txs = await sendStaking({
                     transaction: transactions.map((tx) => tx.serialize()),
                     recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                    // @ts-expect-error Not typed yet in Hub
                     validatorAddress: validator.value!.address,
                     validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
                         ? validator.value.logo
@@ -483,7 +481,6 @@ export default defineComponent({
                 const txs = await sendStaking({
                     transaction: transaction.serialize(),
                     recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                    // @ts-expect-error Not typed yet in Hub
                     validatorAddress: validator.value!.address,
                     validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
                         ? validator.value.logo

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -90,7 +90,18 @@
                 <div class="scroll-mask bottom" v-if="stake && !stake.inactiveBalance && !stake.retiredBalance"></div>
             </div>
         </PageBody>
-        <PageFooter v-if="stake && ((stake.inactiveBalance && hasUnstakableStake) || stake.retiredBalance)">
+        <PageFooter v-if="canManuallyActivateSwitch">
+            <div class="flex-row manual-activate">
+                <CircleExclamationMarkIcon />
+                <span class="flex-grow message">
+                    {{ $t('Manually activate the validator to re-activate staking.') }}
+                </span>
+                <button class="nq-button-pill light-blue" @click="manualActivateSwitch">
+                    {{ $t('Activate validator') }}
+                </button>
+            </div>
+        </PageFooter>
+        <PageFooter v-else-if="stake && ((stake.inactiveBalance && hasUnstakableStake) || stake.retiredBalance)">
             <div class="flex-column footer-content">
                 <div class="flex-row unstaking nq-light-blue">
                     <CircleExclamationMarkIcon />
@@ -156,7 +167,7 @@ import Amount from '../Amount.vue';
 import RoundStakingIcon from '../icons/Staking/RoundStakingIcon.vue';
 import ValidatorInfoBar from './tooltips/ValidatorInfoBar.vue';
 import { SUCCESS_REDIRECT_DELAY, State } from '../StatusScreen.vue';
-import { StakingOperationType } from '../../lib/StakingUtils';
+import { StakingOperationType, toValidatorRef, validatorLabel, ValidatorRef } from '../../lib/StakingUtils';
 import FiatConvertedAmount from '../FiatConvertedAmount.vue';
 import StakingRewardsChart from './StakingRewardsChart.vue';
 
@@ -164,6 +175,7 @@ import { sendStaking } from '../../hub';
 import { useNetworkStore } from '../../stores/Network';
 import { getNetworkClient } from '../../network';
 import { reportToSentry } from '../../lib/Sentry';
+import { sendImmediateValidatorSwitch } from '../../lib/SwitchValidator';
 import CircleArrowDownIcon from '../icons/Staking/CircleArrowDownIcon.vue';
 import StakingRewardsListItem from './StakingRewardsListItem.vue';
 import CircleExclamationMarkIcon from '../icons/Staking/CircleExclamationMarkIcon.vue';
@@ -183,9 +195,13 @@ export default defineComponent({
         const {
             activeStake: stake,
             activeValidator: validator,
+            activeSwitchOperation,
+            canManuallyActivateSwitch,
+            validators,
             restakingRewards,
             monthlyRewards,
             stakingEvents,
+            clearSwitchOperation,
         } = useStakingStore();
         const { height, consensus } = useNetworkStore();
         const { isMobile } = useWindowSize();
@@ -314,14 +330,13 @@ export default defineComponent({
                     );
 
                     const deactivatedAmount = stake.value!.activeBalance;
+                    const validatorRef = toValidatorRef(validator.value!);
 
                     const txs = await sendStaking({
                         transaction: transaction.serialize(),
-                        recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                        validatorAddress: validator.value!.address,
-                        validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
-                            ? validator.value.logo
-                            : undefined,
+                        recipientLabel: validatorRef.name || 'Validator',
+                        validatorAddress: validatorRef.address,
+                        validatorImageUrl: validatorRef.logo,
                         amount: Math.abs(stake.value.activeBalance),
                     });
 
@@ -400,13 +415,12 @@ export default defineComponent({
                     ? stake.value!.retiredBalance
                     : stake.value!.retiredBalance + stake.value!.inactiveBalance;
 
+                const validatorRef = toValidatorRef(validator.value!);
                 const txs = await sendStaking({
                     transaction: transactions.map((tx) => tx.serialize()),
-                    recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                    validatorAddress: validator.value!.address,
-                    validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
-                        ? validator.value.logo
-                        : undefined,
+                    recipientLabel: validatorRef.name || 'Validator',
+                    validatorAddress: validatorRef.address,
+                    validatorImageUrl: validatorRef.logo,
                 });
 
                 if (!txs) {
@@ -438,6 +452,63 @@ export default defineComponent({
                     state: State.WARNING,
                     title: $t('Something went wrong') as string,
                     message: `${error.message} - ${error.data}`,
+                });
+            }
+        }
+
+        async function manualActivateSwitch() {
+            const record = activeSwitchOperation.value;
+            if (!record || !stake.value || !validator.value) return;
+
+            context.emit('statusChange', {
+                type: StakingOperationType.VALIDATOR,
+                state: State.LOADING,
+                title: $t('Activating validator') as string,
+            });
+
+            try {
+                const known = validators.value[record.targetValidatorAddress];
+                const target: ValidatorRef = known
+                    ? toValidatorRef(known)
+                    : { address: record.targetValidatorAddress, name: record.targetValidatorName };
+
+                const txs = await sendImmediateValidatorSwitch({
+                    stakerAddress: activeAddress.value!,
+                    height: height.value,
+                    amount: stake.value.inactiveBalance,
+                    target,
+                    from: toValidatorRef(validator.value),
+                });
+
+                if (!txs) {
+                    context.emit('statusChange', { type: StakingOperationType.NONE });
+                    return;
+                }
+
+                if (txs.some((tx) => tx.executionResult === false)) {
+                    throw new Error('The transaction did not succeed');
+                }
+
+                clearSwitchOperation(activeAddress.value!);
+
+                context.emit('statusChange', {
+                    state: State.SUCCESS,
+                    title: $t(
+                        'Successfully changed validator to {validator}',
+                        { validator: validatorLabel(target) },
+                    ),
+                });
+
+                context.emit('statusChange', {
+                    type: StakingOperationType.NONE,
+                    timeout: SUCCESS_REDIRECT_DELAY,
+                });
+            } catch (error: any) {
+                reportToSentry(error);
+                context.emit('statusChange', {
+                    state: State.WARNING,
+                    title: $t('Something went wrong') as string,
+                    message: `${error.message}${error.data ? ` - ${error.data}` : ''}`,
                 });
             }
         }
@@ -477,14 +548,13 @@ export default defineComponent({
                 );
 
                 const deactivatedAmount = stake.value!.activeBalance;
+                const validatorRef = toValidatorRef(validator.value!);
 
                 const txs = await sendStaking({
                     transaction: transaction.serialize(),
-                    recipientLabel: 'name' in validator.value! ? validator.value.name : 'Validator',
-                    validatorAddress: validator.value!.address,
-                    validatorImageUrl: 'logo' in validator.value! && !validator.value.hasDefaultLogo
-                        ? validator.value.logo
-                        : undefined,
+                    recipientLabel: validatorRef.name || 'Validator',
+                    validatorAddress: validatorRef.address,
+                    validatorImageUrl: validatorRef.logo,
                     amount: deactivatedAmount,
                 });
 
@@ -539,6 +609,8 @@ export default defineComponent({
             unstakeAll,
             unstakeRest,
             canSwitchValidator,
+            canManuallyActivateSwitch,
+            manualActivateSwitch,
             consensus,
             selectedRange,
             rewards,
@@ -758,6 +830,31 @@ export default defineComponent({
             color: var(--text-50);
             text-align: left;
             line-height: 1.4;
+        }
+
+        .manual-activate {
+            align-items: flex-start;
+            gap: 0.75rem;
+            color: var(--nimiq-orange);
+            font-size: 2rem;
+            font-weight: 600;
+            line-height: 1.2;
+
+            svg {
+                flex-shrink: 0;
+                width: 2.25rem;
+                height: 2.25rem;
+                margin-top: 0.125rem;
+            }
+
+            .message {
+                margin-top: 0.125rem;
+            }
+
+            .nq-button-pill {
+                flex-shrink: 0;
+                align-self: center;
+            }
         }
     }
 

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -133,8 +133,14 @@
         </PageFooter>
         <PageFooter v-else-if="stake && stake.inactiveBalance">
             <div class="flex-row unstaking nq-light-blue">
-                <CircleArrowDownIcon /> {{  $t('Unstaking') }}
-                <Amount :amount="stake.inactiveBalance" value-mask class="flex-grow"/>
+                <CircleArrowDownIcon />
+                <span v-if="isSwitchingValidator" class="flex-grow">
+                    {{ $t('Switching to {validator}', { validator: switchTargetLabel }) }}
+                </span>
+                <template v-else>
+                    {{ $t('Unstaking') }}
+                    <Amount :amount="stake.inactiveBalance" value-mask class="flex-grow"/>
+                </template>
                 <button class="nq-button-s unstaking-progress">
                     {{ inactiveReleaseTime }} <!-- <span>Cancel</span> -->
                     <!-- TODO: Add cancel function -->
@@ -198,6 +204,7 @@ export default defineComponent({
             activeSwitchOperation,
             canManuallyActivateSwitch,
             isSwitchingValidator,
+            switchTargetLabel,
             validators,
             restakingRewards,
             monthlyRewards,
@@ -613,6 +620,8 @@ export default defineComponent({
             unstakeRest,
             canSwitchValidator,
             canManuallyActivateSwitch,
+            isSwitchingValidator,
+            switchTargetLabel,
             manualActivateSwitch,
             consensus,
             selectedRange,

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -428,7 +428,7 @@ export default defineComponent({
                 const validatorRef = toValidatorRef(validator.value!);
                 const txs = await sendStaking({
                     transaction: transactions.map((tx) => tx.serialize()),
-                    recipientLabel: validatorRef.name || 'Validator',
+                    senderLabel: validatorRef.name || 'Validator',
                     validatorAddress: validatorRef.address,
                     validatorImageUrl: validatorRef.logo,
                 });

--- a/src/components/staking/StakingInfoPage.vue
+++ b/src/components/staking/StakingInfoPage.vue
@@ -344,7 +344,7 @@ export default defineComponent({
 
                     const txs = await sendStaking({
                         transaction: transaction.serialize(),
-                        recipientLabel: validatorRef.name || 'Validator',
+                        recipientLabel: validatorLabel(validatorRef),
                         validatorAddress: validatorRef.address,
                         validatorImageUrl: validatorRef.logo,
                         amount: Math.abs(stake.value.activeBalance),
@@ -428,7 +428,7 @@ export default defineComponent({
                 const validatorRef = toValidatorRef(validator.value!);
                 const txs = await sendStaking({
                     transaction: transactions.map((tx) => tx.serialize()),
-                    senderLabel: validatorRef.name || 'Validator',
+                    senderLabel: validatorLabel(validatorRef),
                     validatorAddress: validatorRef.address,
                     validatorImageUrl: validatorRef.logo,
                 });
@@ -562,7 +562,7 @@ export default defineComponent({
 
                 const txs = await sendStaking({
                     transaction: transaction.serialize(),
-                    recipientLabel: validatorRef.name || 'Validator',
+                    recipientLabel: validatorLabel(validatorRef),
                     validatorAddress: validatorRef.address,
                     validatorImageUrl: validatorRef.logo,
                     amount: deactivatedAmount,

--- a/src/components/staking/StakingModal.vue
+++ b/src/components/staking/StakingModal.vue
@@ -49,34 +49,40 @@
             <SelectAccountOverlay v-if="overlay === Overlay.SelectAccount"
                 @selected="switchValidator"
             />
-            <StatusScreen v-else-if="statusType !== StakingOperationType.NONE"
-                :state="statusState"
-                :title="statusTitle"
-                :message="statusMessage"
-                :main-action="statusMainAction"
-                :light-blue="true"
-                status=""
-                :alternative-action="statusAlternativeAction"
-                :small="false"
-                @main-action="onStatusMainAction"
-            />
-            <transition v-else name="fade" mode="out-in">
-                <ValidatorDetailsOverlay v-if="overlay === Overlay.ValidatorDetails && selectedValidator"
-                    :key="'details'"
-                    :noButton="page !== Page.ValidatorList"
-                    :showBackArrow="showValidatorDetailsBackArrow"
-                    :validator="selectedValidator"
-                    @statusChange="onStatusChange"
-                    @next="onConfirmValidator"
-                    @back="goBackFromValidatorDetails"
+            <template v-else>
+                <!-- Keep mounted under StatusScreen so async operations can keep emitting events.
+                     v-show on the wrapper avoids triggering the inner fade transition. -->
+                <div v-show="statusType === StakingOperationType.NONE" class="overlay-content-wrapper">
+                    <transition name="fade" mode="out-in">
+                        <ValidatorDetailsOverlay v-if="overlay === Overlay.ValidatorDetails && selectedValidator"
+                            :key="'details'"
+                            :showBackArrow="showValidatorDetailsBackArrow"
+                            :validator="selectedValidator"
+                            @statusChange="onStatusChange"
+                            @next="onConfirmValidator"
+                            @switch-validator="onOverlaySwitchValidator"
+                            @back="goBackFromValidatorDetails"
+                        />
+                        <ValidatorsListOverlay v-else-if="overlay === Overlay.ValidatorsList"
+                            :key="'list'"
+                            :validators="selectedValidators"
+                            :month="selectedRewardsMonth"
+                            @select-validator="onSelectValidatorFromList"
+                        />
+                    </transition>
+                </div>
+                <StatusScreen v-if="statusType !== StakingOperationType.NONE"
+                    :state="statusState"
+                    :title="statusTitle"
+                    :message="statusMessage"
+                    :main-action="statusMainAction"
+                    :light-blue="true"
+                    status=""
+                    :alternative-action="statusAlternativeAction"
+                    :small="false"
+                    @main-action="onStatusMainAction"
                 />
-                <ValidatorsListOverlay v-else-if="overlay === Overlay.ValidatorsList"
-                    :key="'list'"
-                    :validators="selectedValidators"
-                    :month="selectedRewardsMonth"
-                    @select-validator="onSelectValidatorFromList"
-                />
-            </transition>
+            </template>
         </template>
     </Modal>
 </template>
@@ -84,7 +90,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, watch, onBeforeUnmount } from '@vue/composition-api';
 import { useI18n } from '@/lib/useI18n';
-import { RouteName, useRouter } from '@/router';
+import { RouteName, STAKING_QUERY_SHOW_VALIDATORS, useRouter } from '@/router';
 import { useStakingStore, Validator } from '../../stores/Staking';
 import { useAddressStore } from '../../stores/Address';
 import Modal from '../modals/Modal.vue';
@@ -133,6 +139,10 @@ export default defineComponent({
         const { activeAddressInfo } = useAddressStore();
         const { activeValidator, activeStake, totalAccountStake, monthlyRewards } = useStakingStore();
 
+        const router = useRouter();
+
+        const startOnValidatorList = router.currentRoute.query.page === STAKING_QUERY_SHOW_VALIDATORS.page;
+
         // Store selected rewards month
         const selectedRewardsMonth = ref<string | undefined>(props.month);
 
@@ -142,11 +152,13 @@ export default defineComponent({
         // Determine initial page based on route
         const page = ref(props.month
             ? Page.Rewards
-            : activeValidator.value
-                ? Page.Info
-                : totalAccountStake.value
-                    ? Page.ValidatorList
-                    : Page.Welcome);
+            : startOnValidatorList
+                ? Page.ValidatorList
+                : activeValidator.value
+                    ? Page.Info
+                    : totalAccountStake.value
+                        ? Page.ValidatorList
+                        : Page.Welcome);
         const overlay = ref<Overlay | null>(null);
 
         const isStaking = computed(() => !!(activeStake.value?.activeBalance || activeStake.value?.inactiveBalance));
@@ -159,11 +171,14 @@ export default defineComponent({
             selectedRewardsMonth.value && monthlyRewards.value.has(selectedRewardsMonth.value),
         );
 
-        const router = useRouter();
-
         const adjustStake = () => { page.value = Page.Graph; };
         const switchValidator = () => { page.value = Page.ValidatorList; };
         const closeOverlay = () => { overlay.value = null; };
+
+        const onOverlaySwitchValidator = () => {
+            closeOverlay();
+            switchValidator();
+        };
 
         // Rewards navigation - goBackFromRewards is called when user clicks back arrow on rewards page
         const goBackFromRewards = () => {
@@ -262,7 +277,11 @@ export default defineComponent({
             selectedValidator.value = null;
             showValidatorDetailsBackArrow.value = false;
             overlay.value = null;
-            page.value = Page.Graph;
+            if (activeStake.value?.activeBalance || activeStake.value?.inactiveBalance) {
+                page.value = Page.Info;
+            } else {
+                page.value = Page.Graph;
+            }
         }
 
         /* Watchers */
@@ -318,6 +337,7 @@ export default defineComponent({
             // Staking methods / handlers
             adjustStake,
             switchValidator,
+            onOverlaySwitchValidator,
             onSelectValidator,
             onSelectValidatorFromList,
             onShowValidators,
@@ -397,5 +417,12 @@ export default defineComponent({
     ::v-deep .fade-enter,
     ::v-deep .fade-leave-to {
         opacity: 0;
+    }
+
+    .overlay-content-wrapper {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
     }
 </style>

--- a/src/components/staking/StakingOverview.vue
+++ b/src/components/staking/StakingOverview.vue
@@ -19,7 +19,11 @@
                             <CircleExclamationMarkIcon /> {{ $t('Payout ready')}}
                         </template>
                         <template v-else-if="stake && stake.inactiveBalance">
-                            <CircleArrowDownIcon /> {{ $t('Unstaking')}}
+                            <CircleArrowDownIcon />
+                            <span v-if="isSwitchingValidator">
+                                {{ $t('Switching to {validator}', { validator: switchTargetLabel }) }}
+                            </span>
+                            <span v-else>{{ $t('Unstaking') }}</span>
                             <span class="dot"></span>
                             <span>{{ inactiveReleaseTime }} left</span>
                         </template>
@@ -101,6 +105,8 @@ export default defineComponent({
             restakingRewards,
             monthlyRewards,
             stakingEvents,
+            isSwitchingValidator,
+            switchTargetLabel,
         } = useStakingStore();
         const router = useRouter();
         const { height } = useNetworkStore();
@@ -160,6 +166,8 @@ export default defineComponent({
             percentage,
             inactiveReleaseTime,
             hasUnstakableStake,
+            isSwitchingValidator,
+            switchTargetLabel,
             openStakingModal,
             openValidatorDetailsModal,
             totalRewardsFiatValue,

--- a/src/components/staking/StakingValidatorPage.vue
+++ b/src/components/staking/StakingValidatorPage.vue
@@ -37,6 +37,8 @@
 import { computed, defineComponent, ref } from '@vue/composition-api';
 import { PageHeader, PageBody } from '@nimiq/vue-components';
 import { useStakingStore } from '../../stores/Staking';
+import { useConfig } from '../../composables/useConfig';
+import { ENV_DEV } from '../../lib/Constants';
 
 // import ValidatorFilter from './ValidatorFilter.vue';
 import ValidatorListItem from './ValidatorListItem.vue';
@@ -53,6 +55,7 @@ export default defineComponent({
     },
     setup() {
         const { validatorsList } = useStakingStore();
+        const { config } = useConfig();
 
         const validatorList$ = ref<HTMLElement | null>(null);
 
@@ -87,11 +90,18 @@ export default defineComponent({
                 default: {
                     // Only show pools by default when search string is less than 3 characters
                     const showDefaultList = searchValue.value.length < 3;
+                    const isLocalDev = config.environment === ENV_DEV;
 
                     return validatorsList.value.slice()
                         .filter((validator) => {
                             if (showDefaultList) {
-                                // Filter to show only pools
+                                // In local dev, show all validators even if API is unavailable
+                                // Otherwise, filter to show only pools with payout types
+                                if (isLocalDev) {
+                                    return 'payoutType' in validator
+                                        ? validator.payoutType !== 'none'
+                                        : true; // Show validators without API data in local dev
+                                }
                                 return 'payoutType' in validator && validator.payoutType !== 'none';
                             }
 

--- a/src/components/staking/StakingWelcomePage.vue
+++ b/src/components/staking/StakingWelcomePage.vue
@@ -40,6 +40,8 @@
 import { computed, defineComponent, onMounted } from '@vue/composition-api';
 import { PageHeader, PageBody, HexagonIcon } from '@nimiq/vue-components';
 import { useStakingStore } from '../../stores/Staking';
+import { useConfig } from '../../composables/useConfig';
+import { ENV_DEV } from '../../lib/Constants';
 import StakingIcon from '../icons/Staking/StakingIcon.vue';
 import ValidatorIcon from './ValidatorIcon.vue';
 import { getNetworkClient, updateValidators } from '../../network';
@@ -61,11 +63,27 @@ export default defineComponent({
         // .map((validator) => validator.icon));
 
         const { validatorsList } = useStakingStore();
+        const { config } = useConfig();
 
-        const validators = computed(() => validatorsList.value.length === 0
-            ? Array.from({ length: 10 }) as undefined[]
-            : validatorsList.value.filter((validator) => 'payoutType' in validator && validator.payoutType !== 'none'),
-        );
+        const validators = computed(() => {
+            if (validatorsList.value.length === 0) {
+                return Array.from({ length: 10 }) as undefined[];
+            }
+
+            const isLocalDev = config.environment === ENV_DEV;
+
+            // In local dev, show all validators even if API is unavailable
+            const filtered = validatorsList.value.filter((validator) => {
+                if (isLocalDev) {
+                    return 'payoutType' in validator
+                        ? validator.payoutType !== 'none'
+                        : true; // Show validators without API data in local dev
+                }
+                return 'payoutType' in validator && validator.payoutType !== 'none';
+            });
+
+            return filtered;
+        });
 
         function getTopPosition(index: number) {
             return `${((Math.sin((index + 1) * (Math.PI / 10))) * 25)}px`;

--- a/src/components/staking/ValidatorDetailsModal.vue
+++ b/src/components/staking/ValidatorDetailsModal.vue
@@ -2,8 +2,8 @@
     <Modal v-bind="$attrs" v-on="$listeners" class="validator-details-modal large-modal">
         <ValidatorDetailsOverlay
             v-if="activeValidator"
-            :noButton="true"
             :validator="activeValidator"
+            @switch-validator="onSwitchValidator"
         />
     </Modal>
 </template>
@@ -13,7 +13,7 @@ import { defineComponent, watch, onMounted, ref } from '@vue/composition-api';
 import Modal from '../modals/Modal.vue';
 import { useStakingStore } from '../../stores/Staking';
 import ValidatorDetailsOverlay from './ValidatorDetailsOverlay.vue';
-import { useRouter } from '../../router';
+import { useRouter, RouteName, STAKING_QUERY_SHOW_VALIDATORS } from '../../router';
 
 export default defineComponent({
     setup() {
@@ -43,8 +43,14 @@ export default defineComponent({
             }
         });
 
+        function onSwitchValidator() {
+            router.push({ name: RouteName.Staking, query: STAKING_QUERY_SHOW_VALIDATORS })
+                .catch(() => { /* already at target */ });
+        }
+
         return {
             activeValidator,
+            onSwitchValidator,
         };
     },
     components: {

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="validator-details-overlay" :class="{ 'no-button': noButton }">
+    <div class="validator-details-overlay">
         <div class="scroll-container">
             <PageHeader :backArrow="showBackArrow" @back="$emit('back')">
                 <ValidatorIcon :validator="validator" />
@@ -48,33 +48,37 @@
                 </p>
             </PageBody>
         </div>
-        <PageFooter>
-            <div class="confirm-button" v-if="!noButton">
-                <button class="nq-button light-blue" @click="selectValidator">
-                    {{ $t('Select validator') }}
-                </button>
-            </div>
-        </PageFooter>
+        <div class="bottom-bar">
+            <button class="action-button" :disabled="isSubmitting" @click="onActionButtonClick">
+                {{ actionButtonLabel }}
+            </button>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
-import { PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
+import { defineComponent, computed, ref, onBeforeUnmount } from '@vue/composition-api';
+import { PageHeader, PageBody } from '@nimiq/vue-components';
 import { useI18n } from '@/lib/useI18n';
 import { Validator, useStakingStore } from '../../stores/Staking';
 import ValidatorIcon from './ValidatorIcon.vue';
 import ShortAddress from '../ShortAddress.vue';
 import ValidatorScoreDetails from './ValidatorScoreDetails.vue';
 import { useAddressStore } from '../../stores/Address';
-import { sendStaking } from '../../hub';
+import { sendStaking, signSwitchValidatorTransactions } from '../../hub';
+import { sendTransaction as sendTx, getNetworkClient, waitForTransactionConfirmation } from '../../network';
+import { usePolicy } from '../../composables/usePolicy';
 import { useNetworkStore } from '../../stores/Network';
 import { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
 import { StakingOperationType } from '../../lib/StakingUtils';
-import { getNetworkClient } from '../../network';
+import { startSwitchValidator } from '../../lib/AlbatrossWatchtower';
 import ValidatorReward from './tooltips/ValidatorReward.vue';
 import BlueLink from '../BlueLink.vue';
 import { reportToSentry } from '../../lib/Sentry';
+
+const validatorName = (v: Validator): string | undefined => ('name' in v ? v.name : undefined);
+const validatorLogo = (v: Validator): string | undefined =>
+    ('logo' in v && !v.hasDefaultLogo ? v.logo : undefined);
 
 export default defineComponent({
     name: 'ValidatorDetailsOverlay',
@@ -82,10 +86,6 @@ export default defineComponent({
         validator: {
             type: Object as () => Validator,
             required: true,
-        },
-        noButton: {
-            type: Boolean,
-            default: true,
         },
         showBackArrow: {
             type: Boolean,
@@ -95,15 +95,209 @@ export default defineComponent({
     setup(props, context) {
         const { $t } = useI18n();
         const { activeAddress } = useAddressStore();
-        const { activeStake, setStake, activeValidator } = useStakingStore();
+        const {
+            activeStake, setStake, activeValidator,
+            setSwitchOperation, clearSwitchOperation,
+        } = useStakingStore();
+        const { height } = useNetworkStore();
+
+        const hasExistingStake = computed(() => !!activeStake.value
+            && (activeStake.value.activeBalance > 0 || activeStake.value.inactiveBalance > 0));
+
+        const isCurrentValidator = computed(() => !!activeValidator.value
+            && activeValidator.value.address === props.validator.address);
+
+        const actionButtonLabel = computed(() => (hasExistingStake.value
+            ? $t('Switch validator')
+            : $t('Select validator')));
+
+        const isSubmitting = ref(false);
+
+        let successRedirectTimer: number | null = null;
+        function scheduleSuccessRedirect() {
+            if (successRedirectTimer !== null) clearTimeout(successRedirectTimer);
+            successRedirectTimer = window.setTimeout(() => {
+                successRedirectTimer = null;
+                // Emit `next` before clearing the status type so the parent closes the overlay
+                // before the StatusScreen disappears — otherwise the v-show-hidden overlay
+                // briefly flashes back into view.
+                context.emit('next');
+                context.emit('statusChange', { type: StakingOperationType.NONE });
+            }, SUCCESS_REDIRECT_DELAY);
+        }
+        onBeforeUnmount(() => {
+            if (successRedirectTimer !== null) clearTimeout(successRedirectTimer);
+        });
+
+        async function switchViaWatchtower() {
+            if (!activeValidator.value) {
+                reportToSentry(new Error('Attempted switchViaWatchtower without activeValidator'));
+                context.emit('statusChange', {
+                    state: State.WARNING,
+                    title: $t('Something went wrong') as string,
+                    message: $t('Validator information not available') as string,
+                });
+                return;
+            }
+
+            context.emit('statusChange', {
+                type: StakingOperationType.VALIDATOR,
+                state: State.LOADING,
+                title: $t('Switching validator') as string,
+            });
+
+            const [{ Address, TransactionBuilder }, client, policy] = await Promise.all([
+                import('@nimiq/core'),
+                getNetworkClient(),
+                usePolicy(),
+            ]);
+            const networkId = await client.getNetworkId();
+            const currentHeight = height.value;
+            const stakerAddress = Address.fromUserFriendlyAddress(activeAddress.value!);
+
+            // update-staker must be valid at the height the watchtower will broadcast it: one
+            // full epoch after the deactivation lands (matching the watchtower's
+            // `must_be_valid_at = electionBlockAfter(deactivation_block) + blocksPerEpoch`).
+            // Without a future validity height the watchtower rejects with a misleading
+            // "Transaction has invalid value" error.
+            const updateValidityStartHeight = policy.electionBlockAfter(currentHeight) + policy.blocksPerEpoch();
+
+            const deactivateTx = TransactionBuilder.newSetActiveStake(
+                stakerAddress,
+                BigInt(0),
+                BigInt(0),
+                currentHeight,
+                networkId,
+            );
+
+            const updateTx = TransactionBuilder.newUpdateStaker(
+                stakerAddress,
+                Address.fromUserFriendlyAddress(props.validator.address),
+                true, // reactivateAllStake
+                BigInt(0),
+                updateValidityStartHeight,
+                networkId,
+            );
+
+            const signedTxs = await signSwitchValidatorTransactions({
+                transaction: [deactivateTx.serialize(), updateTx.serialize()],
+                senderLabel: validatorName(activeValidator.value) || activeValidator.value.address,
+                recipientLabel: validatorName(props.validator) || props.validator.address,
+                validatorAddress: props.validator.address,
+                validatorImageUrl: validatorLogo(props.validator),
+                fromValidatorAddress: activeValidator.value.address,
+                fromValidatorImageUrl: validatorLogo(activeValidator.value),
+                amount: activeStake.value!.activeBalance + activeStake.value!.inactiveBalance,
+            });
+
+            if (!signedTxs || signedTxs.length < 2) {
+                context.emit('statusChange', { type: StakingOperationType.NONE });
+                return;
+            }
+
+            const deactivationTxHash = signedTxs[0].hash;
+
+            const deactivateResult = await sendTx(signedTxs[0]);
+            if (deactivateResult.executionResult === false) {
+                throw new Error('Deactivation transaction did not succeed');
+            }
+
+            // Watchtower won't accept the request before the deactivation is finalized.
+            try {
+                await waitForTransactionConfirmation(deactivationTxHash, { requireConfirmed: true });
+            } catch (confirmationError: any) {
+                reportToSentry(confirmationError);
+                // eslint-disable-next-line no-console
+                console.warn('Transaction confirmation timeout:', confirmationError);
+            }
+
+            // Watchtower failure is non-fatal: the deactivation is on-chain and the user can
+            // still activate the new validator manually once the cooldown ends.
+            try {
+                await startSwitchValidator({
+                    stakerAddress: activeAddress.value!,
+                    deactivationTxHash,
+                    updateStakerTx: signedTxs[1].serializedTx,
+                });
+            } catch (wtError: any) {
+                reportToSentry(wtError);
+                // eslint-disable-next-line no-console
+                console.warn('Watchtower registration failed:', wtError);
+            }
+
+            setSwitchOperation(activeAddress.value!, {
+                targetValidatorAddress: props.validator.address,
+                targetValidatorName: validatorName(props.validator),
+                startedAtBlock: currentHeight,
+                deactivationTxHash,
+            });
+
+            context.emit('statusChange', {
+                state: State.SUCCESS,
+                title: $t('Validator switch initiated') as string,
+            });
+
+            scheduleSuccessRedirect();
+        }
+
+        async function switchImmediate() {
+            context.emit('statusChange', {
+                type: StakingOperationType.VALIDATOR,
+                state: State.LOADING,
+                title: $t('Changing validator') as string,
+            });
+
+            const [{ Address, TransactionBuilder }, client] = await Promise.all([
+                import('@nimiq/core'),
+                getNetworkClient(),
+            ]);
+            const networkId = await client.getNetworkId();
+
+            const transaction = TransactionBuilder.newUpdateStaker(
+                Address.fromUserFriendlyAddress(activeAddress.value!),
+                Address.fromUserFriendlyAddress(props.validator.address),
+                true, // reactivateAllStake
+                BigInt(0),
+                height.value,
+                networkId,
+            );
+
+            const txs = await sendStaking({
+                transaction: transaction.serialize(),
+                senderLabel: validatorName(activeValidator.value!) || activeValidator.value!.address,
+                recipientLabel: validatorName(props.validator) || props.validator.address,
+                validatorAddress: props.validator.address,
+                validatorImageUrl: validatorLogo(props.validator),
+                fromValidatorAddress: activeValidator.value!.address,
+                fromValidatorImageUrl: validatorLogo(activeValidator.value!),
+                amount: activeStake.value!.inactiveBalance,
+            });
+
+            if (!txs) {
+                context.emit('statusChange', { type: StakingOperationType.NONE });
+                return;
+            }
+
+            if (txs.some((tx) => tx.executionResult === false)) {
+                throw new Error('The transaction did not succeed');
+            }
+
+            clearSwitchOperation(activeAddress.value!);
+
+            context.emit('statusChange', {
+                state: State.SUCCESS,
+                title: $t(
+                    'Successfully changed validator to {validator}',
+                    { validator: validatorName(props.validator) || props.validator.address },
+                ),
+            });
+
+            scheduleSuccessRedirect();
+        }
 
         async function selectValidator() {
-            const validatorLabelOrAddress = 'name' in props.validator
-                ? props.validator.name
-                : props.validator.address;
-
             try {
-                if (!activeStake.value || (!activeStake.value.activeBalance && !activeStake.value.inactiveBalance)) {
+                if (!hasExistingStake.value) {
                     setStake({
                         address: activeAddress.value!,
                         activeBalance: 0,
@@ -111,88 +305,61 @@ export default defineComponent({
                         validator: props.validator.address,
                         retiredBalance: 0,
                     });
-
                     context.emit('next');
-                } else {
-                    context.emit('statusChange', {
-                        type: StakingOperationType.VALIDATOR,
-                        state: State.LOADING,
-                        title: $t('Changing validator') as string,
-                    });
-
-                    const { Address, TransactionBuilder } = await import('@nimiq/core');
-                    const client = await getNetworkClient();
-
-                    const transaction = TransactionBuilder.newUpdateStaker(
-                        Address.fromUserFriendlyAddress(activeAddress.value!),
-                        Address.fromUserFriendlyAddress(props.validator.address),
-                        true,
-                        BigInt(0),
-                        useNetworkStore().state.height,
-                        await client.getNetworkId(),
-                    );
-
-                    const txs = await sendStaking({
-                        transaction: transaction.serialize(),
-                        senderLabel: 'name' in activeValidator.value! ? activeValidator.value.name : 'Validator',
-                        recipientLabel: 'name' in props.validator ? props.validator.name : 'Validator',
-                        // @ts-expect-error Not typed yet in Hub
-                        validatorAddress: props.validator.address,
-                        validatorImageUrl: 'logo' in props.validator && !props.validator.hasDefaultLogo
-                            ? props.validator.logo
-                            : undefined,
-                        fromValidatorAddress: activeValidator.value!.address,
-                        fromValidatorImageUrl: 'logo' in activeValidator.value! && !activeValidator.value.hasDefaultLogo
-                            ? activeValidator.value.logo
-                            : undefined,
-                        amount: activeStake.value.inactiveBalance,
-                    }).catch((error) => {
-                        throw new Error(error.data);
-                    });
-
-                    if (!txs) {
-                        context.emit('statusChange', {
-                            type: StakingOperationType.NONE,
-                        });
-                        return;
-                    }
-
-                    if (txs.some((tx) => tx.executionResult === false)) {
-                        throw new Error('The transaction did not succeed');
-                    }
-
-                    context.emit('statusChange', {
-                        state: State.SUCCESS,
-                        title: $t(
-                            'Successfully changed validator to {validator}',
-                            { validator: validatorLabelOrAddress },
-                        ),
-                    });
-
-                    window.setTimeout(() => {
-                        context.emit('statusChange', { type: StakingOperationType.NONE });
-                        context.emit('next');
-                    }, SUCCESS_REDIRECT_DELAY);
+                    return;
                 }
+
+                if (activeStake.value!.activeBalance > 0) {
+                    await switchViaWatchtower();
+                    return;
+                }
+
+                if (activeStake.value!.inactiveBalance > 0
+                    && activeStake.value!.inactiveRelease
+                    && activeStake.value!.inactiveRelease <= height.value) {
+                    await switchImmediate();
+                    return;
+                }
+
+                // Stake is inactive but the cooldown has not yet ended.
+                context.emit('statusChange', {
+                    state: State.WARNING,
+                    title: $t('Cannot switch yet') as string,
+                    message: $t('Please wait for the cooldown period to end.') as string,
+                });
             } catch (error: any) {
                 reportToSentry(error);
-
                 context.emit('statusChange', {
                     state: State.WARNING,
                     title: $t('Something went wrong') as string,
-                    message: `${error.message} - ${error.data}`,
+                    message: `${error.message}${error.data ? ` - ${error.data}` : ''}`,
                 });
             }
         }
 
+        async function onActionButtonClick() {
+            if (isSubmitting.value) return;
+            if (isCurrentValidator.value) {
+                context.emit('switch-validator');
+                return;
+            }
+            isSubmitting.value = true;
+            try {
+                await selectValidator();
+            } finally {
+                isSubmitting.value = false;
+            }
+        }
+
         return {
-            selectValidator,
+            onActionButtonClick,
+            actionButtonLabel,
+            isSubmitting,
         };
     },
     components: {
         PageHeader,
         PageBody,
-        PageFooter,
         ValidatorIcon,
         ShortAddress,
         ValidatorScoreDetails,
@@ -206,15 +373,15 @@ export default defineComponent({
 @import '../../scss/mixins.scss';
 
 .validator-details-overlay {
-    max-height: calc(100% - 12rem);
-
-    &.no-button {
-        max-height: 100%;
-    }
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
 
 .scroll-container {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
 
     @extend %custom-scrollbar;
@@ -307,24 +474,55 @@ hr {
     color: var(--text-50);
 }
 
-.confirm-button {
-    position: fixed;
-    bottom: 0rem;
-    left: 50%;
-    transform: translateX(-50%);
+.bottom-bar {
+    flex-shrink: 0;
 
-    --border-radius: 1.25rem;
-    border-bottom-right-radius: var(--border-radius);
-    border-bottom-left-radius: var(--border-radius);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-    width: 100%;
+    height: 9rem;
+    padding: 2.75rem 0;
 
     background-color: white;
-    box-shadow: 0 -40px 19px -15px white; // TODO: find a better solution (scroll mask?)
+    border-bottom-left-radius: 1.25rem;
+    border-bottom-right-radius: 1.25rem;
+    box-shadow:
+        0 0 4.125px rgba(31, 35, 72, 0.03),
+        0 0 12.519px rgba(31, 35, 72, 0.05),
+        0 0 32px rgba(31, 35, 72, 0.06),
+        0 0 80px rgba(31, 35, 72, 0.07);
+}
 
-    button {
-        margin: 0 auto;
-        width: 80%;
+.action-button {
+    border: none;
+    cursor: pointer;
+
+    padding: 0.625rem 1.5rem;
+    border-radius: 10rem;
+
+    background-color: rgba(31, 35, 72, 0.06);
+    color: var(--nimiq-blue);
+
+    font-family: 'Mulish', sans-serif;
+    font-size: 1.75rem;
+    font-weight: bold;
+    line-height: 1.22;
+
+    transition: background-color 200ms var(--nimiq-ease), opacity 200ms var(--nimiq-ease);
+
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
+        background-color: rgba(31, 35, 72, 0.1);
+    }
+
+    &:active:not(:disabled) {
+        background-color: rgba(31, 35, 72, 0.14);
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
     }
 }
 </style>

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -65,20 +65,17 @@ import ValidatorIcon from './ValidatorIcon.vue';
 import ShortAddress from '../ShortAddress.vue';
 import ValidatorScoreDetails from './ValidatorScoreDetails.vue';
 import { useAddressStore } from '../../stores/Address';
-import { sendStaking, signSwitchValidatorTransactions } from '../../hub';
+import { signSwitchValidatorTransactions } from '../../hub';
 import { sendTransaction as sendTx, getNetworkClient, waitForTransactionConfirmation } from '../../network';
 import { usePolicy } from '../../composables/usePolicy';
 import { useNetworkStore } from '../../stores/Network';
 import { State, SUCCESS_REDIRECT_DELAY } from '../StatusScreen.vue';
-import { StakingOperationType } from '../../lib/StakingUtils';
+import { StakingOperationType, toValidatorRef, validatorLabel } from '../../lib/StakingUtils';
 import { startSwitchValidator } from '../../lib/AlbatrossWatchtower';
+import { sendImmediateValidatorSwitch } from '../../lib/SwitchValidator';
 import ValidatorReward from './tooltips/ValidatorReward.vue';
 import BlueLink from '../BlueLink.vue';
 import { reportToSentry } from '../../lib/Sentry';
-
-const validatorName = (v: Validator): string | undefined => ('name' in v ? v.name : undefined);
-const validatorLogo = (v: Validator): string | undefined =>
-    ('logo' in v && !v.hasDefaultLogo ? v.logo : undefined);
 
 export default defineComponent({
     name: 'ValidatorDetailsOverlay',
@@ -179,14 +176,17 @@ export default defineComponent({
                 networkId,
             );
 
+            const target = toValidatorRef(props.validator);
+            const from = toValidatorRef(activeValidator.value);
+
             const signedTxs = await signSwitchValidatorTransactions({
                 transaction: [deactivateTx.serialize(), updateTx.serialize()],
-                senderLabel: validatorName(activeValidator.value) || activeValidator.value.address,
-                recipientLabel: validatorName(props.validator) || props.validator.address,
-                validatorAddress: props.validator.address,
-                validatorImageUrl: validatorLogo(props.validator),
-                fromValidatorAddress: activeValidator.value.address,
-                fromValidatorImageUrl: validatorLogo(activeValidator.value),
+                senderLabel: validatorLabel(from),
+                recipientLabel: validatorLabel(target),
+                validatorAddress: target.address,
+                validatorImageUrl: target.logo,
+                fromValidatorAddress: from.address,
+                fromValidatorImageUrl: from.logo,
                 amount: activeStake.value!.activeBalance + activeStake.value!.inactiveBalance,
             });
 
@@ -226,8 +226,8 @@ export default defineComponent({
             }
 
             setSwitchOperation(activeAddress.value!, {
-                targetValidatorAddress: props.validator.address,
-                targetValidatorName: validatorName(props.validator),
+                targetValidatorAddress: target.address,
+                targetValidatorName: target.name,
                 startedAtBlock: currentHeight,
                 deactivationTxHash,
             });
@@ -247,30 +247,14 @@ export default defineComponent({
                 title: $t('Changing validator') as string,
             });
 
-            const [{ Address, TransactionBuilder }, client] = await Promise.all([
-                import('@nimiq/core'),
-                getNetworkClient(),
-            ]);
-            const networkId = await client.getNetworkId();
+            const target = toValidatorRef(props.validator);
 
-            const transaction = TransactionBuilder.newUpdateStaker(
-                Address.fromUserFriendlyAddress(activeAddress.value!),
-                Address.fromUserFriendlyAddress(props.validator.address),
-                true, // reactivateAllStake
-                BigInt(0),
-                height.value,
-                networkId,
-            );
-
-            const txs = await sendStaking({
-                transaction: transaction.serialize(),
-                senderLabel: validatorName(activeValidator.value!) || activeValidator.value!.address,
-                recipientLabel: validatorName(props.validator) || props.validator.address,
-                validatorAddress: props.validator.address,
-                validatorImageUrl: validatorLogo(props.validator),
-                fromValidatorAddress: activeValidator.value!.address,
-                fromValidatorImageUrl: validatorLogo(activeValidator.value!),
+            const txs = await sendImmediateValidatorSwitch({
+                stakerAddress: activeAddress.value!,
+                height: height.value,
                 amount: activeStake.value!.inactiveBalance,
+                target,
+                from: toValidatorRef(activeValidator.value!),
             });
 
             if (!txs) {
@@ -288,7 +272,7 @@ export default defineComponent({
                 state: State.SUCCESS,
                 title: $t(
                     'Successfully changed validator to {validator}',
-                    { validator: validatorName(props.validator) || props.validator.address },
+                    { validator: validatorLabel(target) },
                 ),
             });
 

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -193,7 +193,6 @@ export default defineComponent({
                 validatorImageUrl: target.logo,
                 fromValidatorAddress: from.address,
                 fromValidatorImageUrl: from.logo,
-                amount: activeStake.value!.activeBalance + activeStake.value!.inactiveBalance,
             });
 
             if (!signedTxs) {

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -126,16 +126,21 @@ export default defineComponent({
             if (successRedirectTimer !== null) clearTimeout(successRedirectTimer);
         });
 
+        function ensureActiveValidator(opName: string): Validator | null {
+            const validator = activeValidator.value;
+            if (validator) return validator;
+            reportToSentry(new Error(`Attempted ${opName} without activeValidator`));
+            context.emit('statusChange', {
+                state: State.WARNING,
+                title: $t('Something went wrong') as string,
+                message: $t('Validator information not available') as string,
+            });
+            return null;
+        }
+
         async function switchViaWatchtower() {
-            if (!activeValidator.value) {
-                reportToSentry(new Error('Attempted switchViaWatchtower without activeValidator'));
-                context.emit('statusChange', {
-                    state: State.WARNING,
-                    title: $t('Something went wrong') as string,
-                    message: $t('Validator information not available') as string,
-                });
-                return;
-            }
+            const fromValidator = ensureActiveValidator('switchViaWatchtower');
+            if (!fromValidator) return;
 
             context.emit('statusChange', {
                 type: StakingOperationType.VALIDATOR,
@@ -177,7 +182,7 @@ export default defineComponent({
             );
 
             const target = toValidatorRef(props.validator);
-            const from = toValidatorRef(activeValidator.value);
+            const from = toValidatorRef(fromValidator);
 
             const signedTxs = await signSwitchValidatorTransactions({
                 sender: activeAddress.value!,
@@ -242,6 +247,9 @@ export default defineComponent({
         }
 
         async function switchImmediate() {
+            const fromValidator = ensureActiveValidator('switchImmediate');
+            if (!fromValidator) return;
+
             context.emit('statusChange', {
                 type: StakingOperationType.VALIDATOR,
                 state: State.LOADING,
@@ -255,7 +263,7 @@ export default defineComponent({
                 height: height.value,
                 amount: activeStake.value!.inactiveBalance,
                 target,
-                from: toValidatorRef(activeValidator.value!),
+                from: toValidatorRef(fromValidator),
             });
 
             if (!txs) {

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -180,7 +180,8 @@ export default defineComponent({
             const from = toValidatorRef(activeValidator.value);
 
             const signedTxs = await signSwitchValidatorTransactions({
-                transaction: [deactivateTx.serialize(), updateTx.serialize()],
+                sender: activeAddress.value!,
+                transactions: [deactivateTx.serialize(), updateTx.serialize()],
                 senderLabel: validatorLabel(from),
                 recipientLabel: validatorLabel(target),
                 validatorAddress: target.address,
@@ -190,7 +191,7 @@ export default defineComponent({
                 amount: activeStake.value!.activeBalance + activeStake.value!.inactiveBalance,
             });
 
-            if (!signedTxs || signedTxs.length < 2) {
+            if (!signedTxs) {
                 context.emit('statusChange', { type: StakingOperationType.NONE });
                 return;
             }

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -189,9 +189,6 @@ export default defineComponent({
                 transactions: [deactivateTx.serialize(), updateTx.serialize()],
                 senderLabel: validatorLabel(from),
                 recipientLabel: validatorLabel(target),
-                // The validator labels take sender/recipient, so the staking address is named here.
-                stakerLabel: activeAddressInfo.value?.label,
-                validatorAddress: target.address,
                 validatorImageUrl: target.logo,
                 fromValidatorAddress: from.address,
                 fromValidatorImageUrl: from.logo,

--- a/src/components/staking/ValidatorDetailsOverlay.vue
+++ b/src/components/staking/ValidatorDetailsOverlay.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     },
     setup(props, context) {
         const { $t } = useI18n();
-        const { activeAddress } = useAddressStore();
+        const { activeAddress, activeAddressInfo } = useAddressStore();
         const {
             activeStake, setStake, activeValidator,
             setSwitchOperation, clearSwitchOperation,
@@ -189,6 +189,8 @@ export default defineComponent({
                 transactions: [deactivateTx.serialize(), updateTx.serialize()],
                 senderLabel: validatorLabel(from),
                 recipientLabel: validatorLabel(target),
+                // The validator labels take sender/recipient, so the staking address is named here.
+                stakerLabel: activeAddressInfo.value?.label,
                 validatorAddress: target.address,
                 validatorImageUrl: target.logo,
                 fromValidatorAddress: from.address,

--- a/src/composables/usePolicy.ts
+++ b/src/composables/usePolicy.ts
@@ -1,0 +1,84 @@
+/*
+ * Lightweight Policy composable to mirror the subset of @nimiq/core Policy we need in the wallet.
+ *
+ * Goals:
+ * - Provide blocksPerBatch, batchesPerEpoch directly from @nimiq/core Policy (fixed chain constants),
+ * - Provide blocksPerEpoch derived from those constants,
+ * - Provide genesisBlockNumber from runtime config,
+ * - Provide electionBlockAfter(height) aligned with chain policy using the configured genesis.
+ *
+ * Behavior:
+ * - We always load BLOCKS_PER_BATCH and BATCHES_PER_EPOCH from @nimiq/core and wait until available
+ *   (WASM may need a short warm-up). There are no wallet-side fallbacks.
+ * - The genesis block number is read from the wallet config so we can target the correct network
+ *   (e.g., testnet vs mainnet) when aligning epoch math with other components (like the watchtower).
+ */
+
+import { useConfig } from '@/composables/useConfig';
+
+// Core-provided constants (initialized once when core is ready)
+let cachedBlocksPerBatch = 0;
+let cachedBatchesPerEpoch = 0;
+let coreLoaded = false;
+let loadingPromise: Promise<void> | null = null;
+
+async function loadCorePolicyConstants(): Promise<void> {
+    if (coreLoaded) return Promise.resolve();
+    if (loadingPromise) return loadingPromise;
+    loadingPromise = (async () => {
+        const { Policy } = await import('@nimiq/core');
+        await new Promise<void>((resolve, reject) => {
+            let attempts = 0;
+            const timer = window.setInterval(() => {
+                const bpb = (Policy as any).BLOCKS_PER_BATCH;
+                const bpe = (Policy as any).BATCHES_PER_EPOCH;
+                if (typeof bpb === 'number' && bpb > 0 && typeof bpe === 'number' && bpe > 0) {
+                    cachedBlocksPerBatch = bpb;
+                    cachedBatchesPerEpoch = bpe;
+                    window.clearInterval(timer);
+                    resolve();
+                } else if (++attempts >= 50) {
+                    window.clearInterval(timer);
+                    reject(new Error('Failed to load Policy constants from @nimiq/core'));
+                }
+            }, 50);
+        });
+        coreLoaded = true;
+    })();
+    return loadingPromise;
+}
+
+function computeBlocksPerEpoch(): number {
+    return cachedBlocksPerBatch * cachedBatchesPerEpoch;
+}
+
+function electionBlockAfter(height: number, genesis: number, blocksPerEpoch: number): number {
+    if (height < genesis) return genesis;
+    const relative = height - genesis;
+    const k = Math.floor(relative / blocksPerEpoch) + 1;
+    return genesis + k * blocksPerEpoch;
+}
+
+export async function usePolicy() {
+    // Ensure core constants are loaded before exposing the API
+    await loadCorePolicyConstants();
+
+    const { config } = useConfig();
+    const genesisBlockNumber = config.staking?.genesis?.height || 0;
+
+    const blocksPerBatch = (): number => cachedBlocksPerBatch;
+    const batchesPerEpoch = (): number => cachedBatchesPerEpoch;
+    const blocksPerEpoch = (): number => computeBlocksPerEpoch();
+    const electionBlockAfterBound = (height: number): number =>
+        electionBlockAfter(height, genesisBlockNumber, computeBlocksPerEpoch());
+
+    return {
+        // Constants/getters
+        blocksPerBatch,
+        batchesPerEpoch,
+        blocksPerEpoch,
+        genesisBlockNumber,
+        // Functions
+        electionBlockAfter: electionBlockAfterBound,
+    };
+}

--- a/src/composables/usePolicy.ts
+++ b/src/composables/usePolicy.ts
@@ -52,11 +52,11 @@ function computeBlocksPerEpoch(): number {
     return cachedBlocksPerBatch * cachedBatchesPerEpoch;
 }
 
-function electionBlockAfter(height: number, genesis: number, blocksPerEpoch: number): number {
+function nextBoundaryAfter(height: number, genesis: number, period: number): number {
     if (height < genesis) return genesis;
     const relative = height - genesis;
-    const k = Math.floor(relative / blocksPerEpoch) + 1;
-    return genesis + k * blocksPerEpoch;
+    const k = Math.floor(relative / period) + 1;
+    return genesis + k * period;
 }
 
 export async function usePolicy() {
@@ -70,7 +70,9 @@ export async function usePolicy() {
     const batchesPerEpoch = (): number => cachedBatchesPerEpoch;
     const blocksPerEpoch = (): number => computeBlocksPerEpoch();
     const electionBlockAfterBound = (height: number): number =>
-        electionBlockAfter(height, genesisBlockNumber, computeBlocksPerEpoch());
+        nextBoundaryAfter(height, genesisBlockNumber, computeBlocksPerEpoch());
+    const macroBlockAfterBound = (height: number): number =>
+        nextBoundaryAfter(height, genesisBlockNumber, cachedBlocksPerBatch);
 
     return {
         // Constants/getters
@@ -80,5 +82,6 @@ export async function usePolicy() {
         genesisBlockNumber,
         // Functions
         electionBlockAfter: electionBlockAfterBound,
+        macroBlockAfter: macroBlockAfterBound,
     };
 }

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -38,7 +38,7 @@ export default {
     },
 
     albatrossWatchtower: {
-        endpoint: 'http://localhost:8082',
+        endpoint: 'https://watchtower.pos.nimiq-testnet.com',
     },
 
     polygon: {

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -37,6 +37,10 @@ export default {
         },
     },
 
+    albatrossWatchtower: {
+        endpoint: 'http://localhost:8082',
+    },
+
     polygon: {
         enabled: false,
         networkId: 80002,

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -47,6 +47,10 @@ export default {
         },
     },
 
+    albatrossWatchtower: {
+        endpoint: 'https://watchtower.pos.nimiq.com',
+    },
+
     polygon: {
         enabled: true,
         networkId: 137,

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -35,6 +35,10 @@ export default {
         },
     },
 
+    albatrossWatchtower: {
+        endpoint: 'https://watchtower.pos.nimiq-testnet.com',
+    },
+
     polygon: {
         enabled: false,
         networkId: 80002,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -598,7 +598,7 @@ export async function signUnstakingTransactions(request: {
         transactions: request.transactions,
         validatorAddress: request.validatorAddress,
         validatorImageUrl: request.validatorImageUrl,
-    } as any, getBehavior()).catch(onError);
+    }, getBehavior()).catch(onError);
 
     if (!signedTransactions) return null;
 
@@ -640,7 +640,7 @@ export async function signSwitchValidatorTransactions(request: {
         validatorImageUrl: request.validatorImageUrl,
         fromValidatorAddress: request.fromValidatorAddress,
         fromValidatorImageUrl: request.fromValidatorImageUrl,
-    } as any, getBehavior()).catch(onError);
+    }, getBehavior()).catch(onError);
 
     if (!signedTransactions) return null;
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -582,7 +582,7 @@ export async function signUnstakingTransactions(request: {
     senderLabel?: string,
     recipientLabel?: string,
     transactions: Uint8Array[], // Array of 3 serialized transactions: [deactivation, retire, unstake]
-    validatorAddress?: string,
+    validatorAddress: string,
     validatorImageUrl?: string,
 }): Promise<SignedTransaction[] | null> {
     if (request.transactions.length !== 3) {
@@ -591,6 +591,7 @@ export async function signUnstakingTransactions(request: {
 
     const signedTransactions = await hubApi.signTransaction({
         appName: APP_NAME,
+        layout: 'unstaking',
         sender: request.sender,
         senderLabel: request.senderLabel,
         recipientLabel: request.recipientLabel,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -649,6 +649,24 @@ export async function signUnstakingTransactions(request: {
     return signedTransactions;
 }
 
+/**
+ * Sign switch-validator transactions (set-active-stake + update-staker).
+ * Returns signed transactions without broadcasting - the caller handles
+ * broadcasting the deactivation and sending the update to the watchtower.
+ */
+export async function signSwitchValidatorTransactions(request: {
+    transaction: Uint8Array | Uint8Array[],
+    senderLabel?: string,
+    recipientLabel?: string,
+    validatorAddress?: string,
+    validatorImageUrl?: string,
+    fromValidatorAddress?: string,
+    fromValidatorImageUrl?: string,
+    amount?: number,
+}): Promise<SignedTransaction[] | null> {
+    return signStakingRaw(request) as Promise<SignedTransaction[] | null>;
+}
+
 export async function createCashlink(senderAddress: string, senderBalance?: number) {
     const cashlink = await hubApi.createCashlink({
         appName: APP_NAME,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -628,7 +628,6 @@ export async function signSwitchValidatorTransactions(request: {
     validatorImageUrl?: string,
     fromValidatorAddress: string,
     fromValidatorImageUrl?: string,
-    amount: number,
 }): Promise<SignedTransaction[] | null> {
     const signedTransactions = await hubApi.signTransaction({
         appName: APP_NAME,
@@ -641,7 +640,6 @@ export async function signSwitchValidatorTransactions(request: {
         validatorImageUrl: request.validatorImageUrl,
         fromValidatorAddress: request.fromValidatorAddress,
         fromValidatorImageUrl: request.fromValidatorImageUrl,
-        amount: request.amount,
     } as any, getBehavior()).catch(onError);
 
     if (!signedTransactions) return null;

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -571,41 +571,6 @@ export async function sendStaking(request: Omit<SignStakingRequest, 'appName'>) 
     return txDetails;
 }
 
-export async function signStakingRaw(request: Omit<SignStakingRequest, 'appName'>)
-    : Promise<SignedTransaction | SignedTransaction[] | null> {
-    try {
-        const requestShape = Array.isArray((request as any).transaction) ? 'array' : 'single';
-        const txLen = Array.isArray((request as any).transaction)
-            ? (request as any).transaction.length
-            : ((request as any).transaction || '').length;
-        // eslint-disable-next-line no-console
-        console.debug('signStakingRaw: request', { requestShape, txLen });
-
-        const signedTransactions = await hubApi.signStaking({
-            appName: APP_NAME,
-            ...request,
-        });
-
-        if (!signedTransactions) {
-            // eslint-disable-next-line no-console
-            console.debug('signStakingRaw: no result (null)');
-            return null;
-        }
-
-        const resultShape = Array.isArray(signedTransactions) ? 'array' : 'single';
-        const resultCount = Array.isArray(signedTransactions) ? signedTransactions.length : 1;
-        // eslint-disable-next-line no-console
-        console.debug('signStakingRaw: result', { resultShape, resultCount });
-        return signedTransactions as SignedTransaction | SignedTransaction[];
-    } catch (error: any) {
-        // eslint-disable-next-line no-console
-        console.error('signStakingRaw: error', { message: error?.message });
-        const handled = onError(error);
-        if (handled === null) return null;
-        throw error;
-    }
-}
-
 /**
  * Sign multiple staking transactions for unstaking flow.
  * This function signs 3 transactions: deactivation, retire, and unstake.
@@ -650,21 +615,45 @@ export async function signUnstakingTransactions(request: {
 }
 
 /**
- * Sign switch-validator transactions (set-active-stake + update-staker).
- * Returns signed transactions without broadcasting - the caller handles
- * broadcasting the deactivation and sending the update to the watchtower.
+ * Returns signed transactions without broadcasting — the caller broadcasts the deactivation
+ * and forwards the update-staker to the watchtower.
  */
 export async function signSwitchValidatorTransactions(request: {
-    transaction: Uint8Array | Uint8Array[],
+    sender: string,
+    transactions: [Uint8Array, Uint8Array], // [set-active-stake, update-staker]
     senderLabel?: string,
     recipientLabel?: string,
-    validatorAddress?: string,
+    validatorAddress: string,
     validatorImageUrl?: string,
-    fromValidatorAddress?: string,
+    fromValidatorAddress: string,
     fromValidatorImageUrl?: string,
-    amount?: number,
+    amount: number,
 }): Promise<SignedTransaction[] | null> {
-    return signStakingRaw(request) as Promise<SignedTransaction[] | null>;
+    const signedTransactions = await hubApi.signTransaction({
+        appName: APP_NAME,
+        layout: 'switch-validator',
+        sender: request.sender,
+        senderLabel: request.senderLabel,
+        recipientLabel: request.recipientLabel,
+        transactions: request.transactions,
+        validatorAddress: request.validatorAddress,
+        validatorImageUrl: request.validatorImageUrl,
+        fromValidatorAddress: request.fromValidatorAddress,
+        fromValidatorImageUrl: request.fromValidatorImageUrl,
+        amount: request.amount,
+    } as any, getBehavior()).catch(onError);
+
+    if (!signedTransactions) return null;
+
+    if (!Array.isArray(signedTransactions)) {
+        throw new Error('Hub did not return an array of signed transactions for switch-validator flow');
+    }
+
+    if (signedTransactions.length !== 2) {
+        throw new Error(`Expected 2 signed transactions from Hub, got ${signedTransactions.length}`);
+    }
+
+    return signedTransactions;
 }
 
 export async function createCashlink(senderAddress: string, senderBalance?: number) {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -180,7 +180,14 @@ hubApi.on(HubApi.RequestType.MIGRATE, () => {
 
 hubApi.on(HubApi.RequestType.SIGN_TRANSACTION, async (tx) => {
     // TODO: Show status notification
-    await sendTx(tx);
+    // Handle both single transaction and multi-transaction responses
+    if (Array.isArray(tx)) {
+        for (const signedTx of tx) {
+            await sendTx(signedTx); // eslint-disable-line no-await-in-loop
+        }
+    } else {
+        await sendTx(tx);
+    }
 });
 
 hubApi.on(HubApi.RequestType.SIGN_BTC_TRANSACTION, async (tx) => {
@@ -510,13 +517,34 @@ export async function backup(accountId: string, exportMethod: 'fileOnly' | 'word
     return true;
 }
 
-export async function sendTransaction(request: Omit<SignTransactionRequest, 'appName'>, abortSignal?: AbortSignal) {
+// Type for sendTransaction that accepts both single and multi-transaction formats
+type SendTransactionParams = Omit<SignTransactionRequest, 'appName'> & {
+    // Allow any additional properties for compatibility
+    [key: string]: any,
+};
+
+export async function sendTransaction(
+    request: SendTransactionParams,
+    abortSignal?: AbortSignal,
+): Promise<PlainTransactionDetails | null> {
     const signedTransaction = await hubApi.signTransaction({
         appName: APP_NAME,
         ...request,
-    }, getBehavior({ abortSignal })).catch(onError);
+    } as SignTransactionRequest, getBehavior({ abortSignal })).catch(onError);
     if (!signedTransaction) return null;
 
+    // Handle both single transaction and multi-transaction responses
+    if (Array.isArray(signedTransaction)) {
+        // Multi-transaction: send all sequentially and return the last result
+        let lastResult: PlainTransactionDetails | undefined;
+        for (const tx of signedTransaction) {
+            lastResult = await sendTx(tx); // eslint-disable-line no-await-in-loop
+            if (lastResult.executionResult === false) break;
+        }
+        return lastResult || null;
+    }
+
+    // Single transaction
     return sendTx(signedTransaction);
 }
 
@@ -541,6 +569,84 @@ export async function sendStaking(request: Omit<SignStakingRequest, 'appName'>) 
     }
 
     return txDetails;
+}
+
+export async function signStakingRaw(request: Omit<SignStakingRequest, 'appName'>)
+    : Promise<SignedTransaction | SignedTransaction[] | null> {
+    try {
+        const requestShape = Array.isArray((request as any).transaction) ? 'array' : 'single';
+        const txLen = Array.isArray((request as any).transaction)
+            ? (request as any).transaction.length
+            : ((request as any).transaction || '').length;
+        // eslint-disable-next-line no-console
+        console.debug('signStakingRaw: request', { requestShape, txLen });
+
+        const signedTransactions = await hubApi.signStaking({
+            appName: APP_NAME,
+            ...request,
+        });
+
+        if (!signedTransactions) {
+            // eslint-disable-next-line no-console
+            console.debug('signStakingRaw: no result (null)');
+            return null;
+        }
+
+        const resultShape = Array.isArray(signedTransactions) ? 'array' : 'single';
+        const resultCount = Array.isArray(signedTransactions) ? signedTransactions.length : 1;
+        // eslint-disable-next-line no-console
+        console.debug('signStakingRaw: result', { resultShape, resultCount });
+        return signedTransactions as SignedTransaction | SignedTransaction[];
+    } catch (error: any) {
+        // eslint-disable-next-line no-console
+        console.error('signStakingRaw: error', { message: error?.message });
+        const handled = onError(error);
+        if (handled === null) return null;
+        throw error;
+    }
+}
+
+/**
+ * Sign multiple staking transactions for unstaking flow.
+ * This function signs 3 transactions: deactivation, retire, and unstake.
+ * The deactivation transaction is broadcast immediately, while retire and unstake
+ * are sent to the watchtower for later broadcasting.
+ */
+export async function signUnstakingTransactions(request: {
+    sender: string,
+    senderLabel?: string,
+    recipientLabel?: string,
+    transactions: Uint8Array[], // Array of 3 serialized transactions: [deactivation, retire, unstake]
+    validatorAddress?: string,
+    validatorImageUrl?: string,
+}): Promise<SignedTransaction[] | null> {
+    if (request.transactions.length !== 3) {
+        throw new Error('Expected exactly 3 transactions for unstaking flow: deactivation, retire, unstake');
+    }
+
+    const signedTransactions = await hubApi.signTransaction({
+        appName: APP_NAME,
+        sender: request.sender,
+        senderLabel: request.senderLabel,
+        recipientLabel: request.recipientLabel,
+        transactions: request.transactions,
+        validatorAddress: request.validatorAddress,
+        validatorImageUrl: request.validatorImageUrl,
+    } as any, getBehavior()).catch(onError);
+
+    if (!signedTransactions) return null;
+
+    if (!Array.isArray(signedTransactions)) {
+        // eslint-disable-next-line no-console
+        console.error('Hub returned non-array for multi-transaction request:', signedTransactions);
+        throw new Error('Hub did not return an array of signed transactions for unstaking flow');
+    }
+
+    if (signedTransactions.length !== 3) {
+        throw new Error(`Expected 3 signed transactions from Hub, got ${signedTransactions.length}`);
+    }
+
+    return signedTransactions;
 }
 
 export async function createCashlink(senderAddress: string, senderBalance?: number) {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -624,6 +624,7 @@ export async function signSwitchValidatorTransactions(request: {
     transactions: [Uint8Array, Uint8Array], // [set-active-stake, update-staker]
     senderLabel?: string,
     recipientLabel?: string,
+    stakerLabel?: string,
     validatorAddress: string,
     validatorImageUrl?: string,
     fromValidatorAddress: string,
@@ -635,6 +636,7 @@ export async function signSwitchValidatorTransactions(request: {
         sender: request.sender,
         senderLabel: request.senderLabel,
         recipientLabel: request.recipientLabel,
+        stakerLabel: request.stakerLabel,
         transactions: request.transactions,
         validatorAddress: request.validatorAddress,
         validatorImageUrl: request.validatorImageUrl,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -580,7 +580,6 @@ export async function sendStaking(request: Omit<SignStakingRequest, 'appName'>) 
 export async function signUnstakingTransactions(request: {
     sender: string,
     senderLabel?: string,
-    recipientLabel?: string,
     transactions: Uint8Array[], // Array of 3 serialized transactions: [deactivation, retire, unstake]
     validatorAddress: string,
     validatorImageUrl?: string,
@@ -594,7 +593,6 @@ export async function signUnstakingTransactions(request: {
         layout: 'unstaking',
         sender: request.sender,
         senderLabel: request.senderLabel,
-        recipientLabel: request.recipientLabel,
         transactions: request.transactions,
         validatorAddress: request.validatorAddress,
         validatorImageUrl: request.validatorImageUrl,
@@ -624,8 +622,6 @@ export async function signSwitchValidatorTransactions(request: {
     transactions: [Uint8Array, Uint8Array], // [set-active-stake, update-staker]
     senderLabel?: string,
     recipientLabel?: string,
-    stakerLabel?: string,
-    validatorAddress: string,
     validatorImageUrl?: string,
     fromValidatorAddress: string,
     fromValidatorImageUrl?: string,
@@ -636,9 +632,7 @@ export async function signSwitchValidatorTransactions(request: {
         sender: request.sender,
         senderLabel: request.senderLabel,
         recipientLabel: request.recipientLabel,
-        stakerLabel: request.stakerLabel,
         transactions: request.transactions,
-        validatorAddress: request.validatorAddress,
         validatorImageUrl: request.validatorImageUrl,
         fromValidatorAddress: request.fromValidatorAddress,
         fromValidatorImageUrl: request.fromValidatorImageUrl,

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -631,6 +631,10 @@ msgstr ""
 msgid "Cannot import contacts, wrong file format."
 msgstr ""
 
+#: src/components/staking/ValidatorDetailsOverlay.vue:327
+msgid "Cannot switch yet"
+msgstr ""
+
 #: src/components/TransactionList.vue:60
 #: src/composables/useTransactionInfo.ts:148
 msgid "Cashlink"
@@ -660,7 +664,7 @@ msgstr ""
 msgid "Change your language setting."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:120
+#: src/components/staking/ValidatorDetailsOverlay.vue:247
 msgid "Changing validator"
 msgstr ""
 
@@ -729,7 +733,7 @@ msgid "Click on ‘Troubleshooting’ to learn more."
 msgstr ""
 
 #: src/components/layouts/AddressOverview.vue:296
-#: src/components/staking/StakingModal.vue:205
+#: src/components/staking/StakingModal.vue:220
 #: src/components/swap/SwapAnimation.vue:111
 msgid "Close"
 msgstr ""
@@ -937,7 +941,7 @@ msgstr ""
 msgid "Deactivate validator"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:465
+#: src/components/staking/StakingInfoPage.vue:463
 msgid "Deactivating remaining stake"
 msgstr ""
 
@@ -1948,6 +1952,10 @@ msgstr ""
 msgid "Please transfer"
 msgstr ""
 
+#: src/components/staking/ValidatorDetailsOverlay.vue:328
+msgid "Please wait for the cooldown period to end."
+msgstr ""
+
 #: src/components/layouts/Sidebar.vue:163
 #: src/components/layouts/Sidebar.vue:63
 msgid "Please wait for your current swap to finish before starting a new one."
@@ -2223,7 +2231,7 @@ msgstr ""
 msgid "Select a currency and an amount."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:54
+#: src/components/staking/ValidatorDetailsOverlay.vue:112
 msgid "Select validator"
 msgstr ""
 
@@ -2339,7 +2347,7 @@ msgid "Send, receive and hold BTC in your wallet."
 msgstr ""
 
 #: src/components/staking/StakingGraphPage.vue:134
-#: src/components/staking/StakingGraphPage.vue:229
+#: src/components/staking/StakingGraphPage.vue:227
 msgid "Sending Staking Transaction"
 msgstr ""
 
@@ -2349,7 +2357,7 @@ msgstr ""
 msgid "Sending Transaction"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:371
+#: src/components/staking/StakingInfoPage.vue:370
 msgid "Sending Unstaking Transaction"
 msgstr ""
 
@@ -2496,12 +2504,13 @@ msgstr ""
 #: src/components/modals/BtcSendModal.vue:584
 #: src/components/modals/SendModal.vue:731
 #: src/components/modals/StablecoinSendModal.vue:758
-#: src/components/staking/StakingGraphPage.vue:384
-#: src/components/staking/StakingInfoPage.vue:358
-#: src/components/staking/StakingInfoPage.vue:441
-#: src/components/staking/StakingInfoPage.vue:456
-#: src/components/staking/StakingInfoPage.vue:521
-#: src/components/staking/ValidatorDetailsOverlay.vue:182
+#: src/components/staking/StakingGraphPage.vue:380
+#: src/components/staking/StakingInfoPage.vue:357
+#: src/components/staking/StakingInfoPage.vue:439
+#: src/components/staking/StakingInfoPage.vue:454
+#: src/components/staking/StakingInfoPage.vue:518
+#: src/components/staking/ValidatorDetailsOverlay.vue:137
+#: src/components/staking/ValidatorDetailsOverlay.vue:334
 msgid "Something went wrong"
 msgstr ""
 
@@ -2567,28 +2576,28 @@ msgstr ""
 msgid "Start staking"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:216
+#: src/components/staking/StakingGraphPage.vue:214
 msgid "Successfully added {amount} NIM to your stake with {validator}"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:166
+#: src/components/staking/ValidatorDetailsOverlay.vue:289
 msgid "Successfully changed validator to {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:342
-#: src/components/staking/StakingInfoPage.vue:507
+#: src/components/staking/StakingInfoPage.vue:341
+#: src/components/staking/StakingInfoPage.vue:504
 msgid "Successfully deactivated {amount} NIM"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:364
+#: src/components/staking/StakingGraphPage.vue:360
 msgid "Successfully deactivated {amount} NIM from your stake with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:172
+#: src/components/staking/StakingGraphPage.vue:171
 msgid "Successfully staked {amount} NIM with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:427
+#: src/components/staking/StakingInfoPage.vue:425
 msgid "Successfully unstaked {amount} NIM"
 msgstr ""
 
@@ -2681,8 +2690,13 @@ msgstr ""
 msgid "Switch to USDT"
 msgstr ""
 
+#: src/components/staking/ValidatorDetailsOverlay.vue:111
 #: src/lib/StakingUtils.ts:100
 msgid "Switch validator"
+msgstr ""
+
+#: src/components/staking/ValidatorDetailsOverlay.vue:146
+msgid "Switching validator"
 msgstr ""
 
 #: src/components/layouts/Network.vue:119
@@ -3143,8 +3157,13 @@ msgstr ""
 msgid "Use the slider to lock your NIM and earn rewards."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:457
+#: src/components/staking/StakingInfoPage.vue:455
+#: src/components/staking/ValidatorDetailsOverlay.vue:138
 msgid "Validator information not available"
+msgstr ""
+
+#: src/components/staking/ValidatorDetailsOverlay.vue:237
+msgid "Validator switch initiated"
 msgstr ""
 
 #: src/components/layouts/Settings.vue:223

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -2338,8 +2338,8 @@ msgstr ""
 msgid "Send, receive and hold BTC in your wallet."
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:132
-#: src/components/staking/StakingGraphPage.vue:227
+#: src/components/staking/StakingGraphPage.vue:134
+#: src/components/staking/StakingGraphPage.vue:229
 msgid "Sending Staking Transaction"
 msgstr ""
 
@@ -2496,7 +2496,7 @@ msgstr ""
 #: src/components/modals/BtcSendModal.vue:584
 #: src/components/modals/SendModal.vue:731
 #: src/components/modals/StablecoinSendModal.vue:758
-#: src/components/staking/StakingGraphPage.vue:288
+#: src/components/staking/StakingGraphPage.vue:384
 #: src/components/staking/StakingInfoPage.vue:358
 #: src/components/staking/StakingInfoPage.vue:441
 #: src/components/staking/StakingInfoPage.vue:456
@@ -2567,7 +2567,7 @@ msgstr ""
 msgid "Start staking"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:214
+#: src/components/staking/StakingGraphPage.vue:216
 msgid "Successfully added {amount} NIM to your stake with {validator}"
 msgstr ""
 
@@ -2580,11 +2580,11 @@ msgstr ""
 msgid "Successfully deactivated {amount} NIM"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:263
+#: src/components/staking/StakingGraphPage.vue:364
 msgid "Successfully deactivated {amount} NIM from your stake with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:170
+#: src/components/staking/StakingGraphPage.vue:172
 msgid "Successfully staked {amount} NIM with {validator}"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -248,6 +248,14 @@ msgstr ""
 msgid "Activate USDC/USDT"
 msgstr ""
 
+#: src/components/staking/StakingInfoPage.vue:100
+msgid "Activate validator"
+msgstr ""
+
+#: src/components/staking/StakingInfoPage.vue:466
+msgid "Activating validator"
+msgstr ""
+
 #: src/components/layouts/Settings.vue:229
 msgid "Add"
 msgstr ""
@@ -288,7 +296,7 @@ msgstr ""
 msgid "Add contact"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:91
+#: src/lib/StakingUtils.ts:107
 msgid "Add stake"
 msgstr ""
 
@@ -631,7 +639,7 @@ msgstr ""
 msgid "Cannot import contacts, wrong file format."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:327
+#: src/components/staking/ValidatorDetailsOverlay.vue:311
 msgid "Cannot switch yet"
 msgstr ""
 
@@ -899,7 +907,7 @@ msgstr ""
 msgid "Create request link"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:46
+#: src/lib/StakingUtils.ts:62
 msgid "Create validator"
 msgstr ""
 
@@ -937,19 +945,19 @@ msgstr ""
 msgid "Dataset: {name}"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:58
+#: src/lib/StakingUtils.ts:74
 msgid "Deactivate validator"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:463
+#: src/components/staking/StakingInfoPage.vue:534
 msgid "Deactivating remaining stake"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:301
+#: src/components/staking/StakingInfoPage.vue:317
 msgid "Deactivating Stake"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:26
+#: src/lib/StakingUtils.ts:42
 msgid "Delete validator"
 msgstr ""
 
@@ -1454,7 +1462,7 @@ msgstr ""
 msgid "In case of any issues, like exceeded limits or insufficient amounts, the automatic refunds will only work for individual IBAN addresses."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:119
+#: src/components/staking/StakingInfoPage.vue:130
 msgid "In order to pay out, unstake all."
 msgstr ""
 
@@ -1631,6 +1639,10 @@ msgstr ""
 
 #: src/components/FlaggedAddressWarning.vue:80
 msgid "malicious"
+msgstr ""
+
+#: src/components/staking/StakingInfoPage.vue:97
+msgid "Manually activate the validator to re-activate staking."
 msgstr ""
 
 #: src/components/modals/PolygonActivationModal.vue:19
@@ -1883,7 +1895,7 @@ msgstr ""
 msgid "paused"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:111
+#: src/components/staking/StakingInfoPage.vue:122
 msgid "Pay out"
 msgstr ""
 
@@ -1952,7 +1964,7 @@ msgstr ""
 msgid "Please transfer"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:328
+#: src/components/staking/ValidatorDetailsOverlay.vue:312
 msgid "Please wait for the cooldown period to end."
 msgstr ""
 
@@ -2006,7 +2018,7 @@ msgstr ""
 msgid "Rates the pool's potential to harm the network, based on its size."
 msgstr ""
 
-#: src/lib/StakingUtils.ts:65
+#: src/lib/StakingUtils.ts:81
 msgid "Reactivate validator"
 msgstr ""
 
@@ -2018,7 +2030,7 @@ msgstr ""
 msgid "Read all about it in this {blog_post} or get right into it."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:98
+#: src/components/staking/StakingInfoPage.vue:109
 msgid "ready for pay out"
 msgstr ""
 
@@ -2161,11 +2173,11 @@ msgstr ""
 msgid "Resulting BTC amount is too small."
 msgstr ""
 
-#: src/lib/StakingUtils.ts:123
+#: src/lib/StakingUtils.ts:139
 msgid "Retire stake"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:71
+#: src/lib/StakingUtils.ts:87
 msgid "Retire validator"
 msgstr ""
 
@@ -2231,7 +2243,7 @@ msgstr ""
 msgid "Select a currency and an amount."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:112
+#: src/components/staking/ValidatorDetailsOverlay.vue:109
 msgid "Select validator"
 msgstr ""
 
@@ -2357,7 +2369,7 @@ msgstr ""
 msgid "Sending Transaction"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:370
+#: src/components/staking/StakingInfoPage.vue:385
 msgid "Sending Unstaking Transaction"
 msgstr ""
 
@@ -2411,7 +2423,7 @@ msgstr ""
 msgid "SEPA Instant transaction"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:114
+#: src/lib/StakingUtils.ts:130
 msgid "Set active stake"
 msgstr ""
 
@@ -2505,12 +2517,13 @@ msgstr ""
 #: src/components/modals/SendModal.vue:731
 #: src/components/modals/StablecoinSendModal.vue:758
 #: src/components/staking/StakingGraphPage.vue:380
-#: src/components/staking/StakingInfoPage.vue:357
-#: src/components/staking/StakingInfoPage.vue:439
-#: src/components/staking/StakingInfoPage.vue:454
-#: src/components/staking/StakingInfoPage.vue:518
-#: src/components/staking/ValidatorDetailsOverlay.vue:137
-#: src/components/staking/ValidatorDetailsOverlay.vue:334
+#: src/components/staking/StakingInfoPage.vue:372
+#: src/components/staking/StakingInfoPage.vue:453
+#: src/components/staking/StakingInfoPage.vue:510
+#: src/components/staking/StakingInfoPage.vue:525
+#: src/components/staking/StakingInfoPage.vue:588
+#: src/components/staking/ValidatorDetailsOverlay.vue:134
+#: src/components/staking/ValidatorDetailsOverlay.vue:318
 msgid "Something went wrong"
 msgstr ""
 
@@ -2572,7 +2585,7 @@ msgstr ""
 msgid "standard"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:77
+#: src/lib/StakingUtils.ts:93
 msgid "Start staking"
 msgstr ""
 
@@ -2580,12 +2593,13 @@ msgstr ""
 msgid "Successfully added {amount} NIM to your stake with {validator}"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:289
+#: src/components/staking/StakingInfoPage.vue:496
+#: src/components/staking/ValidatorDetailsOverlay.vue:273
 msgid "Successfully changed validator to {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:341
-#: src/components/staking/StakingInfoPage.vue:504
+#: src/components/staking/StakingInfoPage.vue:356
+#: src/components/staking/StakingInfoPage.vue:574
 msgid "Successfully deactivated {amount} NIM"
 msgstr ""
 
@@ -2597,7 +2611,7 @@ msgstr ""
 msgid "Successfully staked {amount} NIM with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:425
+#: src/components/staking/StakingInfoPage.vue:439
 msgid "Successfully unstaked {amount} NIM"
 msgstr ""
 
@@ -2690,12 +2704,12 @@ msgstr ""
 msgid "Switch to USDT"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:111
-#: src/lib/StakingUtils.ts:100
+#: src/components/staking/ValidatorDetailsOverlay.vue:108
+#: src/lib/StakingUtils.ts:116
 msgid "Switch validator"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:146
+#: src/components/staking/ValidatorDetailsOverlay.vue:143
 msgid "Switching validator"
 msgstr ""
 
@@ -2889,7 +2903,7 @@ msgstr ""
 #: src/components/UsdtTransactionList.vue:227
 #: src/composables/useTransactionList.ts:149
 #: src/composables/useTransactionList.ts:208
-#: src/lib/StakingUtils.ts:163
+#: src/lib/StakingUtils.ts:179
 msgid "This month"
 msgstr ""
 
@@ -3076,15 +3090,15 @@ msgstr ""
 msgid "Unlock at any time. Your NIM will be available within ~24 hours."
 msgstr ""
 
-#: src/lib/StakingUtils.ts:31
+#: src/lib/StakingUtils.ts:47
 msgid "Unstake"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:104
+#: src/components/staking/StakingInfoPage.vue:115
 msgid "Unstake rest"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:125
+#: src/components/staking/StakingInfoPage.vue:136
 #: src/components/staking/StakingOverview.vue:22
 msgid "Unstaking"
 msgstr ""
@@ -3111,7 +3125,7 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: src/lib/StakingUtils.ts:52
+#: src/lib/StakingUtils.ts:68
 msgid "Update validator"
 msgstr ""
 
@@ -3157,8 +3171,8 @@ msgstr ""
 msgid "Use the slider to lock your NIM and earn rewards."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:455
-#: src/components/staking/ValidatorDetailsOverlay.vue:138
+#: src/components/staking/StakingInfoPage.vue:526
+#: src/components/staking/ValidatorDetailsOverlay.vue:135
 msgid "Validator information not available"
 msgstr ""
 
@@ -3290,7 +3304,7 @@ msgstr ""
 msgid "You exceeded the 30-day limit of your bank account and will be refunded. Please note that network fees may be deducted from your funds."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:117
+#: src/components/staking/StakingInfoPage.vue:128
 msgid "You got some new rewards since you unstaked your funds."
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -252,7 +252,7 @@ msgstr ""
 msgid "Activate validator"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:466
+#: src/components/staking/StakingInfoPage.vue:476
 msgid "Activating validator"
 msgstr ""
 
@@ -639,7 +639,7 @@ msgstr ""
 msgid "Cannot import contacts, wrong file format."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:312
+#: src/components/staking/ValidatorDetailsOverlay.vue:317
 msgid "Cannot switch yet"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Change your language setting."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:248
+#: src/components/staking/ValidatorDetailsOverlay.vue:253
 msgid "Changing validator"
 msgstr ""
 
@@ -949,11 +949,11 @@ msgstr ""
 msgid "Deactivate validator"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:534
+#: src/components/staking/StakingInfoPage.vue:544
 msgid "Deactivating remaining stake"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:317
+#: src/components/staking/StakingInfoPage.vue:327
 msgid "Deactivating Stake"
 msgstr ""
 
@@ -1964,7 +1964,7 @@ msgstr ""
 msgid "Please transfer"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:313
+#: src/components/staking/ValidatorDetailsOverlay.vue:318
 msgid "Please wait for the cooldown period to end."
 msgstr ""
 
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Sending Transaction"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:385
+#: src/components/staking/StakingInfoPage.vue:395
 msgid "Sending Unstaking Transaction"
 msgstr ""
 
@@ -2516,14 +2516,14 @@ msgstr ""
 #: src/components/modals/BtcSendModal.vue:584
 #: src/components/modals/SendModal.vue:731
 #: src/components/modals/StablecoinSendModal.vue:758
-#: src/components/staking/StakingGraphPage.vue:380
-#: src/components/staking/StakingInfoPage.vue:372
-#: src/components/staking/StakingInfoPage.vue:453
-#: src/components/staking/StakingInfoPage.vue:510
-#: src/components/staking/StakingInfoPage.vue:525
-#: src/components/staking/StakingInfoPage.vue:588
+#: src/components/staking/StakingGraphPage.vue:381
+#: src/components/staking/StakingInfoPage.vue:382
+#: src/components/staking/StakingInfoPage.vue:463
+#: src/components/staking/StakingInfoPage.vue:520
+#: src/components/staking/StakingInfoPage.vue:535
+#: src/components/staking/StakingInfoPage.vue:598
 #: src/components/staking/ValidatorDetailsOverlay.vue:134
-#: src/components/staking/ValidatorDetailsOverlay.vue:319
+#: src/components/staking/ValidatorDetailsOverlay.vue:324
 msgid "Something went wrong"
 msgstr ""
 
@@ -2593,17 +2593,17 @@ msgstr ""
 msgid "Successfully added {amount} NIM to your stake with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:496
-#: src/components/staking/ValidatorDetailsOverlay.vue:274
+#: src/components/staking/StakingInfoPage.vue:506
+#: src/components/staking/ValidatorDetailsOverlay.vue:279
 msgid "Successfully changed validator to {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:356
-#: src/components/staking/StakingInfoPage.vue:574
+#: src/components/staking/StakingInfoPage.vue:366
+#: src/components/staking/StakingInfoPage.vue:584
 msgid "Successfully deactivated {amount} NIM"
 msgstr ""
 
-#: src/components/staking/StakingGraphPage.vue:360
+#: src/components/staking/StakingGraphPage.vue:361
 msgid "Successfully deactivated {amount} NIM from your stake with {validator}"
 msgstr ""
 
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Successfully staked {amount} NIM with {validator}"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:439
+#: src/components/staking/StakingInfoPage.vue:449
 msgid "Successfully unstaked {amount} NIM"
 msgstr ""
 
@@ -2709,7 +2709,12 @@ msgstr ""
 msgid "Switch validator"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:143
+#: src/components/staking/StakingInfoPage.vue:138
+#: src/components/staking/StakingOverview.vue:24
+msgid "Switching to {validator}"
+msgstr ""
+
+#: src/components/staking/ValidatorDetailsOverlay.vue:146
 msgid "Switching validator"
 msgstr ""
 
@@ -3057,7 +3062,7 @@ msgstr ""
 msgid "Type to search..."
 msgstr ""
 
-#: src/components/staking/StakingOverview.vue:48
+#: src/components/staking/StakingOverview.vue:52
 #: src/components/staking/StakingRewardsListItem.vue:56
 #: src/components/staking/ValidatorsListOverlay.vue:43
 msgid "unavailable"
@@ -3098,8 +3103,8 @@ msgstr ""
 msgid "Unstake rest"
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:136
-#: src/components/staking/StakingOverview.vue:22
+#: src/components/staking/StakingInfoPage.vue:141
+#: src/components/staking/StakingOverview.vue:26
 msgid "Unstaking"
 msgstr ""
 
@@ -3171,12 +3176,12 @@ msgstr ""
 msgid "Use the slider to lock your NIM and earn rewards."
 msgstr ""
 
-#: src/components/staking/StakingInfoPage.vue:526
+#: src/components/staking/StakingInfoPage.vue:536
 #: src/components/staking/ValidatorDetailsOverlay.vue:135
 msgid "Validator information not available"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:238
+#: src/components/staking/ValidatorDetailsOverlay.vue:241
 msgid "Validator switch initiated"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -639,7 +639,7 @@ msgstr ""
 msgid "Cannot import contacts, wrong file format."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:311
+#: src/components/staking/ValidatorDetailsOverlay.vue:312
 msgid "Cannot switch yet"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Change your language setting."
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:247
+#: src/components/staking/ValidatorDetailsOverlay.vue:248
 msgid "Changing validator"
 msgstr ""
 
@@ -1964,7 +1964,7 @@ msgstr ""
 msgid "Please transfer"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:312
+#: src/components/staking/ValidatorDetailsOverlay.vue:313
 msgid "Please wait for the cooldown period to end."
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 #: src/components/staking/StakingInfoPage.vue:525
 #: src/components/staking/StakingInfoPage.vue:588
 #: src/components/staking/ValidatorDetailsOverlay.vue:134
-#: src/components/staking/ValidatorDetailsOverlay.vue:318
+#: src/components/staking/ValidatorDetailsOverlay.vue:319
 msgid "Something went wrong"
 msgstr ""
 
@@ -2594,7 +2594,7 @@ msgid "Successfully added {amount} NIM to your stake with {validator}"
 msgstr ""
 
 #: src/components/staking/StakingInfoPage.vue:496
-#: src/components/staking/ValidatorDetailsOverlay.vue:273
+#: src/components/staking/ValidatorDetailsOverlay.vue:274
 msgid "Successfully changed validator to {validator}"
 msgstr ""
 
@@ -3176,7 +3176,7 @@ msgstr ""
 msgid "Validator information not available"
 msgstr ""
 
-#: src/components/staking/ValidatorDetailsOverlay.vue:237
+#: src/components/staking/ValidatorDetailsOverlay.vue:238
 msgid "Validator switch initiated"
 msgstr ""
 

--- a/src/lib/AlbatrossWatchtower.ts
+++ b/src/lib/AlbatrossWatchtower.ts
@@ -1,0 +1,100 @@
+import { useConfig } from '@/composables/useConfig';
+
+/* eslint-disable camelcase */
+type StartUnstakePayload = {
+    staker_address: string,
+    transactions: {
+        inactive_stake_tx_hash: string,
+        retire_tx: string,
+        unstake_tx: string,
+    },
+};
+/* eslint-enable camelcase */
+
+function toBasicAuth(username: string, password: string): string {
+    // btoa expects binary string; credentials are ASCII
+    return `Basic ${btoa(`${username}:${password}`)}`;
+}
+
+function strip0x(hex: string | undefined): string | undefined {
+    if (!hex) return hex;
+    return hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+}
+
+export async function startUnstaking(payload: StartUnstakePayload): Promise<void> {
+    const { config } = useConfig();
+    const wt = (config as any).albatrossWatchtower as undefined | {
+        endpoint: string,
+    };
+
+    if (!wt?.endpoint) {
+        // eslint-disable-next-line no-console
+        console.warn('watchtower: not configured, skipping startUnstaking');
+        return; // Fail silently if not configured
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' };
+    const username = process.env.VUE_APP_WT_USERNAME || process.env.WT_USERNAME;
+    const password = process.env.VUE_APP_WT_PASSWORD || process.env.WT_PASSWORD;
+    if (username && password) headers.Authorization = toBasicAuth(username, password);
+
+    const url = `${wt.endpoint.replace(/\/$/, '')}/unstake`;
+    // eslint-disable-next-line no-console
+    console.debug('watchtower: POST /unstake', {
+        url,
+        staker: payload.staker_address,
+        hasRetire: !!payload.transactions?.retire_tx,
+        unstakeLen: payload.transactions?.unstake_tx?.length,
+        inactiveStakeTxHash: payload.transactions?.inactive_stake_tx_hash,
+    });
+    let response: Response;
+    try {
+        const normalized = {
+            staker_address: payload.staker_address,
+            transactions: {
+                inactive_stake_tx_hash: strip0x(payload.transactions.inactive_stake_tx_hash)!,
+                retire_tx: strip0x(payload.transactions.retire_tx)!,
+                unstake_tx: strip0x(payload.transactions.unstake_tx)!,
+            },
+        };
+        response = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(normalized),
+        });
+    } catch (networkError: any) {
+        // eslint-disable-next-line no-console
+        console.error('watchtower: network error', networkError?.message || networkError);
+        throw networkError;
+    }
+
+    if (!response.ok) {
+        let message = 'Watchtower request failed';
+        try {
+            const data = await response.json();
+            message = data?.message || JSON.stringify(data);
+        } catch (_) { /* ignore */ }
+        // eslint-disable-next-line no-console
+        console.error('watchtower: HTTP error', response.status, message);
+        if (response.status === 406) {
+            try {
+                const txHash = strip0x(payload.transactions.inactive_stake_tx_hash)!;
+                const statusRes = await fetch(`${wt.endpoint.replace(/\/$/, '')}/transaction/${txHash}`, {
+                    headers: { Accept: 'application/json' },
+                });
+                if (statusRes.ok) {
+                    const statusJson = await statusRes.json();
+                    // eslint-disable-next-line no-console
+                    console.debug('watchtower: transaction status', statusJson);
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.debug('watchtower: transaction status HTTP', statusRes.status);
+                }
+            } catch (e) {
+                // eslint-disable-next-line no-console
+                console.debug('watchtower: transaction status probe failed');
+            }
+        }
+        throw new Error(`HTTP ${response.status}: ${message}`);
+    }
+}

--- a/src/lib/AlbatrossWatchtower.ts
+++ b/src/lib/AlbatrossWatchtower.ts
@@ -1,15 +1,17 @@
 import { useConfig } from '@/composables/useConfig';
 
-/* eslint-disable camelcase */
-type StartUnstakePayload = {
-    staker_address: string,
-    transactions: {
-        inactive_stake_tx_hash: string,
-        retire_tx: string,
-        unstake_tx: string,
-    },
+type StartUnstakeInput = {
+    stakerAddress: string,
+    inactiveStakeTxHash: string,
+    retireTx: string,
+    unstakeTx: string,
 };
-/* eslint-enable camelcase */
+
+type StartSwitchValidatorInput = {
+    stakerAddress: string,
+    deactivationTxHash: string,
+    updateStakerTx: string,
+};
 
 function toBasicAuth(username: string, password: string): string {
     // btoa expects binary string; credentials are ASCII
@@ -21,46 +23,39 @@ function strip0x(hex: string | undefined): string | undefined {
     return hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
 }
 
-export async function startUnstaking(payload: StartUnstakePayload): Promise<void> {
+function getWatchtowerEndpoint(): string | null {
     const { config } = useConfig();
-    const wt = (config as any).albatrossWatchtower as undefined | {
-        endpoint: string,
-    };
+    const wt = (config as any).albatrossWatchtower as undefined | { endpoint: string };
+    return wt?.endpoint?.replace(/\/$/, '') || null;
+}
 
-    if (!wt?.endpoint) {
-        // eslint-disable-next-line no-console
-        console.warn('watchtower: not configured, skipping startUnstaking');
-        return; // Fail silently if not configured
-    }
-
+function buildAuthHeaders(): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' };
     const username = process.env.VUE_APP_WT_USERNAME || process.env.WT_USERNAME;
     const password = process.env.VUE_APP_WT_PASSWORD || process.env.WT_PASSWORD;
     if (username && password) headers.Authorization = toBasicAuth(username, password);
+    return headers;
+}
 
-    const url = `${wt.endpoint.replace(/\/$/, '')}/unstake`;
-    // eslint-disable-next-line no-console
-    console.debug('watchtower: POST /unstake', {
-        url,
-        staker: payload.staker_address,
-        hasRetire: !!payload.transactions?.retire_tx,
-        unstakeLen: payload.transactions?.unstake_tx?.length,
-        inactiveStakeTxHash: payload.transactions?.inactive_stake_tx_hash,
-    });
+/**
+ * POST a body to a watchtower endpoint, throwing on any non-2xx response.
+ * Returns silently (no throw) when the watchtower is not configured.
+ */
+async function postToWatchtower<T extends object>(path: string, body: T): Promise<void> {
+    const endpoint = getWatchtowerEndpoint();
+    if (!endpoint) {
+        // eslint-disable-next-line no-console
+        console.warn(`watchtower: not configured, skipping POST ${path}`);
+        return;
+    }
+
+    const url = `${endpoint}${path}`;
     let response: Response;
     try {
-        const normalized = {
-            staker_address: payload.staker_address,
-            transactions: {
-                inactive_stake_tx_hash: strip0x(payload.transactions.inactive_stake_tx_hash)!,
-                retire_tx: strip0x(payload.transactions.retire_tx)!,
-                unstake_tx: strip0x(payload.transactions.unstake_tx)!,
-            },
-        };
         response = await fetch(url, {
             method: 'POST',
-            headers,
-            body: JSON.stringify(normalized),
+            headers: buildAuthHeaders(),
+            body: JSON.stringify(body),
         });
     } catch (networkError: any) {
         // eslint-disable-next-line no-console
@@ -76,25 +71,29 @@ export async function startUnstaking(payload: StartUnstakePayload): Promise<void
         } catch (_) { /* ignore */ }
         // eslint-disable-next-line no-console
         console.error('watchtower: HTTP error', response.status, message);
-        if (response.status === 406) {
-            try {
-                const txHash = strip0x(payload.transactions.inactive_stake_tx_hash)!;
-                const statusRes = await fetch(`${wt.endpoint.replace(/\/$/, '')}/transaction/${txHash}`, {
-                    headers: { Accept: 'application/json' },
-                });
-                if (statusRes.ok) {
-                    const statusJson = await statusRes.json();
-                    // eslint-disable-next-line no-console
-                    console.debug('watchtower: transaction status', statusJson);
-                } else {
-                    // eslint-disable-next-line no-console
-                    console.debug('watchtower: transaction status HTTP', statusRes.status);
-                }
-            } catch (e) {
-                // eslint-disable-next-line no-console
-                console.debug('watchtower: transaction status probe failed');
-            }
-        }
         throw new Error(`HTTP ${response.status}: ${message}`);
     }
 }
+
+/* eslint-disable camelcase */
+export async function startUnstaking(input: StartUnstakeInput): Promise<void> {
+    return postToWatchtower('/unstake', {
+        staker_address: input.stakerAddress,
+        transactions: {
+            inactive_stake_tx_hash: strip0x(input.inactiveStakeTxHash)!,
+            retire_tx: strip0x(input.retireTx)!,
+            unstake_tx: strip0x(input.unstakeTx)!,
+        },
+    });
+}
+
+export async function startSwitchValidator(input: StartSwitchValidatorInput): Promise<void> {
+    return postToWatchtower('/switch-validator', {
+        staker_address: input.stakerAddress,
+        transactions: {
+            inactive_stake_tx_hash: strip0x(input.deactivationTxHash)!,
+            update_tx: strip0x(input.updateStakerTx)!,
+        },
+    });
+}
+/* eslint-enable camelcase */

--- a/src/lib/StakingUtils.ts
+++ b/src/lib/StakingUtils.ts
@@ -1,7 +1,23 @@
 import { i18n } from '../i18n/i18n-setup';
 import { Transaction } from '../stores/Transactions';
-import { useStakingStore, AggregatedRestakingEvent } from '../stores/Staking';
+import { useStakingStore, AggregatedRestakingEvent, Validator } from '../stores/Staking';
 import { STAKING_CONTRACT_ADDRESS } from './Constants';
+
+export type ValidatorRef = {
+    address: string,
+    name?: string,
+    logo?: string,
+};
+
+export function toValidatorRef(validator: Validator): ValidatorRef {
+    return {
+        address: validator.address,
+        name: 'name' in validator ? validator.name : undefined,
+        logo: 'logo' in validator && !validator.hasDefaultLogo ? validator.logo : undefined,
+    };
+}
+
+export const validatorLabel = (v: ValidatorRef): string => v.name || v.address;
 
 export enum FilterState {
     TRUST = 'trustscore',

--- a/src/lib/SwitchValidator.ts
+++ b/src/lib/SwitchValidator.ts
@@ -1,0 +1,38 @@
+import { sendStaking } from '../hub';
+import { getNetworkClient } from '../network';
+import { ValidatorRef } from './StakingUtils';
+
+export async function sendImmediateValidatorSwitch(params: {
+    stakerAddress: string,
+    height: number,
+    amount: number,
+    target: ValidatorRef,
+    from: ValidatorRef,
+}) {
+    const [{ Address, TransactionBuilder }, client] = await Promise.all([
+        import('@nimiq/core'),
+        getNetworkClient(),
+    ]);
+    const networkId = await client.getNetworkId();
+
+    const reactivateAllStake = true;
+    const transaction = TransactionBuilder.newUpdateStaker(
+        Address.fromUserFriendlyAddress(params.stakerAddress),
+        Address.fromUserFriendlyAddress(params.target.address),
+        reactivateAllStake,
+        BigInt(0),
+        params.height,
+        networkId,
+    );
+
+    return sendStaking({
+        transaction: transaction.serialize(),
+        senderLabel: params.from.name || params.from.address,
+        recipientLabel: params.target.name || params.target.address,
+        validatorAddress: params.target.address,
+        validatorImageUrl: params.target.logo,
+        fromValidatorAddress: params.from.address,
+        fromValidatorImageUrl: params.from.logo,
+        amount: params.amount,
+    });
+}

--- a/src/lib/SwitchValidator.ts
+++ b/src/lib/SwitchValidator.ts
@@ -1,6 +1,6 @@
 import { sendStaking } from '../hub';
 import { getNetworkClient } from '../network';
-import { ValidatorRef } from './StakingUtils';
+import { ValidatorRef, validatorLabel } from './StakingUtils';
 
 export async function sendImmediateValidatorSwitch(params: {
     stakerAddress: string,
@@ -27,8 +27,8 @@ export async function sendImmediateValidatorSwitch(params: {
 
     return sendStaking({
         transaction: transaction.serialize(),
-        senderLabel: params.from.name || params.from.address,
-        recipientLabel: params.target.name || params.target.address,
+        senderLabel: validatorLabel(params.from),
+        recipientLabel: validatorLabel(params.target),
         validatorAddress: params.target.address,
         validatorImageUrl: params.target.logo,
         fromValidatorAddress: params.from.address,

--- a/src/network.ts
+++ b/src/network.ts
@@ -4,7 +4,7 @@ import { SignedTransaction } from '@nimiq/hub-api';
 import type { Client, PlainStakingContract, PlainTransactionDetails } from '@nimiq/core';
 
 import { useAddressStore } from './stores/Address';
-import { useTransactionsStore, TransactionState } from './stores/Transactions';
+import { useTransactionsStore, TransactionState, Transaction } from './stores/Transactions';
 import { useNetworkStore } from './stores/Network';
 import { useProxyStore } from './stores/Proxy';
 import { useConfig } from './composables/useConfig';
@@ -12,6 +12,7 @@ import { useStakingStore, ApiValidator, RawValidator, AggregatedRestakingEvent }
 import { ENV_MAIN, STAKING_CONTRACT_ADDRESS } from './lib/Constants';
 import { reportToSentry } from './lib/Sentry';
 import { useAccountStore } from './stores/Account';
+import { usePolicy } from './composables/usePolicy';
 
 let isLaunched = false;
 let clientPromise: Promise<Client>;
@@ -574,63 +575,93 @@ export async function sendTransaction(tx: SignedTransaction | string) {
     return plain;
 }
 
-export function waitForTransactionConfirmation(
+export async function waitForTransactionConfirmation(
     txHash: string,
     options?: Partial<{
         timeout: number,
-        /** Wait for macro-block confirmation (CONFIRMED state), not just micro-block inclusion */
+        /** Wait for macro-block confirmation, not just micro-block inclusion. */
         requireConfirmed: boolean,
     }>,
 ): Promise<void> {
-    const defaults = {
-        timeout: 120000, // 2 minutes (2 macro blocks in Albatross)
-        requireConfirmed: false,
-    };
-
-    const { timeout, requireConfirmed } = { ...defaults, ...options };
+    const { timeout, requireConfirmed } = { timeout: 120000, requireConfirmed: false, ...options };
     const transactionsStore = useTransactionsStore();
+    const networkStore = useNetworkStore();
 
-    return new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const isReady = (tx: any) => {
-            if (!tx) return false;
-            if (requireConfirmed) {
-                return tx.state === TransactionState.CONFIRMED
-                    || tx.state === TransactionState.MINED;
-            }
-            return tx.state === TransactionState.INCLUDED
-                || tx.state === TransactionState.CONFIRMED
-                || tx.state === TransactionState.MINED;
-        };
+    const isIncluded = (tx: Transaction | undefined): boolean => !!tx && (
+        tx.state === TransactionState.INCLUDED
+        || tx.state === TransactionState.CONFIRMED
+        // @ts-expect-error MINED is not included in the types for PoS transactions
+        || tx.state === TransactionState.MINED
+    );
 
-        const currentTx = transactionsStore.state.transactions[txHash];
-        console.debug('waitForTransactionConfirmation: initial check', {
-            txHash, state: currentTx?.state, requireConfirmed,
+    if (!requireConfirmed) {
+        if (isIncluded(transactionsStore.state.transactions[txHash])) return;
+        await new Promise<void>((resolve, reject) => {
+            const timeoutId = setTimeout(() => {
+                stop();
+                reject(new Error(`Transaction confirmation timeout after ${timeout}ms for tx ${txHash}`));
+            }, timeout);
+            const stop = watch(
+                () => transactionsStore.state.transactions[txHash]?.state,
+                () => {
+                    if (isIncluded(transactionsStore.state.transactions[txHash])) {
+                        clearTimeout(timeoutId);
+                        stop();
+                        resolve();
+                    }
+                },
+            );
         });
+        return;
+    }
 
-        if (isReady(currentTx)) {
-            console.debug('waitForTransactionConfirmation: already ready, resolving immediately');
-            resolve();
-            return;
-        }
+    // Macro-block confirmation: tx.state isn't reliable past `included` (it's mutated in
+    // place by `addTransactions` and Nimiq core doesn't always refire listeners). Instead,
+    // wait for `blockHeight`, compute the target macro block once, and watch the reactive
+    // chain height (which fires on every head-changed event).
+    const policy = await usePolicy();
 
-        // Set up timeout
+    const startTime = Date.now();
+    const remaining = () => Math.max(0, timeout - (Date.now() - startTime));
+
+    let tx = transactionsStore.state.transactions[txHash];
+    if (!tx || !tx.blockHeight) {
+        await new Promise<void>((resolve, reject) => {
+            const timeoutId = setTimeout(() => {
+                stop();
+                reject(new Error(`Transaction confirmation timeout after ${timeout}ms for tx ${txHash}`));
+            }, remaining());
+            const stop = watch(
+                () => transactionsStore.state.transactions[txHash]?.blockHeight,
+                (blockHeight) => {
+                    if (blockHeight) {
+                        clearTimeout(timeoutId);
+                        stop();
+                        resolve();
+                    }
+                },
+            );
+        });
+        tx = transactionsStore.state.transactions[txHash];
+    }
+
+    const macroTarget = policy.macroBlockAfter(tx.blockHeight!);
+    if (networkStore.state.height >= macroTarget) return;
+
+    await new Promise<void>((resolve, reject) => {
         const timeoutId = setTimeout(() => {
-            const tx = transactionsStore.state.transactions[txHash];
-            console.warn('waitForTransactionConfirmation: timeout', { txHash, currentState: tx?.state });
-            stopWatcher();
+            console.warn('waitForTransactionConfirmation: timeout', {
+                txHash, blockHeight: tx.blockHeight, macroTarget, height: networkStore.state.height,
+            });
+            stop();
             reject(new Error(`Transaction confirmation timeout after ${timeout}ms for tx ${txHash}`));
-        }, timeout);
-
-        // Watch for transaction state changes
-        const stopWatcher = watch(
-            () => transactionsStore.state.transactions[txHash],
-            (tx) => {
-                console.debug('waitForTransactionConfirmation: state changed', { txHash, state: tx?.state });
-                if (isReady(tx)) {
-                    console.debug('waitForTransactionConfirmation: transaction ready, resolving');
+        }, remaining());
+        const stop = watch(
+            () => networkStore.state.height,
+            (h) => {
+                if (h >= macroTarget) {
                     clearTimeout(timeoutId);
-                    stopWatcher();
+                    stop();
                     resolve();
                 }
             },

--- a/src/network.ts
+++ b/src/network.ts
@@ -574,6 +574,70 @@ export async function sendTransaction(tx: SignedTransaction | string) {
     return plain;
 }
 
+export function waitForTransactionConfirmation(
+    txHash: string,
+    options?: Partial<{
+        timeout: number,
+        /** Wait for macro-block confirmation (CONFIRMED state), not just micro-block inclusion */
+        requireConfirmed: boolean,
+    }>,
+): Promise<void> {
+    const defaults = {
+        timeout: 120000, // 2 minutes (2 macro blocks in Albatross)
+        requireConfirmed: false,
+    };
+
+    const { timeout, requireConfirmed } = { ...defaults, ...options };
+    const transactionsStore = useTransactionsStore();
+
+    return new Promise((resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const isReady = (tx: any) => {
+            if (!tx) return false;
+            if (requireConfirmed) {
+                return tx.state === TransactionState.CONFIRMED
+                    || tx.state === TransactionState.MINED;
+            }
+            return tx.state === TransactionState.INCLUDED
+                || tx.state === TransactionState.CONFIRMED
+                || tx.state === TransactionState.MINED;
+        };
+
+        const currentTx = transactionsStore.state.transactions[txHash];
+        console.debug('waitForTransactionConfirmation: initial check', {
+            txHash, state: currentTx?.state, requireConfirmed,
+        });
+
+        if (isReady(currentTx)) {
+            console.debug('waitForTransactionConfirmation: already ready, resolving immediately');
+            resolve();
+            return;
+        }
+
+        // Set up timeout
+        const timeoutId = setTimeout(() => {
+            const tx = transactionsStore.state.transactions[txHash];
+            console.warn('waitForTransactionConfirmation: timeout', { txHash, currentState: tx?.state });
+            stopWatcher();
+            reject(new Error(`Transaction confirmation timeout after ${timeout}ms for tx ${txHash}`));
+        }, timeout);
+
+        // Watch for transaction state changes
+        const stopWatcher = watch(
+            () => transactionsStore.state.transactions[txHash],
+            (tx) => {
+                console.debug('waitForTransactionConfirmation: state changed', { txHash, state: tx?.state });
+                if (isReady(tx)) {
+                    console.debug('waitForTransactionConfirmation: transaction ready, resolving');
+                    clearTimeout(timeoutId);
+                    stopWatcher();
+                    resolve();
+                }
+            },
+        );
+    });
+}
+
 async function retry<T>(func: (...args: any[]) => T | Promise<T>, options?: Partial<{
     baseDelay: number,
     maxRetries: number,

--- a/src/router.ts
+++ b/src/router.ts
@@ -162,6 +162,9 @@ export enum RouteName {
     StakingRewards = 'staking-rewards',
 }
 
+/** Query passed to the Staking route to open the modal directly on the validator list page. */
+export const STAKING_QUERY_SHOW_VALIDATORS = { page: 'validators' } as const;
+
 /**
  * Helper function to create context-specific route variants for Settings and Network pages.
  * This allows modals opened from the sidebar to close back to the correct parent page.

--- a/src/stores/Staking.ts
+++ b/src/stores/Staking.ts
@@ -88,6 +88,25 @@ export type RegisteredValidator = RawValidator & ApiValidator & {
 
 export type Validator = RawValidator | RegisteredValidator;
 
+export type SwitchValidatorRecord = {
+    targetValidatorAddress: string,
+    targetValidatorName?: string,
+    startedAtBlock: number,
+    deactivationTxHash: string,
+}
+
+const SWITCH_VALIDATOR_LS_PREFIX = 'switchValidator:';
+
+function getSwitchRecord(address: string): SwitchValidatorRecord | null {
+    try {
+        const raw = localStorage.getItem(`${SWITCH_VALIDATOR_LS_PREFIX}${address}`);
+        if (!raw) return null;
+        return JSON.parse(raw) as SwitchValidatorRecord;
+    } catch {
+        return null;
+    }
+}
+
 export type StakingScoringRules = any
 
 export const useStakingStore = createStore({
@@ -98,7 +117,10 @@ export const useStakingStore = createStore({
         stakeByAddress: {},
         stakingEventsByAddress: {},
         cachedMonthlyRewardsByAddress: {},
-    } as StakingState),
+        // Bumped on every switch-record write so `activeSwitchOperation` (which reads from
+        // localStorage) re-evaluates. Drop once switch records move into reactive state.
+        switchValidatorTrigger: 0,
+    } as StakingState & { switchValidatorTrigger: number }),
     getters: {
         validators: (state): Readonly<Record<string, Validator>> => {
             const validators: Record<string, Validator> = {};
@@ -216,6 +238,18 @@ export const useStakingStore = createStore({
             };
         },
 
+        activeSwitchOperation: (state): Readonly<SwitchValidatorRecord | null> => {
+            void state.switchValidatorTrigger; // eslint-disable-line no-void
+            const { activeAddress } = useAddressStore();
+            if (!activeAddress.value) return null;
+            return getSwitchRecord(activeAddress.value);
+        },
+        isSwitchingValidator: (state, { activeStake, activeSwitchOperation }): boolean => {
+            const record = activeSwitchOperation.value as SwitchValidatorRecord | null;
+            const stake = activeStake.value as Stake | null;
+            if (!record || !stake) return false;
+            return stake.activeBalance === 0 && stake.inactiveBalance > 0;
+        },
         stakingEvents: (state): Readonly<AggregatedRestakingEvent[] | null> => {
             const { activeAddress } = useAddressStore();
             if (!activeAddress.value) return null;
@@ -343,6 +377,7 @@ export const useStakingStore = createStore({
                 ...this.state.stakeByAddress,
                 [stake.address]: stake,
             };
+            this.checkSwitchCompletion(stake.address);
         },
         setStakes(stakes: Stake[]) {
             const newStakes: {[address: string]: Stake} = {};
@@ -352,6 +387,10 @@ export const useStakingStore = createStore({
             }
 
             this.state.stakeByAddress = newStakes;
+
+            for (const stake of stakes) {
+                this.checkSwitchCompletion(stake.address);
+            }
         },
         patchStake(address: string, patch: Partial<Omit<Stake, 'address'>>) {
             if (!this.state.stakeByAddress[address]) return;
@@ -393,6 +432,26 @@ export const useStakingStore = createStore({
 
             this.state.apiValidators = newApiValidators;
         },
+        setSwitchOperation(address: string, record: SwitchValidatorRecord) {
+            const key = `${SWITCH_VALIDATOR_LS_PREFIX}${address}`;
+            const serialized = JSON.stringify(record);
+            if (localStorage.getItem(key) === serialized) return;
+            localStorage.setItem(key, serialized);
+            this.state.switchValidatorTrigger++;
+        },
+        clearSwitchOperation(address: string) {
+            const key = `${SWITCH_VALIDATOR_LS_PREFIX}${address}`;
+            if (localStorage.getItem(key) === null) return;
+            localStorage.removeItem(key);
+            this.state.switchValidatorTrigger++;
+        },
+        checkSwitchCompletion(address: string) {
+            const stake = this.state.stakeByAddress[address];
+            if (!stake || stake.activeBalance === 0) return;
+            const record = getSwitchRecord(address);
+            if (record) this.clearSwitchOperation(address);
+        },
+
         setStakingEvents(address: string, events: AggregatedRestakingEvent[]) {
             // Need to assign whole object for change detection of new addresses.
             // TODO: Simply set new stake in Vue 3.

--- a/src/stores/Staking.ts
+++ b/src/stores/Staking.ts
@@ -459,7 +459,11 @@ export const useStakingStore = createStore({
             const stake = this.state.stakeByAddress[address];
             if (!stake || stake.activeBalance === 0) return;
             const record = getSwitchRecord(address);
-            if (record) this.clearSwitchOperation(address);
+            if (!record) return;
+            // Don't clear until active stake is at the target — the user's manual recovery
+            // handle would otherwise be lost if balance reappears at the old validator.
+            if (stake.validator !== record.targetValidatorAddress) return;
+            this.clearSwitchOperation(address);
         },
 
         setStakingEvents(address: string, events: AggregatedRestakingEvent[]) {

--- a/src/stores/Staking.ts
+++ b/src/stores/Staking.ts
@@ -5,6 +5,7 @@ import { createStore } from 'pinia';
 import { useAccountStore } from './Account';
 import { useAddressStore } from './Address';
 import { useFiatStore } from './Fiat';
+import { useNetworkStore } from './Network';
 import { calculateStakingReward } from '../lib/AlbatrossMath';
 import {
     CryptoCurrency,
@@ -249,6 +250,15 @@ export const useStakingStore = createStore({
             const stake = activeStake.value as Stake | null;
             if (!record || !stake) return false;
             return stake.activeBalance === 0 && stake.inactiveBalance > 0;
+        },
+        canManuallyActivateSwitch: (state, { activeStake, activeSwitchOperation }) => {
+            const record = activeSwitchOperation.value as SwitchValidatorRecord | null;
+            const stake = activeStake.value as Stake | null;
+            const { state: networkState } = useNetworkStore();
+            if (!record || !stake) return false;
+            if (stake.activeBalance !== 0 || stake.inactiveBalance <= 0) return false;
+            if (!stake.inactiveRelease || stake.inactiveRelease > networkState.height) return false;
+            return stake.validator !== record.targetValidatorAddress;
         },
         stakingEvents: (state): Readonly<AggregatedRestakingEvent[] | null> => {
             const { activeAddress } = useAddressStore();

--- a/src/stores/Staking.ts
+++ b/src/stores/Staking.ts
@@ -13,7 +13,13 @@ import {
     FIAT_API_PROVIDER_TX_HISTORY,
     FIAT_PRICE_UNAVAILABLE,
 } from '../lib/Constants';
-import { getEndOfMonthTimestamp, isCurrentMonthAndYear } from '../lib/StakingUtils';
+import {
+    getEndOfMonthTimestamp,
+    isCurrentMonthAndYear,
+    toValidatorRef,
+    validatorLabel,
+    ValidatorRef,
+} from '../lib/StakingUtils';
 
 export type StakingState = {
     chainValidators: Record<string, RawValidator>,
@@ -259,6 +265,15 @@ export const useStakingStore = createStore({
             if (stake.activeBalance !== 0 || stake.inactiveBalance <= 0) return false;
             if (!stake.inactiveRelease || stake.inactiveRelease > networkState.height) return false;
             return stake.validator !== record.targetValidatorAddress;
+        },
+        switchTargetLabel: (state, { activeSwitchOperation, validators }): string => {
+            const record = activeSwitchOperation.value as SwitchValidatorRecord | null;
+            if (!record) return '';
+            const known = (validators.value as Record<string, Validator>)[record.targetValidatorAddress];
+            const target: ValidatorRef = known
+                ? toValidatorRef(known)
+                : { address: record.targetValidatorAddress, name: record.targetValidatorName };
+            return validatorLabel(target);
         },
         stakingEvents: (state): Readonly<AggregatedRestakingEvent[] | null> => {
             const { activeAddress } = useAddressStore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,10 +1461,19 @@
   dependencies:
     nanoid "^3.1.20"
 
-"@nimiq/core@^2.1.1", "@nimiq/core@^2.20.0":
+"@nimiq/core@^2.20.0":
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/@nimiq/core/-/core-2.20.0.tgz#c923cfbfedc53d00d3be235e6c1b281e10c51323"
   integrity sha512-JJYQJRVoI61rulUbeMH83HPv3o+vfaivjk93t50YbYTo5QY4zx/yrpmX1Xsvjk3i2nszaC6iql22g7CPd4tUSQ==
+  dependencies:
+    comlink "^4.4.1"
+    vite-plugin-wasm "^3.5.0"
+    websocket "^1.0.34"
+
+"@nimiq/core@^2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/core/-/core-2.21.0.tgz#99d257cb842658082fe39ed350e3521bca3036ae"
+  integrity sha512-CBWMQhnFSQ8tEqRc3FThq4XaUIf83+KSkoOYPfkzx9kR1dne3ihztUqqxJkZ6ff6onl2AG4S6atL0sFjms0cjQ==
   dependencies:
     comlink "^4.4.1"
     vite-plugin-wasm "^3.5.0"
@@ -1476,22 +1485,21 @@
   dependencies:
     bitcoinjs-lib "^5.1.10"
 
-"@nimiq/fastspot-api@^1.10.2", "@nimiq/fastspot-api@^1.10.3":
+"@nimiq/fastspot-api@^1.10.3":
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/@nimiq/fastspot-api/-/fastspot-api-1.10.3.tgz#9a4b6c5594708f3dd76f8bf1b0fd189ca886dbce"
   integrity sha512-CUkIAcF7R3OlN45idB+yC9Wnuz2YXTPx25xYswCdmbMGu/EGZFNnGHLIe6HkbHd8Eh+uBrwqBmLZGm8jyQ9+6A==
 
-"@nimiq/hub-api@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/hub-api/-/hub-api-1.13.0.tgz#212cc7e544069b68bcb10fac156eefcf5e8b89cf"
-  integrity sha512-QJ6QVsU7PJKwwULI/vOiPLStIrl52bUNLl69d/Svdbcj0x38FaYGVbLhuBXUJH2vfVdqMgdJbEZ5mw/y2OpPng==
+"@nimiq/hub-api@^1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/hub-api/-/hub-api-1.15.0.tgz#d655a6554c6710d63d772ed3492c5b1145d04574"
+  integrity sha512-36RWx5624SOClClvcCGzhnD9kLHxskRXeLIsy+2GWNy7rH73FH+rEU1iW+H2Rm/T//+1g+/BSJHITS8QxuUiGA==
   dependencies:
-    "@nimiq/core" "^2.1.1"
-    "@nimiq/fastspot-api" "^1.10.2"
-    "@nimiq/rpc" "^0.4.0"
-    "@nimiq/utils" "^0.5.0"
-    "@opengsn/common" "^2.2.5"
-    big-integer "^1.6.48"
+    "@nimiq/core" "^2.21.0"
+    "@nimiq/fastspot-api" "^1.10.3"
+    "@nimiq/rpc" "^0.4.1"
+    "@nimiq/utils" "^0.11.7"
+    big-integer "^1.6.52"
 
 "@nimiq/iqons@^1.5.2", "@nimiq/iqons@^1.6.0":
   version "1.6.0"
@@ -1524,7 +1532,7 @@
     node-fetch "^3.3.0"
     xlsx "^0.18.5"
 
-"@nimiq/rpc@^0.4.0", "@nimiq/rpc@^0.4.1":
+"@nimiq/rpc@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.4.1.tgz#d5df1e426793afcdd8c407a2968442bbee874dbd"
   integrity sha512-aQigD21o7S1+J9kfWBA9sDPjtQ+K1keL02eahc6UjSL/+9SVMY+zetSDdjq6d4zNBLRnVayjw0G2hc/yKUMZ0Q==
@@ -1539,17 +1547,17 @@
   resolved "https://registry.yarnpkg.com/@nimiq/ten31-pass-api/-/ten31-pass-api-1.1.0.tgz#4e013dd23302304965ac032e521d38a25b186a24"
   integrity sha512-YLxzRyJcg/0xPMMBl+TcIugm8SdSitWZXEhotXK8wIj/wbtRQEbUoo052JCfpWJXVTsGDNS0VbS9oLA+fuFm1A==
 
+"@nimiq/utils@^0.11.7":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.11.7.tgz#7c3021e67bba914b9756ccde6ef228f5a5655aee"
+  integrity sha512-FLeQ9kBFsOBfOjh0T+jI8kl9K77XOuyQA3yel1VIzOK4dLcnvMmgXjegJfuPAEht9oGe+gxcyzFsb0Yi9Js8Dg==
+  dependencies:
+    big-integer "^1.6.44"
+
 "@nimiq/utils@^0.12.1":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.12.1.tgz#4eb97e9ec8348a7987ae1304fd1d9d85730455bc"
   integrity sha512-AnOPakCbnSkGpWnc4RhG1S4xysI4tWXn+rCVImKMOkqG9GMAQrg9z2/g8y3H4Ngy7BivhfnsfbKIBdspyGPE/w==
-  dependencies:
-    big-integer "^1.6.44"
-
-"@nimiq/utils@^0.5.0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.5.1.tgz#a5641e483e80b00066c3f2b0b85132974cf5c7e5"
-  integrity sha512-6p/oh6nzj/GVlcDn5WFJnSOoDgzGNoGLaR063wBvk+S672+p9sT4dhU2bCRWAY30cLhJsOL7X74QIus5weIpXA==
   dependencies:
     big-integer "^1.6.44"
 
@@ -3158,7 +3166,7 @@ bech32@1.1.4, bech32@^1.1.2:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-big-integer@^1.6.44, big-integer@^1.6.48:
+big-integer@^1.6.44, big-integer@^1.6.52:
   version "1.6.52"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
   integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
@@ -9509,7 +9517,7 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9534,15 +9542,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -9606,7 +9605,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9626,13 +9625,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11295,7 +11287,7 @@ workbox-window@6.4.2:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.4.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11320,15 +11312,6 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
### Why

Unstaking and switching validators each need **several transactions signed at once**, with the later ones
only broadcastable after the first has settled on chain. Asking the user to come back hours later to send
the rest is not viable, so the transactions are all signed up front and the remainder handed to the
watchtower, which broadcasts them once the deactivation has matured.

This branch is the wallet half of that. The Hub half (multi-transaction signing plumbing and Ledger
support) is a separate branch, and the Keyguard half is T404-16.

### What

**Watchtower client** — new `src/lib/AlbatrossWatchtower.ts`

- `startUnstaking()` posts `/unstake` with the deactivation hash plus the signed retire and remove-stake
  transactions; `startSwitchValidator()` posts `/switch-validator` with the deactivation hash and the
  signed update-staker transaction.
- Endpoint comes from config per network (`albatrossWatchtower.endpoint`, added to local, testnet and
  mainnet); optional basic auth from `VUE_APP_WT_USERNAME` / `VUE_APP_WT_PASSWORD`.
- Hashes are `0x`-stripped, any non-2xx throws with the server's message, and an unconfigured watchtower
  no-ops with a console warning rather than failing the flow.

**Multi-transaction signing through the Hub** — `src/hub.ts`

- `signUnstakingTransactions()` (layout `unstaking`, exactly 3: deactivate → retire → remove-stake) and
  `signSwitchValidatorTransactions()` (layout `switch-validator`, exactly 2: set-active-stake →
  update-staker). Both **return the signed transactions without broadcasting**, so the caller decides what
  goes on chain now and what goes to the watchtower.
- `sendTransaction()` and the `SIGN_TRANSACTION` listener now accept an array result and send sequentially,
  stopping on the first failed execution.

**Waiting for the chain** — `src/network.ts`, new `src/composables/usePolicy.ts`

- `waitForTransactionConfirmation()` has two modes: inclusion (watch the transaction's state) and
  macro-block confirmation (`requireConfirmed`). The second cannot watch `tx.state` — it is mutated in
  place by `addTransactions` and core does not always refire listeners — so it computes the target macro
  block from the transaction's height and watches the reactive chain height instead.
- `usePolicy()` exposes `BLOCKS_PER_BATCH` / `BATCHES_PER_EPOCH` from `@nimiq/core` (polling briefly for
  the WASM warm-up, no wallet-side fallbacks) and derives `electionBlockAfter` / `macroBlockAfter` from the
  configured genesis, so the wallet's epoch maths lines up with the watchtower's.

**Switch-validator state** — `src/stores/Staking.ts`, new `src/lib/SwitchValidator.ts`

- A switch record (target validator, start height, deactivation hash) is kept in `localStorage` per address,
  exposed through `activeSwitchOperation`, `isSwitchingValidator`, `canManuallyActivateSwitch` and
  `switchTargetLabel`.
- `checkSwitchCompletion()` runs against every stake snapshot and clears the record **only once active
  stake is actually at the target validator** — clearing on any reappearing balance would take away the
  user's manual recovery handle when the stake came back at the old validator.
- `sendImmediateValidatorSwitch()` is that recovery path: a single update-staker with `reactivateAllStake`,
  for when the cooldown has elapsed and the watchtower did not complete the switch.

**UI** (staking pages, validator overlay/modal)

- "Switching to \<validator\>" with the countdown while a switch is in flight, a manual "activate validator"
  button once it can be triggered by hand, `deactivateAll` hidden during a switch, and the unstaking layout.
- Daniel's four commits on top: validator labels, address and images handled consistently across
  `StakingGraphPage` / `StakingInfoPage`, the unstaking validator label passed as `senderLabel`, the
  validator address passed on staking creation, and `@nimiq/hub-api` bumped for multi-tx signing.

### How it was verified

QA ran on `wallet.nimiq-testnet.com` against the ten-flow test plan on T404-15 (regular send, validator
switch, unstaking, instant payout, start staking, add stake, cashlink creation, swap refund, standard
multi-tx signing, checkout — each for both Keyguard and Ledger). Report:
https://app.qase.io/public/report/379bd6f17c667627377c8950bcb27604cd5e0505

### Follow-ups (landed later or still open)

- Follow-up fixes live on `matheo/watchtower-fixes` (T404-173, T404-174, T404-176): gating a validator
  switch while an unstaking is in progress, the inert Switch Validator button, warning the user when the
  watchtower did not accept the job, and verifying pending operations against the watchtower itself.
- `matheo/watchtower-staker-filter` switches `fetchWatchtowerJobsForStaker` to the watchtower's new
  `?staker=` route, once that PR is merged and deployed.
- The switch record still lives in `localStorage` behind a bump counter rather than in reactive store state.
- T404-177: the "Unstake rest" flow does not yet use the watchtower-based multi-tx path.